### PR TITLE
Handle dupe prices during migration

### DIFF
--- a/learning_resources/migrations/0071_learningresourceprice.py
+++ b/learning_resources/migrations/0071_learningresourceprice.py
@@ -16,13 +16,13 @@ def migrate_price_values(apps, schema_editor):
     )
 
     for resource in LearningResource.objects.exclude(prices=[]):
-        for price in resource.prices:
+        for price in set(resource.prices):
             resource_price, _ = LearningResourcePrice.objects.get_or_create(
                 amount=price, currency=CURRENCY_USD
             )
             resource.resource_prices.add(resource_price)
         for run in resource.runs.exclude(prices=[]).exclude(prices__isnull=True):
-            for price in run.prices:
+            for price in set(run.prices):
                 resource_price, _ = LearningResourcePrice.objects.get_or_create(
                     amount=price, currency=CURRENCY_USD
                 )


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fixes a migration failure caused by old unpublished runs with duplicate prices.



### How can this be tested?
On the main branch:
  - Run `./manage.py migrate learning_resources 0070_learningresource_location`
  - Assign duplicate prices to an existing resource and run:
  ```python
  from learning_resources.models import *
  course = LearningResource.objects.filter(resource_type="course").exclude(prices=[]).first()
  course.prices = [0, 0, 999]
  course.save()
  run = course.runs.first()
  run.prices = [0, 0, 999]
  run.save()
  ```
- Run `./manage.py migrate learning_resources`, it will fail due to a duplicate key.
- Switch to this branch, run the above migration again.  It should pass.


### Additional Context
ETL pipelines currently ensure that prices for any particular resource and run are unique, but RC and prod have some old unpublished runs still around from before this was implemented, causing a migration error.


