### PR TITLE
fix textarea placeholder color

### DIFF
--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -116,17 +116,16 @@ const baseInputStyles = (theme: Theme) => ({
     borderColor: "transparent",
     outline: "2px solid currentcolor",
     outlineOffset: "-2px",
-    color: theme.custom.colors.darkGray2,
   },
   "&.Mui-error": {
     borderColor: theme.custom.colors.red,
     outlineColor: theme.custom.colors.red,
   },
-  "& input::placeholder": {
+  "& input::placeholder, textarea::placeholder": {
     color: theme.custom.colors.silverGrayDark,
     opacity: 1, // some browsers apply opacity to placeholder text
   },
-  "& input:placeholder-shown": {
+  "& input:placeholder-shown, textarea:placeholder-shown": {
     textOverflow: "ellipsis",
   },
   "& textarea": {
@@ -154,7 +153,7 @@ const baseInputStyles = (theme: Theme) => ({
 type CustomInputProps = { responsive?: true }
 const noForward = Object.keys({
   responsive: true,
-} satisfies { [key in keyof CustomInputProps]: boolean })
+} satisfies { [_key in keyof CustomInputProps]: boolean })
 
 const Input = styled(InputBase, {
   shouldForwardProp: (prop) => !noForward.includes(prop),


### PR DESCRIPTION
### What are the relevant tickets?
- Closes https://github.com/mitodl/hq/issues/5427

### Description (What does it do?)
Most of https://github.com/mitodl/hq/issues/5427 was handled in https://github.com/mitodl/mit-learn/pull/1545. This fixes the final placeholder color—multiline inputs, aka `textarea`.

### Screenshots (if appropriate):
This branch:

<img width="637" alt="Screenshot 2024-10-18 at 3 33 17 PM" src="https://github.com/user-attachments/assets/eea7f2f5-5a63-4a44-869e-5a6e4b0cb4e6">

vs RC

<img width="542" alt="Screenshot 2024-10-18 at 3 34 02 PM" src="https://github.com/user-attachments/assets/9ca507cd-bfcb-4c0b-8eca-b46f6857493b">


### How can this be tested?
View the userlist creation modal. The inputs should all have same color placeholder text.
