### PR TITLE
fix intermittent failure for flaky test

### DIFF
--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -1007,6 +1007,7 @@ def test_similar_resources_endpoint_only_returns_published(mocker, client):
     resources = LearningResourceFactory.create_batch(5)
 
     resource_ids = [learning_resource.id for learning_resource in resources]
+    similar_for = resource_ids.pop()
     mocker.patch.object(Search, "execute")
     response_resources = LearningResource.objects.for_search_serialization().filter(
         id__in=resource_ids
@@ -1031,7 +1032,6 @@ def test_similar_resources_endpoint_only_returns_published(mocker, client):
             "took": 123,
         },
     ).hits
-    similar_for = resource_ids[0]
     resp = client.get(
         reverse("lr:v1:learning_resources_api-similar", args=[similar_for])
     )


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/mit-learn/issues/1772
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
Fixes the intermittent test failure in test_similar_resources_endpoint_only_returns_published


### How can this be tested?
1. checkout **main**
2. decorate learning_resources/views_test.py::test_similar_resources_endpoint_only_returns_published  with `@pytest.mark.parametrize('execution_number', range(100))` and run it via `pytest learning_resources/views_test.py::test_similar_resources_endpoint_only_returns_published -s -vvv -x` to see it fail
3. checkout this branch and try the same and note it succeeds every time
