### PR TITLE
Navigation Accessibility

### DIFF
--- a/frontends/main/src/page-components/Header/Header.tsx
+++ b/frontends/main/src/page-components/Header/Header.tsx
@@ -7,7 +7,6 @@ import {
   AppBar,
   NavDrawer,
   Toolbar,
-  ClickAwayListener,
   ActionButtonLink,
 } from "ol-components"
 import {
@@ -270,10 +269,8 @@ const Header: FunctionComponent = () => {
     event.nativeEvent.stopImmediatePropagation() // Prevent clicking on "Explore MIT" button from triggering the ClickAwayHandler
     toggleDrawer(!drawerOpen)
   }
-  const closeDrawer = (event: MouseEvent | TouchEvent) => {
-    if (drawerOpen && event.type !== "touchstart") {
-      toggleDrawer(false)
-    }
+  const closeDrawer = () => {
+    toggleDrawer(false)
   }
 
   return (
@@ -283,14 +280,10 @@ const Header: FunctionComponent = () => {
           <DesktopOnly>
             <StyledMITLogoLink logo="learn" />
             <LeftSpacer />
-            <MenuButton
-              text="Explore MIT"
-              onClick={toggler}
-              drawerOpen={drawerOpen}
-            />
+            <MenuButton text="Explore MIT" onClick={toggler} />
           </DesktopOnly>
           <MobileOnly>
-            <MenuButton onClick={toggler} drawerOpen={drawerOpen} />
+            <MenuButton onClick={toggler} />
             <LeftSpacer />
             <StyledMITLogoLink logo="learn" />
           </MobileOnly>
@@ -298,15 +291,8 @@ const Header: FunctionComponent = () => {
           <UserView />
         </StyledToolbar>
       </Bar>
-      <ClickAwayListener
-        onClickAway={closeDrawer}
-        mouseEvent="onPointerDown"
-        touchEvent="onTouchStart"
-      >
-        <div role="presentation">
-          <NavDrawer navdata={navData} open={drawerOpen} />
-        </div>
-      </ClickAwayListener>
+
+      <NavDrawer navdata={navData} open={drawerOpen} onClose={closeDrawer} />
     </div>
   )
 }

--- a/frontends/main/src/page-components/Header/Header.tsx
+++ b/frontends/main/src/page-components/Header/Header.tsx
@@ -54,8 +54,9 @@ const Bar = styled(AppBar)(({ theme }) => ({
   ".MuiToolbar-root": {
     minHeight: "auto",
   },
+  height: theme.custom.dimensions.headerHeight,
   [theme.breakpoints.down("sm")]: {
-    height: "60px",
+    height: theme.custom.dimensions.headerHeightSm,
     padding: "0",
   },
 }))

--- a/frontends/main/src/page-components/Header/Header.tsx
+++ b/frontends/main/src/page-components/Header/Header.tsx
@@ -265,13 +265,8 @@ const navData: NavData = {
 
 const Header: FunctionComponent = () => {
   const [drawerOpen, toggleDrawer] = useToggle(false)
-  const toggler = (event: React.MouseEvent) => {
-    event.nativeEvent.stopImmediatePropagation() // Prevent clicking on "Explore MIT" button from triggering the ClickAwayHandler
-    toggleDrawer(!drawerOpen)
-  }
-  const closeDrawer = () => {
-    toggleDrawer(false)
-  }
+  const desktopTrigger = React.useRef<HTMLButtonElement>(null)
+  const mobileTrigger = React.useRef<HTMLButtonElement>(null)
 
   return (
     <div>
@@ -280,10 +275,14 @@ const Header: FunctionComponent = () => {
           <DesktopOnly>
             <StyledMITLogoLink logo="learn" />
             <LeftSpacer />
-            <MenuButton text="Explore MIT" onClick={toggler} />
+            <MenuButton
+              ref={desktopTrigger}
+              text="Explore MIT"
+              onClick={toggleDrawer.toggle}
+            />
           </DesktopOnly>
           <MobileOnly>
-            <MenuButton onClick={toggler} />
+            <MenuButton ref={mobileTrigger} onClick={toggleDrawer.toggle} />
             <LeftSpacer />
             <StyledMITLogoLink logo="learn" />
           </MobileOnly>
@@ -292,7 +291,15 @@ const Header: FunctionComponent = () => {
         </StyledToolbar>
       </Bar>
 
-      <NavDrawer navdata={navData} open={drawerOpen} onClose={closeDrawer} />
+      <NavDrawer
+        getClickAwayExcluded={() => [
+          desktopTrigger.current,
+          mobileTrigger.current,
+        ]}
+        navdata={navData}
+        open={drawerOpen}
+        onClose={toggleDrawer.off}
+      />
     </div>
   )
 }

--- a/frontends/main/src/page-components/Header/MenuButton.tsx
+++ b/frontends/main/src/page-components/Header/MenuButton.tsx
@@ -1,14 +1,10 @@
 "use client"
 
 import { styled } from "ol-components"
-import { RiMenuLine, RiCloseLargeLine } from "@remixicon/react"
+import { RiMenuLine } from "@remixicon/react"
 import React from "react"
 
 const MenuIcon = styled(RiMenuLine)(({ theme }) => ({
-  color: theme.custom.colors.darkGray1,
-}))
-
-const CloseMenuIcon = styled(RiCloseLargeLine)(({ theme }) => ({
   color: theme.custom.colors.darkGray1,
 }))
 
@@ -53,17 +49,12 @@ const StyledMenuButton = styled.button(({ theme }) => ({
 interface MenuButtonProps {
   text?: string
   onClick: React.MouseEventHandler<HTMLButtonElement> | undefined
-  drawerOpen: boolean
 }
 
-const MenuButton: React.FC<MenuButtonProps> = ({
-  text,
-  onClick,
-  drawerOpen,
-}) => (
-  <StyledMenuButton onPointerDown={onClick}>
+const MenuButton: React.FC<MenuButtonProps> = ({ text, onClick }) => (
+  <StyledMenuButton onClick={onClick}>
     <MenuButtonInner>
-      {drawerOpen ? <CloseMenuIcon /> : <MenuIcon />}
+      <MenuIcon />
       {text ? <MenuButtonText>{text}</MenuButtonText> : ""}
     </MenuButtonInner>
   </StyledMenuButton>

--- a/frontends/main/src/page-components/Header/MenuButton.tsx
+++ b/frontends/main/src/page-components/Header/MenuButton.tsx
@@ -51,13 +51,15 @@ interface MenuButtonProps {
   onClick: React.MouseEventHandler<HTMLButtonElement> | undefined
 }
 
-const MenuButton: React.FC<MenuButtonProps> = ({ text, onClick }) => (
-  <StyledMenuButton onClick={onClick}>
-    <MenuButtonInner>
-      <MenuIcon />
-      {text ? <MenuButtonText>{text}</MenuButtonText> : ""}
-    </MenuButtonInner>
-  </StyledMenuButton>
+const MenuButton = React.forwardRef<HTMLButtonElement, MenuButtonProps>(
+  ({ onClick, text }, ref) => (
+    <StyledMenuButton ref={ref} onClick={onClick}>
+      <MenuButtonInner>
+        <MenuIcon />
+        {text ? <MenuButtonText>{text}</MenuButtonText> : ""}
+      </MenuButtonInner>
+    </StyledMenuButton>
+  ),
 )
 
 export { MenuButton }

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.test.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.test.tsx
@@ -1,5 +1,6 @@
 import { NavData, NavDrawer } from "./NavDrawer"
 import { render, screen } from "@testing-library/react"
+import user from "@testing-library/user-event"
 import React from "react"
 import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
 
@@ -29,7 +30,7 @@ describe("NavDrawer", () => {
         },
       ],
     }
-    render(<NavDrawer navdata={navData} open={true} />, {
+    render(<NavDrawer onClose={jest.fn()} navdata={navData} open={true} />, {
       wrapper: ThemeProvider,
     })
     const links = screen.getAllByTestId("nav-link")
@@ -40,5 +41,66 @@ describe("NavDrawer", () => {
     expect(icons).toHaveLength(1)
     expect(titles).toHaveLength(3)
     expect(descriptions).toHaveLength(2)
+  })
+
+  const NAV_DATA: NavData = {
+    sections: [
+      {
+        title: "TEST 1",
+        items: [
+          {
+            title: "Title 1",
+            description: "Description 1",
+            href: "https://link.one",
+          },
+        ],
+      },
+      {
+        title: "TEST 2",
+        items: [
+          {
+            title: "Title 2",
+            description: "Description 2",
+            href: "https://link.two",
+          },
+        ],
+      },
+    ],
+  }
+
+  test("close button calls onClose", async () => {
+    const onClose = jest.fn()
+    render(<NavDrawer onClose={onClose} navdata={NAV_DATA} open={true} />, {
+      wrapper: ThemeProvider,
+    })
+    const close = screen.getByRole("button", { name: "Close Navigation" })
+    await user.click(close)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  test("escape calls onClose", async () => {
+    const onClose = jest.fn()
+    render(<NavDrawer onClose={onClose} navdata={NAV_DATA} open={true} />, {
+      wrapper: ThemeProvider,
+    })
+    const links = screen.getAllByRole("link")
+    links[0].focus()
+    await user.keyboard("{Escape}")
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  test("click away calls onClose", async () => {
+    const onClose = jest.fn()
+    render(
+      <div>
+        <NavDrawer onClose={onClose} navdata={NAV_DATA} open={true} />
+        <button type="button">Outside</button>
+      </div>,
+      {
+        wrapper: ThemeProvider,
+      },
+    )
+    await user.click(screen.getByRole("button", { name: "Outside" }))
+    expect(onClose).toHaveBeenCalled()
   })
 })

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.test.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.test.tsx
@@ -89,18 +89,31 @@ describe("NavDrawer", () => {
     expect(onClose).toHaveBeenCalled()
   })
 
-  test("click away calls onClose", async () => {
+  test("click away calls onClose if target is not excluded", async () => {
     const onClose = jest.fn()
-    render(
-      <div>
-        <NavDrawer onClose={onClose} navdata={NAV_DATA} open={true} />
-        <button type="button">Outside</button>
-      </div>,
-      {
-        wrapper: ThemeProvider,
-      },
-    )
+    const Component = () => {
+      const excluded = React.useRef<HTMLButtonElement>(null)
+      return (
+        <div>
+          <NavDrawer
+            getClickAwayExcluded={() => [excluded.current]}
+            onClose={onClose}
+            navdata={NAV_DATA}
+            open={true}
+          />
+          <button type="button">Outside</button>
+          <button ref={excluded} type="button">
+            Excluded
+          </button>
+        </div>
+      )
+    }
+    render(<Component />, { wrapper: ThemeProvider })
     await user.click(screen.getByRole("button", { name: "Outside" }))
     expect(onClose).toHaveBeenCalled()
+    onClose.mockReset()
+
+    await user.click(screen.getByRole("button", { name: "Excluded" }))
+    expect(onClose).not.toHaveBeenCalled()
   })
 })

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.test.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.test.tsx
@@ -104,6 +104,7 @@ describe("NavDrawer", () => {
           <button type="button">Outside</button>
           <button ref={excluded} type="button">
             Excluded
+            <svg data-testid="foo" />
           </button>
         </div>
       )
@@ -114,6 +115,7 @@ describe("NavDrawer", () => {
     onClose.mockReset()
 
     await user.click(screen.getByRole("button", { name: "Excluded" }))
+    await user.click(screen.getByTestId("foo"))
     expect(onClose).not.toHaveBeenCalled()
   })
 })

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
@@ -165,9 +165,19 @@ const NavItem: React.FC<NavItem> = (props) => {
 type NavDrawerProps = {
   navdata: NavData
   onClose: () => void
+  /**
+   * Returns a list of HTMLElements that should not trigger the drawer to close
+   * on click-away
+   */
+  getClickAwayExcluded?: () => (HTMLElement | null)[]
 } & DrawerProps
 
-const NavDrawer = ({ navdata, onClose, ...others }: NavDrawerProps) => {
+const NavDrawer = ({
+  navdata,
+  onClose,
+  getClickAwayExcluded = () => [],
+  ...others
+}: NavDrawerProps) => {
   const navSections = navdata.sections.map((section, i) => {
     const navItemElements = section.items.map((item) => (
       <NavItem
@@ -208,7 +218,20 @@ const NavDrawer = ({ navdata, onClose, ...others }: NavDrawerProps) => {
      *  - Events (clicks, scrolls) outside the drawer fire on the underlying
      *    content, not on an overlay element.
      */
-    <ClickAwayListener onClickAway={onClose}>
+    <ClickAwayListener
+      onClickAway={(e) => {
+        if (!others.open) return
+        const excluded = getClickAwayExcluded()
+        const target = e.target
+        if (
+          target instanceof HTMLElement &&
+          excluded?.some((el) => el?.contains(target))
+        ) {
+          return
+        }
+        onClose()
+      }}
+    >
       <div role="presentation">
         <Drawer
           anchor="left"

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
@@ -169,7 +169,7 @@ type NavDrawerProps = {
    * Returns a list of HTMLElements that should not trigger the drawer to close
    * on click-away
    */
-  getClickAwayExcluded?: () => (HTMLElement | null)[]
+  getClickAwayExcluded?: () => (Element | null)[]
 } & DrawerProps
 
 const NavDrawer = ({
@@ -224,7 +224,7 @@ const NavDrawer = ({
         const excluded = getClickAwayExcluded()
         const target = e.target
         if (
-          target instanceof HTMLElement &&
+          target instanceof Element &&
           excluded?.some((el) => el?.contains(target))
         ) {
           return

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
@@ -3,13 +3,13 @@ import styled from "@emotion/styled"
 import React, { ReactElement } from "react"
 
 const DrawerContent = styled.div(({ theme }) => ({
-  paddingTop: "72px",
+  paddingTop: theme.custom.dimensions.headerHeight,
   width: "366px",
   height: "100%",
   background: theme.custom.colors.white,
   borderRight: `1px solid ${theme.custom.colors.lightGray2}`,
   [theme.breakpoints.down("sm")]: {
-    height: "60px",
+    paddingTop: theme.custom.dimensions.headerHeightSm,
   },
 }))
 

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
@@ -1,6 +1,10 @@
 import Drawer, { DrawerProps } from "@mui/material/Drawer"
+import ClickAwayListener from "@mui/material/ClickAwayListener"
+import { FocusTrap } from "@mui/base/FocusTrap"
 import styled from "@emotion/styled"
 import React, { ReactElement } from "react"
+import { RiCloseLargeLine } from "@remixicon/react"
+import { ActionButton } from "../Button/Button"
 
 const DrawerContent = styled.div(({ theme }) => ({
   paddingTop: theme.custom.dimensions.headerHeight,
@@ -22,13 +26,21 @@ const NavSection = styled.div({
   gap: "12px",
 })
 
-const NavSectionHeader = styled.div(({ theme }) => ({
-  display: "flex",
-  alignItems: "center",
-  alignSelf: "stretch",
-  color: theme.custom.colors.darkGray1,
-  ...theme.typography.subtitle3,
-}))
+const NavSectionHeader = styled.div<{ hasButton: boolean }>(
+  ({ theme, hasButton }) => [
+    {
+      display: "flex",
+      alignItems: "center",
+      alignSelf: "stretch",
+      color: theme.custom.colors.darkGray1,
+      ...theme.typography.subtitle3,
+    },
+    hasButton && {
+      justifyContent: "space-between",
+      height: "16px",
+    },
+  ],
+)
 
 const NavItemsContainer = styled.div(({ theme }) => ({
   display: "flex",
@@ -84,6 +96,12 @@ const NavTextContainer = styled.div({
   alignSelf: "center",
   gap: "4px",
 })
+
+const CloseButton = styled(ActionButton)(({ theme }) => ({
+  svg: { fontSize: "18px" },
+  color: theme.custom.colors.darkGray1,
+  transform: "translateX(12px)",
+}))
 
 const NavLinkText = styled.div(({ theme }) => ({
   color: theme.custom.colors.darkGray2,
@@ -146,11 +164,11 @@ const NavItem: React.FC<NavItem> = (props) => {
 
 type NavDrawerProps = {
   navdata: NavData
+  onClose: () => void
 } & DrawerProps
 
-const NavDrawer = (props: NavDrawerProps) => {
-  const { navdata } = props
-  const navSections = navdata.sections.map((section) => {
+const NavDrawer = ({ navdata, onClose, ...others }: NavDrawerProps) => {
+  const navSections = navdata.sections.map((section, i) => {
     const navItemElements = section.items.map((item) => (
       <NavItem
         key={item.title}
@@ -162,30 +180,66 @@ const NavDrawer = (props: NavDrawerProps) => {
     ))
     return (
       <NavSection key={section.title}>
-        <NavSectionHeader>{section.title}</NavSectionHeader>
+        <NavSectionHeader hasButton={i === 0}>
+          {section.title}
+          {i === 0 && (
+            <CloseButton
+              aria-label="Close Navigation"
+              onClick={onClose}
+              variant="text"
+              size="small"
+            >
+              <RiCloseLargeLine aria-hidden />
+            </CloseButton>
+          )}
+        </NavSectionHeader>
         <NavItemsContainer>{navItemElements}</NavItemsContainer>
       </NavSection>
     )
   })
 
   return (
-    <Drawer
-      anchor="left"
-      variant="persistent"
-      elevation={0}
-      hideBackdrop={true}
-      PaperProps={{
-        sx: {
-          borderRight: "none",
-          boxShadow: "0px 6px 24px 0px rgba(37, 38, 43, 0.10)",
-          zIndex: (theme) => theme.zIndex.appBar - 1,
-          overscrollBehavior: "contain",
-        },
-      }}
-      {...props}
-    >
-      <DrawerContent>{navSections}</DrawerContent>
-    </Drawer>
+    /**
+     * ClickAwayListner + FocusTrap ensure the drawer behaves like a modal:
+     *  - clicking outside the drawer closes it
+     *  - the drawer traps focus
+     *
+     * But the drawer is persistent in that:
+     *  - Events (clicks, scrolls) outside the drawer fire on the underlying
+     *    content, not on an overlay element.
+     */
+    <ClickAwayListener onClickAway={onClose}>
+      <div role="presentation">
+        <Drawer
+          anchor="left"
+          variant="persistent"
+          elevation={0}
+          hideBackdrop={true}
+          PaperProps={{
+            sx: {
+              borderRight: "none",
+              boxShadow: "0px 6px 24px 0px rgba(37, 38, 43, 0.10)",
+              zIndex: (theme) => theme.zIndex.appBar - 1,
+              overscrollBehavior: "contain",
+            },
+          }}
+          {...others}
+        >
+          <FocusTrap open={!!others.open}>
+            <DrawerContent
+              onKeyUp={(e) => {
+                if (e.key === "Escape") {
+                  onClose()
+                }
+              }}
+              tabIndex={-1}
+            >
+              {navSections}
+            </DrawerContent>
+          </FocusTrap>
+        </Drawer>
+      </div>
+    </ClickAwayListener>
   )
 }
 

--- a/frontends/ol-components/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/frontends/ol-components/src/components/ThemeProvider/ThemeProvider.tsx
@@ -23,6 +23,10 @@ const custom: ThemeOptions["custom"] = {
   transitionDuration: "300ms",
   shadow: `${shadow.shadowOffsetX} ${shadow.shadowOffsetY} ${shadow.shadowBlurRadius} ${shadow.shadowColor}`,
   colors,
+  dimensions: {
+    headerHeight: "72px",
+    headerHeightSm: "60px",
+  },
 }
 
 const BREAKPOINTS = {

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -230,4 +230,4 @@ export { MITLearnGlobalStyles } from "./components/ThemeProvider/MITLearnGlobalS
 export { default as styled } from "@emotion/styled"
 export { css, Global } from "@emotion/react"
 
-export { AppRouterCacheProvider as NextJsAppRouterCacheProvider } from "@mui/material-nextjs/v13-appRouter"
+export { AppRouterCacheProvider as NextJsAppRouterCacheProvider } from "@mui/material-nextjs/v14-appRouter"

--- a/frontends/ol-components/src/types/theme.d.ts
+++ b/frontends/ol-components/src/types/theme.d.ts
@@ -43,6 +43,10 @@ interface CustomTheme {
     orange: string
     yellow: string
   }
+  dimensions: {
+    headerHeight: string
+    headerHeightSm: string
+  }
 }
 
 /* https://mui.com/material-ui/customization/theming/#typescript */


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5828

### Description (What does it do?)
Makes navigation menu keyboard openable / closeable

### Screenshots (if appropriate):
The close button moved:
<img width="855" alt="Screenshot 2024-10-22 at 12 32 26 PM" src="https://github.com/user-attachments/assets/cf18e0a8-6314-4776-9b05-11932acb0a3f">


### How can this be tested?
1. Open and close the navigation menu with your mouse, with your keyboard.
2. Check that "Escape" closes the nav menu
3. Check that the nav menu traps focus (cycling through all the links+button should get you back to the beginning)
4. Check that clicking outside the nav menu closes it
    - even if you click on the initial trigger (the hamburger / explore MIT button)
