### PR TITLE
[ON HOLD] hide tab when no results

### DIFF
--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
@@ -247,6 +247,30 @@ describe("Search Page Tabs", () => {
     expect(tab).toHaveAccessibleName(expectedActive)
   })
 
+  test("Clearing facets does NOT reset tab", async () => {
+    setMockApiResponses({
+      search: {
+        count: 0,
+        metadata: {
+          aggregations: {
+            resource_category: [
+              { key: "course", doc_count: 100 },
+              { key: "program", doc_count: 10 },
+            ],
+          },
+          suggestions: [],
+        },
+      },
+    })
+    const { location } = renderWithProviders(<SearchPage />, {
+      url: "?topic=Physics&resource_category=course",
+    })
+    const activeTab = screen.getByRole("tab", { selected: true })
+    expect(activeTab).toHaveTextContent("Courses")
+    await user.click(screen.getByRole("button", { name: /clear all/i }))
+    expect(location.current.search).toBe("?resource_category=course")
+  })
+
   test.each([
     { programCount: 0, programsVisible: false, url: "?" },
     {

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -109,7 +109,7 @@ export {
   TabButtonList,
 } from "./components/TabButtons/TabButtonList"
 
-export { default as TabContext } from "@mui/lab/TabContext"
+export { default as TabContext, useTabContext } from "@mui/lab/TabContext"
 export type { TabContextProps } from "@mui/lab/TabContext"
 export { default as TabPanel } from "@mui/lab/TabPanel"
 export type { TabPanelProps } from "@mui/lab/TabPanel"


### PR DESCRIPTION
_On hold pending decision whether we actually want to do this._

### What are the relevant tickets?
- closes https://github.com/mitodl/hq/issues/4547

### Description (What does it do?)
Hides search tabs when there are no results.

### Screenshots (if appropriate):

Video:

https://github.com/mitodl/mit-open/assets/9010790/0161f2ca-ebd0-4f67-b658-99c4e4332b6d


If tab has 0 results but is active, show it:

<img width="1098" alt="Screenshot 2024-07-08 at 11 48 36 AM" src="https://github.com/mitodl/mit-open/assets/9010790/faaac6d2-7e0c-4d51-886c-75a2bf7435e6">

If tab has 0 results but is not active, hide it:

<img width="1145" alt="Screenshot 2024-07-08 at 11 48 45 AM" src="https://github.com/mitodl/mit-open/assets/9010790/793169ef-cddc-48b6-a9b5-5a874fdd212e">


### How can this be tested?
1. Check that tab is hidden if there are not results:
    -  Search for something like "cats" that will have no programs. The "Programs" tab should disappear.
2. Check that if the tab is active AND there are no results, it is still visible.
    - clear your search
    - select the "Programs" tab
    - repeat your search for "cats" (or whatever) from (1).
