### PR TITLE
Announce search count for screen readers

### DIFF
--- a/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
@@ -14,7 +14,18 @@ import type {
 } from "api"
 import invariant from "tiny-invariant"
 import { Permissions } from "@/common/permissions"
-import { assertHeadings } from "ol-test-utilities"
+import { assertHeadings, ControlledPromise } from "ol-test-utilities"
+
+const DEFAULT_SEARCH_RESPONSE: LearningResourcesSearchResponse = {
+  count: 0,
+  next: null,
+  previous: null,
+  results: [],
+  metadata: {
+    aggregations: {},
+    suggestions: [],
+  },
+}
 
 const setMockApiResponses = ({
   search,
@@ -28,14 +39,7 @@ const setMockApiResponses = ({
   })
 
   setMockResponse.get(expect.stringContaining(urls.search.resources()), {
-    count: 0,
-    next: null,
-    previous: null,
-    results: [],
-    metadata: {
-      aggregations: {},
-      suggestions: [],
-    },
+    ...DEFAULT_SEARCH_RESPONSE,
     ...search,
   })
   setMockResponse.get(
@@ -710,9 +714,47 @@ describe("Search Page pagination controls", () => {
 })
 
 test("Count changes are announced to screen readers", async () => {
-  setMockApiResponses({ search: { count: 137 } })
+  setMockApiResponses({ search: { count: 123 } })
   renderWithProviders(<SearchPage />)
-  const count = await screen.findByText("137 results")
+  const count = await screen.findByText("123 results")
   expect(count).toHaveAttribute("aria-live", "polite")
   expect(count).toHaveAttribute("aria-atomic", "true")
+  // aria-relevant is important here. See https://stackoverflow.com/a/62179258/2747370
+  expect(count).toHaveAttribute("aria-relevant", "all")
+
+  const nextResponse = new ControlledPromise()
+  const nextData = { ...DEFAULT_SEARCH_RESPONSE, count: 456 }
+  setMockResponse.get(
+    expect.stringContaining(urls.search.resources()),
+    nextResponse,
+  )
+
+  const queryInput = await screen.findByRole<HTMLInputElement>("textbox", {
+    name: "Search for",
+  })
+  await user.clear(queryInput)
+  await user.paste("woof")
+  await user.click(screen.getByRole("button", { name: "Search" }))
+
+  /**
+   * The point here is to check that while new data is loading, the aria-live
+   * region is empty.
+   *
+   * That's important: it guarantees that the result count will always be read,
+   * even if the count hasn't changed.
+   *
+   * For example:
+   *  - search for "foo" ... 0 results
+   *  - try again, search for "bar" ... still 0 results
+   *
+   * This ensures that we read "0 results" both times.
+   */
+  await waitFor(() => {
+    expect(count).toHaveTextContent("")
+  })
+  nextResponse.resolve(nextData)
+
+  await waitFor(() => {
+    expect(count).toHaveTextContent("456 results")
+  })
 })

--- a/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
@@ -708,3 +708,11 @@ describe("Search Page pagination controls", () => {
     ])
   })
 })
+
+test("Count changes are announced to screen readers", async () => {
+  setMockApiResponses({ search: { count: 137 } })
+  renderWithProviders(<SearchPage />)
+  const count = await screen.findByText("137 results")
+  expect(count).toHaveAttribute("aria-live", "polite")
+  expect(count).toHaveAttribute("aria-atomic", "true")
+})

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -893,7 +893,13 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
               Search Results
             </VisuallyHidden>
             <VisuallyHidden aria-live="polite" aria-atomic aria-relevant="all">
-              {/* This could be just isLoading, except we set keepPreviousData to true */}
+              {/* This could be just isLoading, except we set keepPreviousData
+               * to true
+               *
+               * Reset to empty string with `aria-relevant="all"` to announce
+               * the count when data is loaded even if count is same as previous
+               * count.
+               */}
               {isFetching || isLoading ? "" : `${data?.count} results`}
             </VisuallyHidden>
             <DesktopSortContainer>{sortDropdown}</DesktopSortContainer>

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -606,7 +606,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
     page,
   ])
 
-  const { data, isLoading } = useLearningResourcesSearch(
+  const { data, isLoading, isFetching } = useLearningResourcesSearch(
     allParams as LRSearchRequest,
     { keepPreviousData: true },
   )
@@ -892,8 +892,9 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
             <VisuallyHidden as={resultsHeadingEl}>
               Search Results
             </VisuallyHidden>
-            <VisuallyHidden aria-live="polite" aria-atomic>
-              {`${data?.count} results`}
+            <VisuallyHidden aria-live="polite" aria-atomic aria-relevant="all">
+              {/* This could be just isLoading, except we set keepPreviousData to true */}
+              {isFetching || isLoading ? "" : `${data?.count} results`}
             </VisuallyHidden>
             <DesktopSortContainer>{sortDropdown}</DesktopSortContainer>
             <StyledResourceTabs

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -892,6 +892,9 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
             <VisuallyHidden as={resultsHeadingEl}>
               Search Results
             </VisuallyHidden>
+            <VisuallyHidden aria-live="polite" aria-atomic>
+              {`${data?.count} results`}
+            </VisuallyHidden>
             <DesktopSortContainer>{sortDropdown}</DesktopSortContainer>
             <StyledResourceTabs
               setSearchParams={setSearchParams}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5420

### Description (What does it do?)
Adds an aria-live region that announces search result count.

### How can this be tested?
1. Visit the search page or any channel page
2. Make searches while a screenreader is active. On a Mac, you could use VoiceOver.
3. Each search should announce "<count> results".
4. Make two searches with the same count. This is easiest with 0 results. E.g., search "fooooz" then "foooozz". You should hear the count announced both times, even though the count did not change.
