### PR TITLE
Card Accessibility Improvements

### DIFF
--- a/frontends/main/src/app-pages/HomePage/HomePage.test.tsx
+++ b/frontends/main/src/app-pages/HomePage/HomePage.test.tsx
@@ -57,7 +57,7 @@ const setupAPIs = () => {
       limit: 6,
       sortby: "-news_date",
     }),
-    {},
+    newsEvents.newsItems({ count: 0 }),
   )
   setMockResponse.get(
     urls.newsEvents.list({
@@ -65,7 +65,7 @@ const setupAPIs = () => {
       limit: 5,
       sortby: "event_date",
     }),
-    {},
+    newsEvents.eventItems({ count: 0 }),
   )
 
   setMockResponse.get(urls.topics.list({ is_toplevel: true }), {

--- a/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
+++ b/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
@@ -219,42 +219,32 @@ const NewsEventsSection: React.FC = () => {
     return null
   }
 
-  const stories = news!.results?.slice(0, 6) || []
+  const stories = news.results.slice(0, 6)
 
-  const EventCards =
-    events!.results?.map((item) => (
-      <EventCard
-        key={item.id}
-        href={item.url}
-        onClick={(e) => {
-          const anchor = e.currentTarget.querySelector<HTMLAnchorElement>(
-            `a[href="${item.url}"]`,
-          )
-          anchor?.click()
-        }}
-      >
-        <Card.Content>
-          <EventDate>
-            <EventDay>
-              {formatDate(
-                (item as EventFeedItem).event_details?.event_datetime,
-                "D",
-              )}
-            </EventDay>
-            <EventMonth>
-              {formatDate(
-                (item as EventFeedItem).event_details?.event_datetime,
-                "MMM",
-              )}
-            </EventMonth>
-          </EventDate>
-          <Link href={item.url}>
-            <EventTitle>{item.title}</EventTitle>
-          </Link>
-          <Chevron />
-        </Card.Content>
-      </EventCard>
-    )) || []
+  const EventCards = events.results.map((item) => (
+    <EventCard key={item.id} href={item.url}>
+      <Card.Content>
+        <EventDate>
+          <EventDay>
+            {formatDate(
+              (item as EventFeedItem).event_details?.event_datetime,
+              "D",
+            )}
+          </EventDay>
+          <EventMonth>
+            {formatDate(
+              (item as EventFeedItem).event_details?.event_datetime,
+              "MMM",
+            )}
+          </EventMonth>
+        </EventDate>
+        <Link href={item.url}>
+          <EventTitle>{item.title}</EventTitle>
+        </Link>
+        <Chevron />
+      </Card.Content>
+    </EventCard>
+  ))
 
   return (
     <Section>

--- a/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
+++ b/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
@@ -188,7 +188,7 @@ const Story: React.FC<{ item: NewsFeedItem; mobile: boolean }> = ({
   mobile,
 }) => {
   return (
-    <StoryCard mobile={mobile} href={item.url}>
+    <StoryCard mobile={mobile} href={item.url} forwardClicksToLink>
       {item.image.url ? (
         <Card.Image src={item.image.url} alt={item.image.alt || ""} />
       ) : null}
@@ -222,7 +222,7 @@ const NewsEventsSection: React.FC = () => {
   const stories = news.results.slice(0, 6)
 
   const EventCards = events.results.map((item) => (
-    <EventCard key={item.id} href={item.url}>
+    <EventCard key={item.id} href={item.url} forwardClicksToLink>
       <Card.Content>
         <EventDate>
           <EventDay>

--- a/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
+++ b/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
@@ -15,6 +15,7 @@ import {
 import type { NewsFeedItem, EventFeedItem } from "api/v0"
 import { formatDate } from "ol-utilities"
 import { RiArrowRightSLine } from "@remixicon/react"
+import Link from "next/link"
 
 const Section = styled.section`
   background: ${theme.custom.colors.white};
@@ -111,10 +112,7 @@ const EventCard = styled(Card)`
   align-self: stretch;
   justify-content: space-between;
   overflow: visible;
-
-  > a {
-    padding: 16px;
-  }
+  padding: 16px;
 `
 
 const EventDate = styled.div`
@@ -225,7 +223,16 @@ const NewsEventsSection: React.FC = () => {
 
   const EventCards =
     events!.results?.map((item) => (
-      <EventCard key={item.id} href={item.url}>
+      <EventCard
+        key={item.id}
+        href={item.url}
+        onClick={(e) => {
+          const anchor = e.currentTarget.querySelector<HTMLAnchorElement>(
+            `a[href="${item.url}"]`,
+          )
+          anchor?.click()
+        }}
+      >
         <Card.Content>
           <EventDate>
             <EventDay>
@@ -241,7 +248,9 @@ const NewsEventsSection: React.FC = () => {
               )}
             </EventMonth>
           </EventDate>
-          <EventTitle>{item.title}</EventTitle>
+          <Link href={item.url}>
+            <EventTitle>{item.title}</EventTitle>
+          </Link>
           <Chevron />
         </Card.Content>
       </EventCard>

--- a/frontends/main/src/components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
+++ b/frontends/main/src/components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
@@ -16,6 +16,10 @@ const ConfiguredPostHogProvider: React.FC<{ children: React.ReactNode }> = ({
     },
   }
 
+  console.log({
+    postHogOptions,
+  })
+
   return apiKey ? (
     <PostHogProvider apiKey={apiKey} options={postHogOptions}>
       {children}

--- a/frontends/main/src/components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
+++ b/frontends/main/src/components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
@@ -16,10 +16,6 @@ const ConfiguredPostHogProvider: React.FC<{ children: React.ReactNode }> = ({
     },
   }
 
-  console.log({
-    postHogOptions,
-  })
-
   return apiKey ? (
     <PostHogProvider apiKey={apiKey} options={postHogOptions}>
       {children}

--- a/frontends/main/src/page-components/UserListCard/UserListCardCondensed.tsx
+++ b/frontends/main/src/page-components/UserListCard/UserListCardCondensed.tsx
@@ -3,6 +3,7 @@ import { UserList } from "api"
 import { pluralize } from "ol-utilities"
 import { RiListCheck3 } from "@remixicon/react"
 import { ListCardCondensed, styled, theme, Typography } from "ol-components"
+import Link from "next/link"
 
 const StyledCard = styled(ListCardCondensed)({
   display: "flex",
@@ -37,24 +38,29 @@ const IconContainer = styled.div(({ theme }) => ({
   },
 }))
 
-type UserListCardCondensedProps<U extends UserList = UserList> = {
-  userList: U
-  href?: string
+type UserListCardCondensedProps = {
+  userList: UserList
+  href: string
   className?: string
 }
 
-const UserListCardCondensed = <U extends UserList>({
+const UserListCardCondensed = ({
   userList,
   href,
   className,
-}: UserListCardCondensedProps<U>) => {
+}: UserListCardCondensedProps) => {
   return (
     <StyledCard href={href} className={className}>
       <ListCardCondensed.Content>
         <TextContainer>
-          <Typography variant="subtitle1" color={theme.custom.colors.darkGray2}>
-            {userList.title}
-          </Typography>
+          <Link href={href}>
+            <Typography
+              variant="subtitle1"
+              color={theme.custom.colors.darkGray2}
+            >
+              {userList.title}
+            </Typography>
+          </Link>
           <ItemsText variant="body3">
             {userList.item_count} {pluralize("item", userList.item_count)}
           </ItemsText>

--- a/frontends/ol-components/src/components/Card/Card.test.tsx
+++ b/frontends/ol-components/src/components/Card/Card.test.tsx
@@ -5,7 +5,6 @@ import React from "react"
 import { getOriginalSrc } from "ol-test-utilities"
 import invariant from "tiny-invariant"
 import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
-import { faker } from "@faker-js/faker/locale/en"
 
 describe("Card", () => {
   test("has class MitCard-root on root element", () => {
@@ -42,49 +41,96 @@ describe("Card", () => {
     expect(actions).toHaveTextContent("Actions")
   })
 
-  test("The whole card is clickable as a link", async () => {
-    const href = `#${faker.lorem.word()}`
+  test.each([
+    { forwardClicksToLink: true, finalHref: "#woof" },
+    { forwardClicksToLink: false, finalHref: "" },
+  ])(
+    "The whole card is clickable as a link if forwardClicksToLink ($forwardClicksToLink)",
+    async ({ forwardClicksToLink, finalHref }) => {
+      const href = "#woof"
+      render(
+        <Card href={href} forwardClicksToLink={forwardClicksToLink}>
+          <Card.Title>Title</Card.Title>
+          <Card.Image src="https://via.placeholder.com/150" alt="placeholder" />
+          <Card.Info>Info</Card.Info>
+          <Card.Footer>Footer</Card.Footer>
+          <Card.Actions>Actions</Card.Actions>
+        </Card>,
+        { wrapper: ThemeProvider },
+      )
+      const card = document.querySelector(".MitCard-root")
+      invariant(card instanceof HTMLDivElement) // Sanity: Chceck it's not an anchor
+
+      await user.click(card)
+      expect(window.location.hash).toBe(finalHref)
+    },
+  )
+
+  test.each([
+    { forwardClicksToLink: true, finalHref: "#meow" },
+    { forwardClicksToLink: false, finalHref: "" },
+  ])(
+    "The whole card is clickable as a link when using Content when forwardClicksToLink ($forwardClicksToLink), except buttons and links",
+    async ({ finalHref, forwardClicksToLink }) => {
+      const href = "#meow"
+      const onClick = jest.fn()
+      render(
+        <Card href={href} forwardClicksToLink={forwardClicksToLink}>
+          <Card.Content>
+            <div>Hello!</div>
+            <div data-card-actions>
+              <button onClick={onClick}>Button</button>
+            </div>
+            <a href={href}>Link</a>
+          </Card.Content>
+        </Card>,
+        { wrapper: ThemeProvider },
+      )
+      const button = screen.getByRole("button", { name: "Button" })
+      await user.click(button)
+      expect(onClick).toHaveBeenCalled()
+      expect(window.location.hash).toBe("")
+
+      // outermost wrapper is not actually clickable
+      const card = document.querySelector(".MitCard-root")
+      invariant(card instanceof HTMLDivElement) // Sanity: Chceck it's not an anchor
+
+      await user.click(card)
+      expect(window.location.hash).toBe(finalHref)
+    },
+  )
+
+  test("Clicks on interactive elements are not forwarded", async () => {
+    const btnOnClick = jest.fn()
+    const divOnClick = jest.fn()
     render(
-      <Card href={href}>
+      <Card href={"#one"} forwardClicksToLink>
         <Card.Title>Title</Card.Title>
         <Card.Image src="https://via.placeholder.com/150" alt="placeholder" />
         <Card.Info>Info</Card.Info>
-        <Card.Footer>Footer</Card.Footer>
-        <Card.Actions>Actions</Card.Actions>
-      </Card>,
-      { wrapper: ThemeProvider },
-    )
-    // outermost wrapper is not actually clickable
-    const card = document.querySelector(".MitCard-root > *")
-    invariant(card instanceof HTMLDivElement) // Sanity: Chceck it's not an anchor
-
-    await user.click(card)
-    expect(window.location.hash).toBe(href)
-  })
-
-  test("The whole card is clickable as a link when using Content, except buttons and links", async () => {
-    const href = `#${faker.lorem.word()}`
-    const onClick = jest.fn()
-    render(
-      <Card href={href}>
-        <Card.Content>
-          <div>Hello!</div>
-          <button onClick={onClick}>Button</button>
-          <a href={href}>Link</a>
-        </Card.Content>
+        <Card.Footer>
+          <button onClick={btnOnClick}>Button</button>
+          <a href="#two">Link Two</a>
+          {/*
+          eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+          */}
+          <div data-card-action onClick={divOnClick}>
+            Interactive Div
+          </div>
+        </Card.Footer>
       </Card>,
       { wrapper: ThemeProvider },
     )
     const button = screen.getByRole("button", { name: "Button" })
+    const link = screen.getByRole("link", { name: "Link Two" })
+    const div = screen.getByText("Interactive Div")
     await user.click(button)
-    expect(onClick).toHaveBeenCalled()
+    expect(btnOnClick).toHaveBeenCalled()
     expect(window.location.hash).toBe("")
-
-    // outermost wrapper is not actually clickable
-    const card = document.querySelector(".MitCard-root > *")
-    invariant(card instanceof HTMLDivElement) // Sanity: Chceck it's not an anchor
-
-    await user.click(card)
-    expect(window.location.hash).toBe(href)
+    await user.click(link)
+    expect(window.location.hash).toBe("#two")
+    await user.click(div)
+    expect(divOnClick).toHaveBeenCalled()
+    expect(window.location.hash).toBe("#two")
   })
 })

--- a/frontends/ol-components/src/components/Card/Card.test.tsx
+++ b/frontends/ol-components/src/components/Card/Card.test.tsx
@@ -3,6 +3,7 @@ import { Card } from "./Card"
 import React from "react"
 import { getOriginalSrc } from "ol-test-utilities"
 import invariant from "tiny-invariant"
+import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
 
 describe("Card", () => {
   test("has class MitCard-root on root element", () => {
@@ -14,6 +15,7 @@ describe("Card", () => {
         <Card.Footer>Footer</Card.Footer>
         <Card.Actions>Actions</Card.Actions>
       </Card>,
+      { wrapper: ThemeProvider },
     )
     const card = container.firstChild as HTMLElement
     const title = card.querySelector(".MitCard-title")

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -5,6 +5,7 @@ import React, {
   isValidElement,
   CSSProperties,
   useCallback,
+  AriaAttributes,
 } from "react"
 import styled from "@emotion/styled"
 import { theme } from "../ThemeProvider/ThemeProvider"
@@ -18,7 +19,7 @@ type LinkableProps = {
   href?: string
   children?: ReactNode
   className?: string
-}
+} & Pick<AriaAttributes, "aria-label">
 /**
  * Render a NextJS link if href is provided, otherwise a span.
  * Does not scroll if the href is a query string.
@@ -27,10 +28,16 @@ export const Linkable: React.FC<LinkableProps> = ({
   href,
   children,
   className,
+  "aria-label": ariaLabel,
 }) => {
   if (href) {
     return (
-      <Link className={className} href={href} scroll={!href.startsWith("?")}>
+      <Link
+        aria-label={ariaLabel}
+        className={className}
+        href={href}
+        scroll={!href.startsWith("?")}
+      >
         {children}
       </Link>
     )
@@ -206,7 +213,8 @@ type TitleProps = {
   children?: ReactNode
   lines?: number
   style?: CSSProperties
-}
+} & Pick<AriaAttributes, "aria-label">
+
 type SlotProps = { children?: ReactNode; style?: CSSProperties }
 
 type Card = FC<CardProps> & {

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -166,6 +166,10 @@ export const useClickChildHref = (
       const target = e.target as HTMLElement
       if (!anchor || target.closest("a, button, [data-card-action]")) return
       if (e.metaKey || e.ctrlKey) {
+        /**
+         * Enables ctrl+click to open card's link in new tab.
+         * Without this, ctrl+click only works on the anchor itself.
+         */
         const opts: PointerEventInit = {
           bubbles: false,
           metaKey: e.metaKey,

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -72,6 +72,7 @@ export const Container = styled.div<{ display?: CSSProperties["display"] }>(
       background: theme.custom.colors.white,
       display,
       position: "relative",
+      overflow: "hidden", // to clip image so they match border radius
     },
     onClick && {
       "&:hover": {

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -50,21 +50,11 @@ export const Linkable: React.FC<LinkableProps> = ({
  * Link container in the DOM structure. They cannot be a descendent of it as
  * buttons inside anchors are not valid HTML.
  */
-export const Wrapper = styled.div<{ size?: Size }>`
+export const Wrapper = styled.div`
   position: relative;
-  ${({ size }) => {
-    let width
-    if (!size) return ""
-    if (size === "medium") width = 300
-    if (size === "small") width = 192
-    return `
-      min-width: ${width}px;
-      max-width: ${width}px;
-    `
-  }}
 `
 
-export const Container = styled.div<{ display?: CSSProperties["display"] }>(
+export const BaseContainer = styled.div<{ display?: CSSProperties["display"] }>(
   ({ theme, onClick, display = "block" }) => [
     {
       borderRadius: "8px",
@@ -84,6 +74,16 @@ export const Container = styled.div<{ display?: CSSProperties["display"] }>(
     },
   ],
 )
+const CONTAINER_WIDTHS: Record<Size, number> = {
+  small: 192,
+  medium: 300,
+}
+const Container = styled(BaseContainer)<{ size?: Size }>(({ size }) => [
+  size && {
+    minWidth: CONTAINER_WIDTHS[size],
+    maxWidth: CONTAINER_WIDTHS[size],
+  },
+])
 
 const Content = () => <></>
 
@@ -155,9 +155,6 @@ const Bottom = styled.div`
 const Actions = styled.div`
   display: flex;
   gap: 8px;
-  position: absolute;
-  bottom: 16px;
-  right: 16px;
 `
 
 /**
@@ -266,50 +263,46 @@ const Card: Card = ({ children, className, size, href, onClick }) => {
 
   if (content) {
     return (
-      <Wrapper className={allClassNames} size={size}>
-        <Container onClick={handleClick} className={className}>
-          {content}
-        </Container>
-      </Wrapper>
+      <Container className={allClassNames} size={size} onClick={handleClick}>
+        {content}
+      </Container>
     )
   }
 
   return (
-    <Wrapper className={allClassNames} size={size}>
-      <Container onClick={handleClick}>
-        {image && (
-          // alt text will be checked on Card.Image
-          // eslint-disable-next-line styled-components-a11y/alt-text
-          <Image
-            className="MitCard-image"
-            size={size}
-            height={170}
-            width={298}
-            {...(image as ImageProps)}
-          />
-        )}
-        <Body>
-          {info.children && (
-            <Info className="MitCard-info" size={size} {...info}>
-              {info.children}
-            </Info>
-          )}
-          <Title href={href} className="MitCard-title" size={size} {...title}>
-            {title.children}
-          </Title>
-        </Body>
-        <Bottom>
-          <Footer className="MitCard-footer" {...footer}>
-            {footer.children}
-          </Footer>
-        </Bottom>
-      </Container>
-      {actions.children && (
-        <Actions className="MitCard-actions" {...actions}>
-          {actions.children}
-        </Actions>
+    <Container className={allClassNames} size={size} onClick={handleClick}>
+      {image && (
+        // alt text will be checked on Card.Image
+        // eslint-disable-next-line styled-components-a11y/alt-text
+        <Image
+          className="MitCard-image"
+          size={size}
+          height={170}
+          width={298}
+          {...(image as ImageProps)}
+        />
       )}
-    </Wrapper>
+      <Body>
+        {info.children && (
+          <Info className="MitCard-info" size={size} {...info}>
+            {info.children}
+          </Info>
+        )}
+        <Title href={href} className="MitCard-title" size={size} {...title}>
+          {title.children}
+        </Title>
+      </Body>
+      <Bottom>
+        <Footer className="MitCard-footer" {...footer}>
+          {footer.children}
+        </Footer>
+        {actions.children && (
+          <Actions className="MitCard-actions" {...actions}>
+            {actions.children}
+          </Actions>
+        )}
+      </Bottom>
+    </Container>
   )
 }
 

--- a/frontends/ol-components/src/components/Card/ListCard.test.tsx
+++ b/frontends/ol-components/src/components/Card/ListCard.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from "@testing-library/react"
 import user from "@testing-library/user-event"
 import { ListCard } from "./ListCard"
 import React from "react"
-import { faker } from "@faker-js/faker/locale/en"
 import invariant from "tiny-invariant"
 import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
 
@@ -20,48 +19,93 @@ describe("ListCard", () => {
     expect(card).toHaveClass("Foo")
   })
 
-  test("The whole card is clickable as a link", async () => {
-    const href = `#${faker.lorem.word()}`
+  test.each([
+    { forwardClicksToLink: true, finalHref: "#woof" },
+    { forwardClicksToLink: false, finalHref: "" },
+  ])(
+    "The whole card is clickable as a link",
+    async ({ forwardClicksToLink, finalHref }) => {
+      const href = "#woof"
+      render(
+        <ListCard href={href} forwardClicksToLink={forwardClicksToLink}>
+          <ListCard.Title>Title</ListCard.Title>
+          <ListCard.Info>Info</ListCard.Info>
+          <ListCard.Footer>Footer</ListCard.Footer>
+          <ListCard.Actions>Actions</ListCard.Actions>
+        </ListCard>,
+        { wrapper: ThemeProvider },
+      )
+      // outermost wrapper is not actually clickable
+      const card = document.querySelector(".MitListCard-root > *")
+      invariant(card instanceof HTMLDivElement) // Sanity: Chceck it's not an anchor
+
+      await user.click(card)
+      expect(window.location.hash).toBe(finalHref)
+    },
+  )
+
+  test.each([
+    { forwardClicksToLink: true, finalHref: "#meow" },
+    { forwardClicksToLink: false, finalHref: "" },
+  ])(
+    "The whole card is clickable as a link when using Content, except buttons and links",
+    async ({ forwardClicksToLink, finalHref }) => {
+      const href = "#meow"
+      const onClick = jest.fn()
+      render(
+        <ListCard forwardClicksToLink={forwardClicksToLink} href={href}>
+          <ListCard.Content>
+            <div>Hello!</div>
+            <button onClick={onClick}>Button</button>
+            <a href={href}>Link</a>
+          </ListCard.Content>
+        </ListCard>,
+        { wrapper: ThemeProvider },
+      )
+      const button = screen.getByRole("button", { name: "Button" })
+      await user.click(button)
+      expect(onClick).toHaveBeenCalled()
+      expect(window.location.hash).toBe("")
+
+      // outermost wrapper is not actually clickable
+      const card = document.querySelector(".MitListCard-root > *")
+      invariant(card instanceof HTMLDivElement) // Sanity: Chceck it's not an anchor
+
+      await user.click(card)
+      expect(window.location.hash).toBe(finalHref)
+    },
+  )
+
+  test("Clicks on interactive elements are not forwarded", async () => {
+    const btnOnClick = jest.fn()
+    const divOnClick = jest.fn()
     render(
-      <ListCard href={href}>
+      <ListCard href={"#one"} forwardClicksToLink>
         <ListCard.Title>Title</ListCard.Title>
         <ListCard.Info>Info</ListCard.Info>
-        <ListCard.Footer>Footer</ListCard.Footer>
-        <ListCard.Actions>Actions</ListCard.Actions>
-      </ListCard>,
-      { wrapper: ThemeProvider },
-    )
-    // outermost wrapper is not actually clickable
-    const card = document.querySelector(".MitListCard-root > *")
-    invariant(card instanceof HTMLDivElement) // Sanity: Chceck it's not an anchor
-
-    await user.click(card)
-    expect(window.location.hash).toBe(href)
-  })
-
-  test("The whole card is clickable as a link when using Content, except buttons and links", async () => {
-    const href = `#${faker.lorem.word()}`
-    const onClick = jest.fn()
-    render(
-      <ListCard href={href}>
-        <ListCard.Content>
-          <div>Hello!</div>
-          <button onClick={onClick}>Button</button>
-          <a href={href}>Link</a>
-        </ListCard.Content>
+        <ListCard.Footer>
+          <button onClick={btnOnClick}>Button</button>
+          <a href="#two">Link Two</a>
+          {/*
+          eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+          */}
+          <div data-card-action onClick={divOnClick}>
+            Interactive Div
+          </div>
+        </ListCard.Footer>
       </ListCard>,
       { wrapper: ThemeProvider },
     )
     const button = screen.getByRole("button", { name: "Button" })
+    const link = screen.getByRole("link", { name: "Link Two" })
+    const div = screen.getByText("Interactive Div")
     await user.click(button)
-    expect(onClick).toHaveBeenCalled()
+    expect(btnOnClick).toHaveBeenCalled()
     expect(window.location.hash).toBe("")
-
-    // outermost wrapper is not actually clickable
-    const card = document.querySelector(".MitListCard-root > *")
-    invariant(card instanceof HTMLDivElement) // Sanity: Chceck it's not an anchor
-
-    await user.click(card)
-    expect(window.location.hash).toBe(href)
+    await user.click(link)
+    expect(window.location.hash).toBe("#two")
+    await user.click(div)
+    expect(divOnClick).toHaveBeenCalled()
+    expect(window.location.hash).toBe("#two")
   })
 })

--- a/frontends/ol-components/src/components/Card/ListCard.test.tsx
+++ b/frontends/ol-components/src/components/Card/ListCard.test.tsx
@@ -1,17 +1,67 @@
-import { render } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
+import user from "@testing-library/user-event"
 import { ListCard } from "./ListCard"
 import React from "react"
+import { faker } from "@faker-js/faker/locale/en"
+import invariant from "tiny-invariant"
+import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
 
 describe("ListCard", () => {
-  test("has class MitCard-root on root element", () => {
+  test("has class MitListCard-root on root element", () => {
     const { container } = render(
       <ListCard className="Foo">
         <ListCard.Content>Hello world</ListCard.Content>
       </ListCard>,
+      { wrapper: ThemeProvider },
     )
     const card = container.firstChild
 
     expect(card).toHaveClass("MitListCard-root")
     expect(card).toHaveClass("Foo")
+  })
+
+  test("The whole card is clickable as a link", async () => {
+    const href = `#${faker.lorem.word()}`
+    render(
+      <ListCard href={href}>
+        <ListCard.Title>Title</ListCard.Title>
+        <ListCard.Info>Info</ListCard.Info>
+        <ListCard.Footer>Footer</ListCard.Footer>
+        <ListCard.Actions>Actions</ListCard.Actions>
+      </ListCard>,
+      { wrapper: ThemeProvider },
+    )
+    // outermost wrapper is not actually clickable
+    const card = document.querySelector(".MitListCard-root > *")
+    invariant(card instanceof HTMLDivElement) // Sanity: Chceck it's not an anchor
+
+    await user.click(card)
+    expect(window.location.hash).toBe(href)
+  })
+
+  test("The whole card is clickable as a link when using Content, except buttons and links", async () => {
+    const href = `#${faker.lorem.word()}`
+    const onClick = jest.fn()
+    render(
+      <ListCard href={href}>
+        <ListCard.Content>
+          <div>Hello!</div>
+          <button onClick={onClick}>Button</button>
+          <a href={href}>Link</a>
+        </ListCard.Content>
+      </ListCard>,
+      { wrapper: ThemeProvider },
+    )
+    const button = screen.getByRole("button", { name: "Button" })
+    await user.click(button)
+    expect(onClick).toHaveBeenCalled()
+    expect(window.location.hash).toBe("")
+
+    // outermost wrapper is not actually clickable
+    const card = document.querySelector(".MitListCard-root > *")
+    invariant(card instanceof HTMLDivElement) // Sanity: Chceck it's not an anchor
+
+    await user.click(card)
+    expect(window.location.hash).toBe(href)
   })
 })

--- a/frontends/ol-components/src/components/Card/ListCard.tsx
+++ b/frontends/ol-components/src/components/Card/ListCard.tsx
@@ -8,13 +8,7 @@ import React, {
 import styled from "@emotion/styled"
 import { RiDraggable } from "@remixicon/react"
 import { theme } from "../ThemeProvider/ThemeProvider"
-import {
-  Wrapper,
-  BaseContainer,
-  ImageProps,
-  useClickChildHref,
-  Linkable,
-} from "./Card"
+import { BaseContainer, ImageProps, useClickChildHref, Linkable } from "./Card"
 import { TruncateText } from "../TruncateText/TruncateText"
 import { ActionButton, ActionButtonProps } from "../Button/Button"
 import { default as NextImage } from "next/image"
@@ -123,19 +117,12 @@ export const Bottom = styled.div`
 /**
  * Slot intended to contain ListCardAction buttons.
  */
-export const Actions = styled.div<{ hasImage?: boolean }>`
+export const Actions = styled.div`
   display: flex;
   gap: 8px;
-  position: absolute;
-  bottom: 24px;
-  right: ${({ hasImage }) => (hasImage ? "284px" : "24px")};
   ${theme.breakpoints.down("md")} {
-    bottom: 8px;
     gap: 4px;
-    right: ${({ hasImage }) => (hasImage ? "120px" : "8px")};
   }
-
-  background-color: ${theme.custom.colors.white};
 `
 
 const ListCardActionButton = styled(ActionButton)<{ isMobile?: boolean }>(
@@ -200,32 +187,30 @@ const ListCard: Card = ({ children, className, href, draggable, onClick }) => {
   }
 
   return (
-    <Wrapper className={classNames}>
-      <BaseContainer display="flex" onClick={handleClick}>
-        {draggable && (
-          <DragArea>
-            <RiDraggable />
-          </DragArea>
+    <BaseContainer className={classNames} display="flex" onClick={handleClick}>
+      {draggable && (
+        <DragArea>
+          <RiDraggable />
+        </DragArea>
+      )}
+      <Body>
+        <Info>{info}</Info>
+        {title && (
+          <Title {...title} href={href}>
+            <TruncateText lineClamp={2}>{title.children}</TruncateText>
+          </Title>
         )}
-        <Body>
-          <Info>{info}</Info>
-          {title && (
-            <Title {...title} href={href}>
-              <TruncateText lineClamp={2}>{title.children}</TruncateText>
-            </Title>
-          )}
-          <Bottom>
-            <Footer>{footer}</Footer>
-          </Bottom>
-        </Body>
-        {imageProps && (
-          // alt text will be checked on ListCard.Image
-          // eslint-disable-next-line styled-components-a11y/alt-text
-          <Image {...(imageProps as ImageProps)} />
-        )}
-      </BaseContainer>
-      {actions && <Actions hasImage={!!imageProps}>{actions}</Actions>}
-    </Wrapper>
+        <Bottom>
+          <Footer>{footer}</Footer>
+          {actions && <Actions>{actions}</Actions>}
+        </Bottom>
+      </Body>
+      {imageProps && (
+        // alt text will be checked on ListCard.Image
+        // eslint-disable-next-line styled-components-a11y/alt-text
+        <Image {...(imageProps as ImageProps)} />
+      )}
+    </BaseContainer>
   )
 }
 

--- a/frontends/ol-components/src/components/Card/ListCard.tsx
+++ b/frontends/ol-components/src/components/Card/ListCard.tsx
@@ -23,7 +23,6 @@ const Content = () => <></>
 
 export const Body = styled.div`
   flex-grow: 1;
-  overflow: hidden;
   margin: 24px;
   ${theme.breakpoints.down("md")} {
     margin: 12px;

--- a/frontends/ol-components/src/components/Card/ListCard.tsx
+++ b/frontends/ol-components/src/components/Card/ListCard.tsx
@@ -10,7 +10,7 @@ import { RiDraggable } from "@remixicon/react"
 import { theme } from "../ThemeProvider/ThemeProvider"
 import {
   Wrapper,
-  Container,
+  BaseContainer,
   ImageProps,
   useClickChildHref,
   Linkable,
@@ -193,15 +193,15 @@ const ListCard: Card = ({ children, className, href, draggable, onClick }) => {
   const classNames = ["MitListCard-root", className ?? ""].join(" ")
   if (content) {
     return (
-      <Container onClick={handleClick} className={classNames}>
+      <BaseContainer onClick={handleClick} className={classNames}>
         {content}
-      </Container>
+      </BaseContainer>
     )
   }
 
   return (
     <Wrapper className={classNames}>
-      <Container display="flex" onClick={handleClick}>
+      <BaseContainer display="flex" onClick={handleClick}>
         {draggable && (
           <DragArea>
             <RiDraggable />
@@ -223,7 +223,7 @@ const ListCard: Card = ({ children, className, href, draggable, onClick }) => {
           // eslint-disable-next-line styled-components-a11y/alt-text
           <Image {...(imageProps as ImageProps)} />
         )}
-      </Container>
+      </BaseContainer>
       {actions && <Actions hasImage={!!imageProps}>{actions}</Actions>}
     </Wrapper>
   )

--- a/frontends/ol-components/src/components/Card/ListCard.tsx
+++ b/frontends/ol-components/src/components/Card/ListCard.tsx
@@ -1,4 +1,10 @@
-import React, { FC, ReactNode, Children, isValidElement } from "react"
+import React, {
+  FC,
+  ReactNode,
+  Children,
+  isValidElement,
+  AriaAttributes,
+} from "react"
 import styled from "@emotion/styled"
 import { RiDraggable } from "@remixicon/react"
 import { theme } from "../ThemeProvider/ThemeProvider"
@@ -154,19 +160,23 @@ type CardProps = {
   draggable?: boolean
   onClick?: () => void
 }
+type TitleProps = {
+  children?: ReactNode
+} & Pick<AriaAttributes, "aria-label">
+
 export type Card = FC<CardProps> & {
   Content: FC<{ children: ReactNode }>
   Image: FC<ImageProps>
   Info: FC<{ children: ReactNode }>
-  Title: FC<{ children: ReactNode }>
+  Title: FC<TitleProps>
   Footer: FC<{ children: ReactNode }>
   Actions: FC<{ children: ReactNode }>
   Action: FC<ActionButtonProps>
 }
 
 const ListCard: Card = ({ children, className, href, draggable, onClick }) => {
-  let content, imageProps, info, title, footer, actions
-
+  let content, imageProps, info, footer, actions
+  let title: TitleProps = {}
   const hasHref = typeof href === "string"
   const handleHrefClick = useClickChildHref(href, onClick)
   const handleClick = hasHref ? handleHrefClick : onClick
@@ -176,7 +186,7 @@ const ListCard: Card = ({ children, className, href, draggable, onClick }) => {
     if (child.type === Content) content = child.props.children
     else if (child.type === Image) imageProps = child.props
     else if (child.type === Info) info = child.props.children
-    else if (child.type === Title) title = child.props.children
+    else if (child.type === Title) title = child.props
     else if (child.type === Footer) footer = child.props.children
     else if (child.type === Actions) actions = child.props.children
   })
@@ -200,9 +210,11 @@ const ListCard: Card = ({ children, className, href, draggable, onClick }) => {
         )}
         <Body>
           <Info>{info}</Info>
-          <Title href={href}>
-            <TruncateText lineClamp={2}>{title}</TruncateText>
-          </Title>
+          {title && (
+            <Title {...title} href={href}>
+              <TruncateText lineClamp={2}>{title.children}</TruncateText>
+            </Title>
+          )}
           <Bottom>
             <Footer>{footer}</Footer>
           </Bottom>

--- a/frontends/ol-components/src/components/Card/ListCard.tsx
+++ b/frontends/ol-components/src/components/Card/ListCard.tsx
@@ -1,35 +1,17 @@
 import React, { FC, ReactNode, Children, isValidElement } from "react"
-import Link from "next/link"
 import styled from "@emotion/styled"
 import { RiDraggable } from "@remixicon/react"
 import { theme } from "../ThemeProvider/ThemeProvider"
-import { Wrapper, containerStyles, ImageProps } from "./Card"
+import {
+  Wrapper,
+  Container,
+  ImageProps,
+  useClickChildHref,
+  Linkable,
+} from "./Card"
 import { TruncateText } from "../TruncateText/TruncateText"
 import { ActionButton, ActionButtonProps } from "../Button/Button"
 import { default as NextImage } from "next/image"
-
-export const LinkContainer = styled(Link)`
-  ${containerStyles}
-  display: flex;
-
-  :hover {
-    text-decoration: none;
-    border-color: ${theme.custom.colors.silverGrayLight};
-    box-shadow:
-      0 2px 4px 0 rgb(37 38 43 / 10%),
-      0 2px 4px 0 rgb(37 38 43 / 10%);
-    cursor: pointer;
-  }
-`
-
-export const Container = styled.div`
-  ${containerStyles}
-`
-
-export const DraggableContainer = styled.div`
-  ${containerStyles}
-  display: flex;
-`
 
 const Content = () => <></>
 
@@ -102,7 +84,7 @@ export const Info = styled.div`
   align-items: center;
 `
 
-export const Title = styled.span`
+export const Title = styled(Linkable)`
   flex-grow: 1;
   color: ${theme.custom.colors.darkGray2};
   text-overflow: ellipsis;
@@ -170,6 +152,7 @@ type CardProps = {
   className?: string
   href?: string
   draggable?: boolean
+  onClick?: () => void
 }
 export type Card = FC<CardProps> & {
   Content: FC<{ children: ReactNode }>
@@ -181,14 +164,12 @@ export type Card = FC<CardProps> & {
   Action: FC<ActionButtonProps>
 }
 
-const ListCard: Card = ({ children, className, href, draggable }) => {
-  const _Container = draggable
-    ? DraggableContainer
-    : href
-      ? LinkContainer
-      : Container
-
+const ListCard: Card = ({ children, className, href, draggable, onClick }) => {
   let content, imageProps, info, title, footer, actions
+
+  const hasHref = typeof href === "string"
+  const handleHrefClick = useClickChildHref(href, onClick)
+  const handleClick = hasHref ? handleHrefClick : onClick
 
   Children.forEach(children, (child) => {
     if (!isValidElement(child)) return
@@ -203,15 +184,15 @@ const ListCard: Card = ({ children, className, href, draggable }) => {
   const classNames = ["MitListCard-root", className ?? ""].join(" ")
   if (content) {
     return (
-      <_Container className={classNames} href={href!}>
+      <Container onClick={handleClick} className={classNames}>
         {content}
-      </_Container>
+      </Container>
     )
   }
 
   return (
     <Wrapper className={classNames}>
-      <_Container href={href!} scroll={!href?.startsWith("?")}>
+      <Container display="flex" onClick={handleClick}>
         {draggable && (
           <DragArea>
             <RiDraggable />
@@ -219,7 +200,7 @@ const ListCard: Card = ({ children, className, href, draggable }) => {
         )}
         <Body>
           <Info>{info}</Info>
-          <Title>
+          <Title href={href}>
             <TruncateText lineClamp={2}>{title}</TruncateText>
           </Title>
           <Bottom>
@@ -231,7 +212,7 @@ const ListCard: Card = ({ children, className, href, draggable }) => {
           // eslint-disable-next-line styled-components-a11y/alt-text
           <Image {...(imageProps as ImageProps)} />
         )}
-      </_Container>
+      </Container>
       {actions && <Actions hasImage={!!imageProps}>{actions}</Actions>}
     </Wrapper>
   )

--- a/frontends/ol-components/src/components/Card/ListCardCondensed.tsx
+++ b/frontends/ol-components/src/components/Card/ListCardCondensed.tsx
@@ -1,4 +1,10 @@
-import React, { FC, ReactNode, Children, isValidElement } from "react"
+import React, {
+  FC,
+  ReactNode,
+  Children,
+  isValidElement,
+  AriaAttributes,
+} from "react"
 import styled from "@emotion/styled"
 import { RiDraggable } from "@remixicon/react"
 import { theme } from "../ThemeProvider/ThemeProvider"
@@ -61,10 +67,28 @@ const Content = () => <></>
 type CardProps = {
   children: ReactNode[] | ReactNode
   className?: string
+  /**
+   * If provided, the card will render its title as a link.
+   *
+   * Clicks on the entire card can be forwarded to the link via `forwardClicksToLink`.
+   */
   href?: string
+  /**
+   * Defaults to `false`. If `true`, clicking the whole card will click the
+   * href link as well.
+   *
+   * NOTES:
+   *  - If using Card.Content to customize, you must ensure the content includes
+   *  an anchor with the card's href.
+   *  - Clicks will NOT be forwarded if:
+   *    - The click target is a child of Card.Actions OR an element with
+   *    - The click target is a child of any element with data-card-actions attribute
+   */
+  forwardClicksToLink?: boolean
   draggable?: boolean
   onClick?: () => void
-}
+  as?: React.ElementType
+} & AriaAttributes
 
 type Card = FC<CardProps> & Omit<BaseCard, "Image">
 
@@ -74,12 +98,14 @@ const ListCardCondensed: Card = ({
   href,
   draggable,
   onClick,
+  forwardClicksToLink = false,
+  ...others
 }) => {
   let content, info, title, footer, actions
 
   const hasHref = typeof href === "string"
   const handleHrefClick = useClickChildHref(href, onClick)
-  const handleClick = hasHref ? handleHrefClick : onClick
+  const handleClick = hasHref && forwardClicksToLink ? handleHrefClick : onClick
 
   Children.forEach(children, (child) => {
     if (!isValidElement(child)) return
@@ -92,14 +118,14 @@ const ListCardCondensed: Card = ({
 
   if (content) {
     return (
-      <BaseContainer onClick={handleClick} className={className}>
+      <BaseContainer {...others} onClick={handleClick} className={className}>
         {content}
       </BaseContainer>
     )
   }
 
   return (
-    <BaseContainer className={className} onClick={handleClick}>
+    <BaseContainer {...others} className={className} onClick={handleClick}>
       {draggable && (
         <DragArea>
           <RiDraggable />
@@ -112,7 +138,7 @@ const ListCardCondensed: Card = ({
         </Title>
         <Bottom>
           <Footer>{footer}</Footer>
-          {actions && <Actions>{actions}</Actions>}
+          {actions && <Actions data-card-actions>{actions}</Actions>}
         </Bottom>
       </Body>
     </BaseContainer>

--- a/frontends/ol-components/src/components/Card/ListCardCondensed.tsx
+++ b/frontends/ol-components/src/components/Card/ListCardCondensed.tsx
@@ -2,14 +2,11 @@ import React, { FC, ReactNode, Children, isValidElement } from "react"
 import styled from "@emotion/styled"
 import { RiDraggable } from "@remixicon/react"
 import { theme } from "../ThemeProvider/ThemeProvider"
-import { Wrapper } from "./Card"
+import { Wrapper, Container, useClickChildHref } from "./Card"
 import { TruncateText } from "../TruncateText/TruncateText"
 import {
   ListCard,
   Body as BaseBody,
-  LinkContainer,
-  Container,
-  DraggableContainer,
   DragArea as BaseDragArea,
   Info as BaseInfo,
   Title as BaseTitle,
@@ -73,18 +70,23 @@ type CardProps = {
   className?: string
   href?: string
   draggable?: boolean
+  onClick?: () => void
 }
 
 type Card = FC<CardProps> & Omit<BaseCard, "Image">
 
-const ListCardCondensed: Card = ({ children, className, href, draggable }) => {
-  const _Container = draggable
-    ? DraggableContainer
-    : href
-      ? LinkContainer
-      : Container
-
+const ListCardCondensed: Card = ({
+  children,
+  className,
+  href,
+  draggable,
+  onClick,
+}) => {
   let content, info, title, footer, actions
+
+  const hasHref = typeof href === "string"
+  const handleHrefClick = useClickChildHref(href, onClick)
+  const handleClick = hasHref ? handleHrefClick : onClick
 
   Children.forEach(children, (child) => {
     if (!isValidElement(child)) return
@@ -97,15 +99,15 @@ const ListCardCondensed: Card = ({ children, className, href, draggable }) => {
 
   if (content) {
     return (
-      <_Container className={className} href={href!}>
+      <Container onClick={handleClick} className={className}>
         {content}
-      </_Container>
+      </Container>
     )
   }
 
   return (
     <Wrapper className={className}>
-      <_Container href={href!} scroll={!href?.startsWith("?")}>
+      <Container onClick={handleClick}>
         {draggable && (
           <DragArea>
             <RiDraggable />
@@ -113,14 +115,14 @@ const ListCardCondensed: Card = ({ children, className, href, draggable }) => {
         )}
         <Body>
           <Info>{info}</Info>
-          <Title>
+          <Title href={href}>
             <TruncateText lineClamp={4}>{title}</TruncateText>
           </Title>
           <Bottom>
             <Footer>{footer}</Footer>
           </Bottom>
         </Body>
-      </_Container>
+      </Container>
       {actions && <Actions>{actions}</Actions>}
     </Wrapper>
   )

--- a/frontends/ol-components/src/components/Card/ListCardCondensed.tsx
+++ b/frontends/ol-components/src/components/Card/ListCardCondensed.tsx
@@ -2,7 +2,7 @@ import React, { FC, ReactNode, Children, isValidElement } from "react"
 import styled from "@emotion/styled"
 import { RiDraggable } from "@remixicon/react"
 import { theme } from "../ThemeProvider/ThemeProvider"
-import { Wrapper, BaseContainer, useClickChildHref } from "./Card"
+import { BaseContainer, useClickChildHref } from "./Card"
 import { TruncateText } from "../TruncateText/TruncateText"
 import {
   ListCard,
@@ -11,7 +11,6 @@ import {
   Info as BaseInfo,
   Title as BaseTitle,
   Footer,
-  Actions as BaseActions,
   Bottom as BaseBottom,
 } from "./ListCard"
 import type { Card as BaseCard } from "./ListCard"
@@ -53,15 +52,9 @@ const Bottom = styled(BaseBottom)`
     height: auto;
   }
 `
-const Actions = styled(BaseActions)`
-  bottom: 16px;
-  right: 16px;
+const Actions = styled.div`
+  display: flex;
   gap: 16px;
-  ${theme.breakpoints.down("md")} {
-    bottom: 16px;
-    right: 16px;
-    gap: 16px;
-  }
 `
 const Content = () => <></>
 
@@ -106,25 +99,23 @@ const ListCardCondensed: Card = ({
   }
 
   return (
-    <Wrapper className={className}>
-      <BaseContainer onClick={handleClick}>
-        {draggable && (
-          <DragArea>
-            <RiDraggable />
-          </DragArea>
-        )}
-        <Body>
-          <Info>{info}</Info>
-          <Title href={href}>
-            <TruncateText lineClamp={4}>{title}</TruncateText>
-          </Title>
-          <Bottom>
-            <Footer>{footer}</Footer>
-          </Bottom>
-        </Body>
-      </BaseContainer>
-      {actions && <Actions>{actions}</Actions>}
-    </Wrapper>
+    <BaseContainer className={className} onClick={handleClick}>
+      {draggable && (
+        <DragArea>
+          <RiDraggable />
+        </DragArea>
+      )}
+      <Body>
+        <Info>{info}</Info>
+        <Title href={href}>
+          <TruncateText lineClamp={4}>{title}</TruncateText>
+        </Title>
+        <Bottom>
+          <Footer>{footer}</Footer>
+          {actions && <Actions>{actions}</Actions>}
+        </Bottom>
+      </Body>
+    </BaseContainer>
   )
 }
 

--- a/frontends/ol-components/src/components/Card/ListCardCondensed.tsx
+++ b/frontends/ol-components/src/components/Card/ListCardCondensed.tsx
@@ -2,7 +2,7 @@ import React, { FC, ReactNode, Children, isValidElement } from "react"
 import styled from "@emotion/styled"
 import { RiDraggable } from "@remixicon/react"
 import { theme } from "../ThemeProvider/ThemeProvider"
-import { Wrapper, Container, useClickChildHref } from "./Card"
+import { Wrapper, BaseContainer, useClickChildHref } from "./Card"
 import { TruncateText } from "../TruncateText/TruncateText"
 import {
   ListCard,
@@ -99,15 +99,15 @@ const ListCardCondensed: Card = ({
 
   if (content) {
     return (
-      <Container onClick={handleClick} className={className}>
+      <BaseContainer onClick={handleClick} className={className}>
         {content}
-      </Container>
+      </BaseContainer>
     )
   }
 
   return (
     <Wrapper className={className}>
-      <Container onClick={handleClick}>
+      <BaseContainer onClick={handleClick}>
         {draggable && (
           <DragArea>
             <RiDraggable />
@@ -122,7 +122,7 @@ const ListCardCondensed: Card = ({
             <Footer>{footer}</Footer>
           </Bottom>
         </Body>
-      </Container>
+      </BaseContainer>
       {actions && <Actions>{actions}</Actions>}
     </Wrapper>
   )

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { screen, render } from "@testing-library/react"
+import { screen, render, within } from "@testing-library/react"
 import { LearningResourceCard } from "./LearningResourceCard"
 import type { LearningResourceCardProps } from "./LearningResourceCard"
 import { DEFAULT_RESOURCE_IMG, getReadableResourceType } from "ol-utilities"
@@ -14,19 +14,29 @@ const setup = (props: LearningResourceCardProps) => {
 }
 
 describe("Learning Resource Card", () => {
-  test("Renders resource type, title and start date", () => {
-    const resource = factories.learningResources.resource({
-      resource_type: ResourceTypeEnum.Course,
-      next_start_date: "2026-01-01",
-    })
+  test.each([
+    { resourceType: ResourceTypeEnum.Course, expectedLabel: "Course" },
+    { resourceType: ResourceTypeEnum.Program, expectedLabel: "Program" },
+  ])(
+    "Renders resource type, title and start date as a labeled article",
+    ({ resourceType, expectedLabel }) => {
+      const resource = factories.learningResources.resource({
+        resource_type: resourceType,
+        next_start_date: "2026-01-01",
+      })
 
-    setup({ resource })
+      setup({ resource })
 
-    screen.getByText("Course")
-    screen.getByText(resource.title)
-    screen.getByText("Starts:")
-    screen.getByText("January 01, 2026")
-  })
+      const card = screen.getByRole("article", {
+        name: `${expectedLabel}: ${resource.title}`,
+      })
+
+      within(card).getByText(expectedLabel)
+      within(card).getByText(resource.title)
+      within(card).getByText("Starts:")
+      within(card).getByText("January 01, 2026")
+    },
+  )
 
   test("Displays run start date", () => {
     const resource = factories.learningResources.resource({
@@ -96,11 +106,8 @@ describe("Learning Resource Card", () => {
     setup({ resource, href: "/path/to/thing" })
 
     const link = screen.getByRole<HTMLAnchorElement>("link", {
-      // Accessible name has resource type prepended
-      name: `Course: ${resource.title}`,
+      name: resource.title,
     })
-    // Visual title does not have resource name prepended
-    expect(link.textContent).toBe(resource.title)
     expect(new URL(link.href).pathname).toBe("/path/to/thing")
   })
 

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.test.tsx
@@ -96,8 +96,11 @@ describe("Learning Resource Card", () => {
     setup({ resource, href: "/path/to/thing" })
 
     const link = screen.getByRole<HTMLAnchorElement>("link", {
-      name: new RegExp(resource.title),
+      // Accessible name has resource type prepended
+      name: `Course: ${resource.title}`,
     })
+    // Visual title does not have resource name prepended
+    expect(link.textContent).toBe(resource.title)
     expect(new URL(link.href).pathname).toBe("/path/to/thing")
   })
 

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -231,7 +231,14 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
 
   const readableType = getReadableResourceType(resource.resource_type)
   return (
-    <StyledCard href={href} className={className} size={size}>
+    <StyledCard
+      as="article"
+      aria-label={`${readableType}: ${resource.title}`}
+      href={href}
+      forwardClicksToLink
+      className={className}
+      size={size}
+    >
       <Card.Image
         src={resource.image?.url ? resource.image?.url : DEFAULT_RESOURCE_IMG}
         alt={resource.image?.alt ?? ""}
@@ -240,7 +247,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
       <Card.Info>
         <Info resource={resource} size={size} />
       </Card.Info>
-      <Card.Title aria-label={`${readableType}: ${resource.title}`}>
+      <Card.Title>
         <EllipsisTitle lineClamp={size === "small" ? 2 : 3}>
           {resource.title}
         </EllipsisTitle>

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -229,6 +229,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
     return null
   }
 
+  const readableType = getReadableResourceType(resource.resource_type)
   return (
     <StyledCard href={href} className={className} size={size}>
       <Card.Image
@@ -239,7 +240,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
       <Card.Info>
         <Info resource={resource} size={size} />
       </Card.Info>
-      <Card.Title>
+      <Card.Title aria-label={`${readableType}: ${resource.title}`}>
         <EllipsisTitle lineClamp={size === "small" ? 2 : 3}>
           {resource.title}
         </EllipsisTitle>
@@ -257,7 +258,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
         {onAddToUserListClick && (
           <CardActionButton
             filled={inUserList}
-            aria-label={`Bookmark ${getReadableResourceType(resource.resource_type)}`}
+            aria-label={`Bookmark ${readableType}`}
             onClick={(event) => onAddToUserListClick(event, resource.id)}
           >
             {inUserList ? (

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { BrowserRouter } from "react-router-dom"
-import { screen, render } from "@testing-library/react"
+import { screen, render, within } from "@testing-library/react"
 import { LearningResourceListCard } from "./LearningResourceListCard"
 import type { LearningResourceListCardProps } from "./LearningResourceListCard"
 import { DEFAULT_RESOURCE_IMG, getReadableResourceType } from "ol-utilities"
@@ -19,19 +19,29 @@ const setup = (props: LearningResourceListCardProps) => {
 }
 
 describe("Learning Resource List Card", () => {
-  test("Renders resource type, title and start date", () => {
-    const resource = factories.learningResources.resource({
-      resource_type: ResourceTypeEnum.Course,
-      next_start_date: "2026-01-01",
-    })
+  test.each([
+    { resourceType: ResourceTypeEnum.Course, expectedLabel: "Course" },
+    { resourceType: ResourceTypeEnum.Program, expectedLabel: "Program" },
+  ])(
+    "Renders resource type, title and start date as a labeled article",
+    ({ resourceType, expectedLabel }) => {
+      const resource = factories.learningResources.resource({
+        resource_type: resourceType,
+        next_start_date: "2026-01-01",
+      })
 
-    setup({ resource })
+      setup({ resource })
 
-    screen.getByText("Course")
-    screen.getByText(resource.title)
-    screen.getByText("Starts:")
-    screen.getByText("January 01, 2026")
-  })
+      const card = screen.getByRole("article", {
+        name: `${expectedLabel}: ${resource.title}`,
+      })
+
+      within(card).getByText(expectedLabel)
+      within(card).getByText(resource.title)
+      within(card).getByText("Starts:")
+      within(card).getByText("January 01, 2026")
+    },
+  )
 
   test("Displays run start date", () => {
     const resource = factories.learningResources.resource({
@@ -93,11 +103,8 @@ describe("Learning Resource List Card", () => {
     setup({ resource, href: "/path/to/thing" })
 
     const link = screen.getByRole<HTMLAnchorElement>("link", {
-      // Accessible name has resource type prepended
-      name: `Course: ${resource.title}`,
+      name: resource.title,
     })
-    // Visual title does not have resource name prepended
-    expect(link.textContent).toBe(resource.title)
 
     expect(link).toHaveAttribute("href", "/path/to/thing")
   })

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
@@ -92,11 +92,14 @@ describe("Learning Resource List Card", () => {
 
     setup({ resource, href: "/path/to/thing" })
 
-    const card = screen.getByRole("link", {
-      name: new RegExp(resource.title),
+    const link = screen.getByRole<HTMLAnchorElement>("link", {
+      // Accessible name has resource type prepended
+      name: `Course: ${resource.title}`,
     })
+    // Visual title does not have resource name prepended
+    expect(link.textContent).toBe(resource.title)
 
-    expect(card).toHaveAttribute("href", "/path/to/thing")
+    expect(link).toHaveAttribute("href", "/path/to/thing")
   })
 
   test("Click action buttons", async () => {

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -309,7 +309,14 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
   }
   const readableType = getReadableResourceType(resource.resource_type)
   return (
-    <ListCard href={href} className={className} draggable={draggable}>
+    <ListCard
+      as="article"
+      aria-label={`${readableType}: ${resource.title}`}
+      href={href}
+      forwardClicksToLink
+      className={className}
+      draggable={draggable}
+    >
       <ListCard.Image
         src={resource.image?.url || DEFAULT_RESOURCE_IMG}
         alt={resource.image?.alt ?? ""}
@@ -318,9 +325,7 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
       <ListCard.Info>
         <Info resource={resource} />
       </ListCard.Info>
-      <ListCard.Title aria-label={`${readableType}: ${resource.title}`}>
-        {resource.title}
-      </ListCard.Title>
+      <ListCard.Title>{resource.title}</ListCard.Title>
       <ListCard.Actions>
         {onAddToLearningPathClick && (
           <CardActionButton

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -307,6 +307,7 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
   if (!resource) {
     return null
   }
+  const readableType = getReadableResourceType(resource.resource_type)
   return (
     <ListCard href={href} className={className} draggable={draggable}>
       <ListCard.Image
@@ -317,7 +318,9 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
       <ListCard.Info>
         <Info resource={resource} />
       </ListCard.Info>
-      <ListCard.Title>{resource.title}</ListCard.Title>
+      <ListCard.Title aria-label={`${readableType}: ${resource.title}`}>
+        {resource.title}
+      </ListCard.Title>
       <ListCard.Actions>
         {onAddToLearningPathClick && (
           <CardActionButton
@@ -331,7 +334,7 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
         {onAddToUserListClick && (
           <CardActionButton
             filled={inUserList}
-            aria-label={`Bookmark ${getReadableResourceType(resource.resource_type)}`}
+            aria-label={`Bookmark ${readableType}`}
             onClick={(event) => onAddToUserListClick(event, resource.id)}
           >
             {inUserList ? (

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.tsx
@@ -115,8 +115,16 @@ const LearningResourceListCardCondensed: React.FC<
   if (!resource) {
     return null
   }
+  const readableType = getReadableResourceType(resource.resource_type)
   return (
-    <ListCardCondensed href={href} className={className} draggable={draggable}>
+    <ListCardCondensed
+      as="article"
+      aria-label={`${readableType}: ${resource.title}`}
+      href={href}
+      forwardClicksToLink
+      className={className}
+      draggable={draggable}
+    >
       <ListCardCondensed.Info>
         <Info resource={resource} />
       </ListCardCondensed.Info>
@@ -134,7 +142,7 @@ const LearningResourceListCardCondensed: React.FC<
         {onAddToUserListClick && (
           <CardActionButton
             filled={inUserList}
-            aria-label={`Bookmark ${getReadableResourceType(resource.resource_type)}`}
+            aria-label={`Bookmark ${readableType}`}
             onClick={(event) => onAddToUserListClick(event, resource.id)}
           >
             {inUserList ? (


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5538

### Description  (What does it do?)
This PR makes some accessibility enhancements to cards and learning resource cards in particular. 

**Card Title is Link:** Previously the entire card was a link. Now just the title is a link, leading to much better link names. *The whole card remains clickable.*

**LearningResourceCards are `article`s**: Learning resource cards now use `article` as a root element with `[resource.type]: [resource.title]` as the article name. Consequently, cards are landmarks that appear in landmark navigation

**Simplified Positioning**: Cards no longer use absolute positioning for buttons. 

### Screenshots

![landmarks_rotor](https://github.com/user-attachments/assets/22a6a3de-be46-4023-8f89-e58a3c583798)
![links_rotor](https://github.com/user-attachments/assets/9fc9ae27-e56f-4e0b-b601-0791eecd1c80)

Card aesthetics should be unchanged:


<img width="1336" alt="Screenshot 2024-10-30 at 7 57 45 AM" src="https://github.com/user-attachments/assets/602c5491-f81d-46f0-a21c-5ba080abe588">
<img width="1403" alt="Screenshot 2024-10-30 at 7 57 55 AM" src="https://github.com/user-attachments/assets/ad242370-4d87-4d9e-a2d5-7dadde20f197">
<img width="1119" alt="Screenshot 2024-10-30 at 7 58 04 AM" src="https://github.com/user-attachments/assets/2b942839-3424-4ec0-a994-9abb750dc02c">
<img width="1095" alt="Screenshot 2024-10-30 at 7 58 12 AM" src="https://github.com/user-attachments/assets/efbd183b-9dad-4164-a4f1-e5f6c976ee9f">

### How can this be tested?
1. Inspect cards and check that their aesthetic is unchanged. Cards include:
    - Carousel resource cards (LearningResourceCard)
    - Search result cards (LearningResourceListCard)
    - Userlist cards at `/dashboard/my-lists/` 
    - Draggable resource cards at `/dashboard/my-lists/{list_id}` when "Reordering"
    - News & Events cards on the homepage 
2.Where cards were clickable as links before, they should be now.
    - You should still be able to ctrl+click to open in a new tab
3. Interactive children in cards should still work, and should NOT navigate the whole link.  Examples are
   - "AddToListDialog" (learning path and userlist versions) 
   - The "..." menu on learning path cards.
