### PR TITLE
Add the ol-profile openid scope to auth

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -356,6 +356,8 @@ SOCIAL_AUTH_OL_OIDC_SECRET = get_string(
     default="some super secret key",
 )
 
+SOCIAL_AUTH_OL_OIDC_SCOPE = ["ol-profile"]
+
 USERINFO_URL = get_string(
     name="USERINFO_URL",
     default=None,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/5559

### Description (What does it do?)
<!--- Describe your changes in detail -->
This configures the `ol-oidc` social auth to additionally request the `ol-profile` scope because it wasn't trivial to extend the `profile` scope w/ Pulumi. This scope is being added in https://github.com/mitodl/ol-infrastructure/pull/2757.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- In keycloak, add a `ol-profile` client scope.
- Try to login and verify keycloak errors because the scope isn't valid for the client. 
- Go to the client for the Learn app and add the `ol-profile` scope as a default scope (it doesn't really matter default or optional since Learn requests specific ones).
- Verify you can now login without errors.