### PR TITLE
Search count inside label

### DIFF
--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",
     "@emotion/cache": "^11.13.1",
-    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#10ba276fa647101399119baecafec03f9bcb1325",
+    "@mitodl/course-search-utils": "^3.3.1",
     "@next/bundle-analyzer": "^14.2.15",
     "@remixicon/react": "^4.2.0",
     "@sentry/nextjs": "^8",

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",
     "@emotion/cache": "^11.13.1",
-    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#d60d354725c23227a263279392a633f502399ee6",
+    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#10ba276fa647101399119baecafec03f9bcb1325",
     "@next/bundle-analyzer": "^14.2.15",
     "@remixicon/react": "^4.2.0",
     "@sentry/nextjs": "^8",

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",
     "@emotion/cache": "^11.13.1",
-    "@mitodl/course-search-utils": "^3.3.0",
+    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#d60d354725c23227a263279392a633f502399ee6",
     "@next/bundle-analyzer": "^14.2.15",
     "@remixicon/react": "^4.2.0",
     "@sentry/nextjs": "^8",

--- a/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
@@ -157,8 +157,10 @@ describe("SearchPage", () => {
 
     const clearAll = await screen.findByRole("button", { name: /clear all/i })
 
-    const physics = await screen.findByRole("checkbox", { name: "Physics" })
-    const chemistry = await screen.findByRole("checkbox", { name: "Chemistry" })
+    const physics = await screen.findByRole("checkbox", { name: "Physics 100" })
+    const chemistry = await screen.findByRole("checkbox", {
+      name: "Chemistry 200",
+    })
     // initial
     expect(physics).toBeChecked()
     expect(chemistry).toBeChecked()
@@ -554,9 +556,9 @@ test("Facet 'Offered By' uses API response for names", async () => {
     search: {
       metadata: {
         aggregations: {
-          offered_by: offerors.results.map((o) => ({
+          offered_by: offerors.results.map((o, i) => ({
             key: o.code,
-            doc_count: 10,
+            doc_count: 10 + i,
           })),
         },
         suggestions: [],
@@ -571,13 +573,13 @@ test("Facet 'Offered By' uses API response for names", async () => {
   await user.click(showFacetButton)
 
   const offeror0 = await screen.findByRole("checkbox", {
-    name: offerors.results[0].name,
+    name: `${offerors.results[0].name} 10`,
   })
   const offeror1 = await screen.findByRole("checkbox", {
-    name: offerors.results[1].name,
+    name: `${offerors.results[1].name} 11`,
   })
   const offeror2 = await screen.findByRole("checkbox", {
-    name: offerors.results[2].name,
+    name: `${offerors.results[2].name} 12`,
   })
   expect(offeror0).toBeVisible()
   expect(offeror1).toBeVisible()

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -206,7 +206,7 @@ const FacetStyles = styled.div`
         float: right;
       }
 
-      &.chcked,
+      &.checked,
       &:hover {
         .facet-label .facet-text {
           color: ${({ theme }) => theme.custom.colors.darkGray2};

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -140,7 +140,7 @@ const FacetStyles = styled.div`
     width: 100%;
     align-items: baseline;
 
-    label {
+    .facet-text {
       ${truncateText(1)};
       color: ${({ theme }) => theme.custom.colors.silverGrayDark};
     }
@@ -193,7 +193,7 @@ const FacetStyles = styled.div`
       margin-left: -2px;
 
       input,
-      label {
+      .facet-label {
         cursor: pointer;
       }
 
@@ -205,12 +205,13 @@ const FacetStyles = styled.div`
         color: ${({ theme }) => theme.custom.colors.silverGrayDark};
         float: right;
       }
-    }
 
-    .facet-visible.checked .facet-label label,
-    .facet-visible .facet-label label:hover,
-    .facet-visible input:hover + .facet-label label {
-      color: ${({ theme }) => theme.custom.colors.darkGray2};
+      &.chcked,
+      &:hover {
+        .facet-label .facet-text {
+          color: ${({ theme }) => theme.custom.colors.darkGray2};
+        }
+      }
     }
 
     .facet-more-less {
@@ -294,12 +295,10 @@ const FacetStyles = styled.div`
     padding-top: 5px;
 
     /* stylelint-disable no-descending-specificity */
-    .facet-visible {
-      .facet-label {
-        label,
-        .facet-count {
-          color: ${({ theme }) => theme.custom.colors.darkGray2};
-        }
+    .facet-visible .facet-label {
+      .facet-text,
+      .facet-count {
+        color: ${({ theme }) => theme.custom.colors.darkGray2};
       }
 
       margin-bottom: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3533,9 +3533,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#d60d354725c23227a263279392a633f502399ee6":
+"@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#10ba276fa647101399119baecafec03f9bcb1325":
   version: 3.3.0
-  resolution: "@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#commit=d60d354725c23227a263279392a633f502399ee6"
+  resolution: "@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#commit=10ba276fa647101399119baecafec03f9bcb1325"
   dependencies:
     "@mitodl/open-api-axios": "npm:2024.9.16"
     "@remixicon/react": "npm:^4.2.0"
@@ -3555,7 +3555,7 @@ __metadata:
       optional: true
     react-router:
       optional: true
-  checksum: 10/945338540c740fd91a8a84584cc6dc6d93e990c533d6bfb62ea6d2bf5947b8fe08d626e85ddb225597ea4b822f7cd06d0c1ceeaa2e69e510b9f76fc3aa7302e3
+  checksum: 10/5e295150ba54c37ec0ae2659df58f5f1e8a681341798346a273b267418281893e23102ef0b902c0d98ea9d947d49f9944c7499244a32805e43501f706c550de0
   languageName: node
   linkType: hard
 
@@ -14505,7 +14505,7 @@ __metadata:
     "@ebay/nice-modal-react": "npm:^1.2.13"
     "@emotion/cache": "npm:^11.13.1"
     "@faker-js/faker": "npm:^8.4.1"
-    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#d60d354725c23227a263279392a633f502399ee6"
+    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#10ba276fa647101399119baecafec03f9bcb1325"
     "@next/bundle-analyzer": "npm:^14.2.15"
     "@remixicon/react": "npm:^4.2.0"
     "@sentry/nextjs": "npm:^8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3533,9 +3533,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@npm:^3.3.0":
+"@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#d60d354725c23227a263279392a633f502399ee6":
   version: 3.3.0
-  resolution: "@mitodl/course-search-utils@npm:3.3.0"
+  resolution: "@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#commit=d60d354725c23227a263279392a633f502399ee6"
   dependencies:
     "@mitodl/open-api-axios": "npm:2024.9.16"
     "@remixicon/react": "npm:^4.2.0"
@@ -3555,7 +3555,7 @@ __metadata:
       optional: true
     react-router:
       optional: true
-  checksum: 10/b6550dff9b96e3724be052a945e817d519c6ee196902def7137a3cfb874bcf030d4e00ff231ad35f948a8157fc439f2eb4dec87f61f7f10bfeeab7b76cddf1a1
+  checksum: 10/945338540c740fd91a8a84584cc6dc6d93e990c533d6bfb62ea6d2bf5947b8fe08d626e85ddb225597ea4b822f7cd06d0c1ceeaa2e69e510b9f76fc3aa7302e3
   languageName: node
   linkType: hard
 
@@ -14505,7 +14505,7 @@ __metadata:
     "@ebay/nice-modal-react": "npm:^1.2.13"
     "@emotion/cache": "npm:^11.13.1"
     "@faker-js/faker": "npm:^8.4.1"
-    "@mitodl/course-search-utils": "npm:^3.3.0"
+    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#d60d354725c23227a263279392a633f502399ee6"
     "@next/bundle-analyzer": "npm:^14.2.15"
     "@remixicon/react": "npm:^4.2.0"
     "@sentry/nextjs": "npm:^8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3533,9 +3533,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#10ba276fa647101399119baecafec03f9bcb1325":
-  version: 3.3.0
-  resolution: "@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#commit=10ba276fa647101399119baecafec03f9bcb1325"
+"@mitodl/course-search-utils@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "@mitodl/course-search-utils@npm:3.3.1"
   dependencies:
     "@mitodl/open-api-axios": "npm:2024.9.16"
     "@remixicon/react": "npm:^4.2.0"
@@ -3555,7 +3555,7 @@ __metadata:
       optional: true
     react-router:
       optional: true
-  checksum: 10/5e295150ba54c37ec0ae2659df58f5f1e8a681341798346a273b267418281893e23102ef0b902c0d98ea9d947d49f9944c7499244a32805e43501f706c550de0
+  checksum: 10/d0f69157755f1ff90a4cb9cee017320f08e2073066ac4b948120eb8b2c3c6cedb844f9c358596b47e8a04c9eba896c4da49f593436a9a9bf0f9d9894d2fc3119
   languageName: node
   linkType: hard
 
@@ -14505,7 +14505,7 @@ __metadata:
     "@ebay/nice-modal-react": "npm:^1.2.13"
     "@emotion/cache": "npm:^11.13.1"
     "@faker-js/faker": "npm:^8.4.1"
-    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#10ba276fa647101399119baecafec03f9bcb1325"
+    "@mitodl/course-search-utils": "npm:^3.3.1"
     "@next/bundle-analyzer": "npm:^14.2.15"
     "@remixicon/react": "npm:^4.2.0"
     "@sentry/nextjs": "npm:^8"


### PR DESCRIPTION
### What are the relevant tickets?

For https://github.com/mitodl/hq/issues/5708

### Description (What does it do?)
Puts the search count inside the `<label>` for screenreaders 

### Screenshots (if appropriate):
No visual change

<img width="399" alt="Screenshot 2024-10-22 at 4 57 11 PM" src="https://github.com/user-attachments/assets/08f7b1d6-504a-4f67-adbe-5f9e93537589">
<img width="1634" alt="Screenshot 2024-10-22 at 4 59 14 PM" src="https://github.com/user-attachments/assets/f3757839-f06f-488f-8ff1-fab4cee47861">


### How can this be tested?
1. Check that the search page has no visual change
    - OK I guess there is one... the mouse cursor is `pointer` on the count now, too.
    - you might want to check that the checkboxes change color the same as prod on hover, etc
2. Check that the checkbox has count as part of its label in the accessibility tree. You could also enable a screenreader like voiceover, if you want. (See screenshot above)

### Checklist:
- [ ] Review with https://github.com/mitodl/course-search-utils/pull/151
