### PR TITLE
move nextjs hash.txt generation after heroku deploy

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Set VERSION
         run: echo "VERSION=$(./scripts/get_version.sh)" >> $GITHUB_ENV
 
-      - name: Write commit SHA to file
-        run: echo $GITHUB_SHA > frontends/main/public/hash.txt
-
       - name: Heroku login
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
@@ -38,7 +35,10 @@ jobs:
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
           branch: release
 
-      - name: Build and push the Docker image
+      - name: Write commit SHA to file
+        run: echo $GITHUB_SHA > frontends/main/public/hash.txt
+
+      - name: Build and push the NextJS Docker image
         env:
           HEROKU_APP_NAME: mitopen-production-nextjs
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Set VERSION
         run: echo "VERSION=$(./scripts/get_version.sh)" >> $GITHUB_ENV
 
-      - name: Write commit SHA to file
-        run: echo $GITHUB_SHA > frontends/main/public/hash.txt
-
       - name: Heroku login
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
@@ -38,7 +35,10 @@ jobs:
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
           branch: release-candidate
 
-      - name: Build and push the Docker image
+      - name: Write commit SHA to file
+        run: echo $GITHUB_SHA > frontends/main/public/hash.txt
+
+      - name: Build and push the NextJS Docker image
         env:
           HEROKU_APP_NAME: mitopen-rc-nextjs
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}


### PR DESCRIPTION
### What are the relevant tickets?
Maybe it fixes DOOF

### Description (What does it do?)
Doof is having trouble when deploying to RC:  The `heroku/main` branch seems to have an extra commit containing the file `frontends/main/public/hash.txt`. Let's move generation of that file after heroku deploy.

Note: The `frontends/main/public/hash.txt` isn't really required by anything but it's nice to know exactly what is deployed to the nextjs server.


### How can this be tested?
Trigger a doof release and see if it goes through without any hiccups. 
