### PR TITLE
Middleware for SSL redirect

### DIFF
--- a/frontends/main/src/middleware.ts
+++ b/frontends/main/src/middleware.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server"
+import type { NextRequest } from "next/server"
+
+/* The CDNs handle SSL redirects, but this is intended to block content being served
+ * over HTTP if directly addressed at their origin server domains.
+ */
+export function middleware(request: NextRequest) {
+  const protocol = request.headers.get("x-forwarded-proto")
+  const host = request.headers.get("host")
+
+  if (
+    protocol !== "https" &&
+    process.env.NODE_ENV === "production" &&
+    /* This is included so we can test the build locally with yarn build; yarn start;
+     * without needing an additional APP_ENV variable (Next.js builds with NODE_ENV=production always).
+     * We're typically using open.odl.local or just localhost.
+     */
+    !host?.includes("local")
+  ) {
+    const url = `https://${host}${request.nextUrl.pathname}${request.nextUrl.searchParams.toString() ? `?${request.nextUrl.searchParams}` : ""}`
+    return NextResponse.redirect(url, 301)
+  }
+
+  return NextResponse.next()
+}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Closes https://github.com/mitodl/hq/issues/5836

### Description (What does it do?)
<!--- Describe your changes in detail -->

Adds a middleware function to redirect any traffic on HTTP to HTTPS.

Redirects for requests to http://mit.learn.edu are handled by the CDN, though this change blocks content from being served over HTTP if the assigned Next.js server domains are addressed directly. Very edge case as we have a CORS list, though this was highlighted while we had a whitelisted domain before the CDN was set up on RC.



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Build the app for production and test that it redirects to HTTPS
- Run `yarn build`
- Run `PORT=8062 yarn start`
- Add an `/etc/hosts` file entry to 127.0.01 that does not include the string "local", e.g. `127.0.01     testing`.
- Navigate to http://testing:8062/
- You should be redirected to https://testing:8062/ (where locally you'll see an SSL error).
- Paths and search params should be preserved.
