### PR TITLE
Replace plain <a> tags with Next.js <Link> components

### DIFF
--- a/frontends/main/src/common/urls.ts
+++ b/frontends/main/src/common/urls.ts
@@ -95,17 +95,17 @@ export const PROFILE = "/dashboard/profile"
 
 export const SETTINGS = "/dashboard/settings"
 
-export const SEARCH = "/search/"
+export const SEARCH = "/search"
 
-export const ABOUT = "/about/"
+export const ABOUT = "/about"
 
 export const ACCESSIBILITY = "https://accessibility.mit.edu/"
 
-export const PRIVACY = "/privacy/"
+export const PRIVACY = "/privacy"
 
-export const TERMS = "/terms/"
+export const TERMS = "/terms"
 
-export const UNITS = "/units/"
+export const UNITS = "/units"
 
 export const CONTACT = "mailto:mitlearn-support@mit.edu"
 

--- a/frontends/main/src/page-components/Footer/Footer.tsx
+++ b/frontends/main/src/page-components/Footer/Footer.tsx
@@ -4,6 +4,7 @@ import { Container, styled } from "ol-components"
 import MITLogoLink from "@/components/MITLogoLink/MITLogoLink"
 import * as urls from "@/common/urls"
 import React, { FunctionComponent } from "react"
+import Link from "next/link"
 
 const FooterContainer = styled.div(({ theme }) => ({
   display: "flex",
@@ -96,7 +97,7 @@ const FooterLinkContainer = styled.div(({ theme }) => ({
   },
 }))
 
-const FooterLink = styled.a(({ theme }) => ({
+const FooterLink = styled(Link)(({ theme }) => ({
   color: theme.custom.colors.black,
   textDecoration: "none",
   textAlign: "center",
@@ -108,8 +109,8 @@ const FooterLink = styled.a(({ theme }) => ({
 }))
 
 interface FooterLinkComponentProps {
-  href?: string
-  text?: string
+  href: string
+  text: string
 }
 
 const FooterLinkComponent: FunctionComponent<FooterLinkComponentProps> = (

--- a/frontends/main/src/page-components/Header/Header.tsx
+++ b/frontends/main/src/page-components/Header/Header.tsx
@@ -141,7 +141,6 @@ const SearchButton: FunctionComponent = () => {
     <StyledSearchButton
       edge="circular"
       variant="text"
-      rawAnchor={true}
       href={SEARCH}
       aria-label="Search"
     >

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.test.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.test.tsx
@@ -51,7 +51,7 @@ describe("NavDrawer", () => {
           {
             title: "Title 1",
             description: "Description 1",
-            href: "https://link.one",
+            href: "#hash-1",
           },
         ],
       },
@@ -61,7 +61,7 @@ describe("NavDrawer", () => {
           {
             title: "Title 2",
             description: "Description 2",
-            href: "https://link.two",
+            href: "#hash-2",
           },
         ],
       },
@@ -117,5 +117,18 @@ describe("NavDrawer", () => {
     await user.click(screen.getByRole("button", { name: "Excluded" }))
     await user.click(screen.getByTestId("foo"))
     expect(onClose).not.toHaveBeenCalled()
+  })
+
+  test("clicking a link navigates and closes the drawer", async () => {
+    const onClose = jest.fn()
+    render(<NavDrawer onClose={onClose} navdata={NAV_DATA} open={true} />, {
+      wrapper: ThemeProvider,
+    })
+
+    const link = screen.getByRole("link", { name: "Title 1 Description 1" })
+    await user.click(link)
+
+    expect(window.location.hash).toBe("#hash-1")
+    expect(onClose).toHaveBeenCalled()
   })
 })

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
@@ -2,6 +2,7 @@ import Drawer, { DrawerProps } from "@mui/material/Drawer"
 import ClickAwayListener from "@mui/material/ClickAwayListener"
 import { FocusTrap } from "@mui/base/FocusTrap"
 import styled from "@emotion/styled"
+import Link from "next/link"
 import React, { ReactElement } from "react"
 import { RiCloseLargeLine } from "@remixicon/react"
 import { ActionButton } from "../Button/Button"
@@ -51,7 +52,7 @@ const NavItemsContainer = styled.div(({ theme }) => ({
   color: theme.custom.colors.silverGrayDark,
 }))
 
-const NavItemLink = styled.a({
+const NavItemLink = styled(Link)({
   display: "flex",
   alignItems: "flex-start",
   alignSelf: "stretch",
@@ -127,10 +128,11 @@ export interface NavItem {
   icon?: string | ReactElement
   description?: string
   href: string
+  onClick?: () => void
 }
 
 const NavItem: React.FC<NavItem> = (props) => {
-  const { title, icon, description, href } = props
+  const { title, icon, description, href, onClick } = props
   const navItem = (
     <NavItemContainer>
       <NavIconContainer style={{ paddingTop: description ? "4px" : "" }}>
@@ -156,7 +158,7 @@ const NavItem: React.FC<NavItem> = (props) => {
     </NavItemContainer>
   )
   return (
-    <NavItemLink href={href} data-testid="nav-link">
+    <NavItemLink href={href} onClick={onClick} data-testid="nav-link">
       {navItem}
     </NavItemLink>
   )
@@ -186,6 +188,7 @@ const NavDrawer = ({
         icon={item.icon}
         description={item.description}
         href={item.href}
+        onClick={onClose}
       />
     ))
     return (


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Closes https://github.com/mitodl/hq/issues/5853.

### Description (What does it do?)
<!--- Describe your changes in detail -->

Replaces any remaining plain links to internal routes with Next.js `<Link>` components.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Check the nav drawer links. These should navigate without reloading the page.
  - Search links (navigating between items in “Learn” and “Discover Learning Resources”) should update the search filters without reload.
  - The nav drawer should close on selection.
 
- The header search icon should navigate without reload.

- Footer links should navigate without reload ("Accessibility" and "Contact Us" are external, but still navigate ok).

### Additional Context

The Channel detail links to external sites and login links in the header, user menu and Personalize section are the only remaining plain `<a>` tags. The login links use `<ButtonLink>` with `rawAnchor={true}`, which we perhaps don't need as Next.js `<Link>` works fine for external URLs and `target="_blank"` (e.g. the MIT logo link in the header).