### PR TITLE
Update for Storybook's new home in ol-components

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -23,7 +23,7 @@ jobs:
         run: yarn install
 
       - name: Build Storybook
-        run: yarn workspace mit-learn build-storybook
+        run: yarn workspace ol-components build-storybook
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -1,3 +1,5 @@
+name: Publish Storybook
+
 on:
   # Runs on pushes targeting the default branch
   push:


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Relates to https://github.com/mitodl/hq/issues/5395

### Description (What does it do?)
<!--- Describe your changes in detail -->

The build is [failing](https://github.com/mitodl/mit-learn/actions/runs/11457923267/job/31879229242) on the main branch since merging https://github.com/mitodl/mit-learn/pull/1717 as we did not update the publish-pages job to build Storybook from its new entrypoint in the ol-components workspace. This PR fixes that.


### How can this be tested?

Once merged to main, the publish-pages.yml Actions workflow should pass.

