### PR TITLE
Updates search_update event tracking to fire later

### DIFF
--- a/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -610,20 +610,20 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   }
 
   const setParamValue = (value: string, prev: string | string[]) => {
-    captureSearchEvent()
     actuallySetParamValue(value, prev)
+    captureSearchEvent()
   }
 
   const clearAllFacets = () => {
-    captureSearchEvent()
     actuallyClearAllFacets()
+    captureSearchEvent()
   }
 
   const setSearchParams = (
     value: URLSearchParams | ((prev: URLSearchParams) => URLSearchParams),
   ) => {
-    captureSearchEvent()
     actuallySetSearchParams(value)
+    captureSearchEvent()
   }
 
   const toggleParamValue = (
@@ -631,8 +631,8 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
     rawValue: string,
     checked: boolean,
   ) => {
-    captureSearchEvent()
     actuallyToggleParamValue(name, rawValue, checked)
+    captureSearchEvent()
   }
 
   const sortDropdown = (


### PR DESCRIPTION

### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/5817

### Description (What does it do?)

This is a pretty simple PR. It just moves the calls to `captureSearchEvent` after the relevant calls to adjust search parameters, so we get the resulting `search_update` event in PostHog after the change has been made. 

### How can this be tested?

A PostHog account is needed for testing.

1. In PostHog, go to Activity, then filter it in such a way that you're easily able to see your own events. (IP address is recorded so that's probably the easiest way.) Ideally, also adjust the columns to show some of the `search_param_` properties and limit your facet selections to those so it's easier to identify what's changing.
2. Open Learn in a new tab, then search for something, then change some of the parameters. (If you've adjusted the columns in step 1, limit your changes to those facet types.) Try to get to a point where you have at least one resource returned.
3. Open the drawer for one of the search results. 
4. View the events that were triggered in PostHog. There will be some delay before it processes the events but they should show up after ~one minute.

Your `search_update` events should include the updated selections. Prior to this, they would not - it'd capture your state before you made changes. 
