### PR TITLE
Clear resource_type filter when leaving Learning Materials search tab

### DIFF
--- a/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
@@ -491,6 +491,32 @@ describe("Search Page Tabs", () => {
     expect(params2.get("department")).toBe("8") // should preserve other params
   })
 
+  test("Switching from learning materials tab clears resource type only", async () => {
+    setMockApiResponses({
+      search: {
+        count: 1000,
+        metadata: {
+          aggregations: {
+            resource_type: [{ key: "video", doc_count: 100 }],
+          },
+          suggestions: [],
+        },
+      },
+    })
+    const { location } = renderWithProviders(<SearchPage />, {
+      url: "?resource_category=learning_material&resource_type=video&topic=Biology",
+    })
+    const tabLM = screen.getByRole("tab", { name: /Learning Materials/ })
+    const tabCourses = screen.getByRole("tab", { name: /Courses/ })
+    expect(tabLM).toHaveAttribute("aria-selected")
+
+    // Click "Courses"
+    await user.click(tabCourses)
+    expect(location.current.search).toBe(
+      "?resource_category=course&topic=Biology",
+    )
+  })
+
   test("Tab titles show corret result counts", async () => {
     setMockApiResponses({
       search: {

--- a/frontends/main/src/page-components/SearchDisplay/ResourceCategoryTabs.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/ResourceCategoryTabs.tsx
@@ -94,6 +94,9 @@ const ResourceCategoryTabList: React.FC<ResourceCategoryTabsProps> = ({
         const tab = tabs.find((t) => t.name === value)
         setSearchParams((prev) => {
           const next = new URLSearchParams(prev)
+          if (prev.get("resource_category") === "learning_material") {
+            next.delete("resource_type")
+          }
           if (tab?.resource_category) {
             next.set("resource_category", tab.resource_category)
           } else {


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5333

### Description (What does it do?)
If you are on the "Learning Materials" tab of the search page with resource_type filters selected ("Video" for example), then switch to another tab, the `resource_type` filter should be cleared,  but not other filters like topic.



### How can this be tested?
- Go to http://open.odl.local:8062/search?resource_category=learning_material&resource_type=video&topic=Biology, the "Video" option should be checked for "Resource Type" facet and "Biology" for the Topic facet.  Course and Program tab headers should show counts of 0.  The "All" tab header should show the same count as the current tab.
- Switch to the "Courses" tab.  You should get results back with a count > 0, the biology topic should still be selected, and there should be no `resource_type` parameter in the url : http://open.odl.local:8062/search?topic=Biology&resource_category=course
- Repeat the previous 2 steps, but this time switch to the "All" tab instead of the "Course" tab.  The behavior should be the same, with a url of http://open.odl.local:8062/search?topic=Biology 

