### PR TITLE
adding fix for pruning percolate queries

### DIFF
--- a/learning_resources_search/utils.py
+++ b/learning_resources_search/utils.py
@@ -32,10 +32,12 @@ def prune_channel_subscriptions():
             percolate_serializer.get_search_request_data()
             | {"endpoint": LEARNING_RESOURCE}
         )
-        actual_query, _ = PercolateQuery.objects.get_or_create(
+        actual_query, _ = PercolateQuery.objects.update_or_create(
             source_type=PercolateQuery.CHANNEL_SUBSCRIPTION_TYPE,
             original_query=adjusted_original_query,
-            query=adjust_query_for_percolator(adjusted_original_query),
+            defaults={
+                "query": adjust_query_for_percolator(adjusted_original_query),
+            },
         )
         queries = PercolateQuery.objects.filter(
             original_query__contains=urllib.parse.parse_qs(query_string),


### PR DESCRIPTION
### Description (What does it do?)
This PR includes a fix for a duplicate key integrity error when running the "prune_percolate_queries" management command./

### How can this be tested?
1. Checkout **main** - make sure you have channel data (topics, offeror, departments etc) loaded up.
2. The easiest way I got into the same state as staging was to replicate the data. Run the following in django shell to generate the user ids that the fixtures from rc expect:
```
from django.contrib.auth import get_user_model
from random import randint
User = get_user_model()
for uid in [35, 36, 44, 13, 78, 178, 20, 26]:
	User.objects.create(pk=uid, email=f'{randint(1,1000)}-test@test.com',username=f'{randint(1,1000)}-test')
```
4. Delete all existing percolate queries via django admin
5. load in the attached RC [percolate fixtures](https://github.com/user-attachments/files/17550153/percolate-query-rc.json)  via `python manage.py  loaddata --app learning_resources_search  percolate-query-rc.json`
6. attempt to run the prune queries management command via `python manage.py prune_subscription_queries` -> note that it fails with the same integrity error we see on RC
7. checkout this branch and attempt to re-run the command and note that it succeeds.
