### PR TITLE
Fix path to Storybook build

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
-          path: ./frontends/mit-learn/storybook-static
+          path: ./frontends/ol-components/storybook-static
 
   deploy:
     needs: build


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Relates to https://github.com/mitodl/hq/issues/5395

### Description (What does it do?)
<!--- Describe your changes in detail -->

The build is [failing](https://github.com/mitodl/mit-learn/actions/runs/11457923267/job/31879229242) on the main branch since merging https://github.com/mitodl/mit-learn/pull/1717 as we did not update the publish-pages job to publish Storybook from its new build directory in ol-components. This PR fixes that.


### How can this be tested?

Once merged to main, the publish-pages.yml Actions workflow should pass.

