### PR TITLE
learning resource drawer v2 run comparison table

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
@@ -204,6 +204,7 @@ const courses = {
             },
           ],
           prices: ["150"],
+          location: "Earth",
         }),
         factories.learningResources.run({
           delivery: [
@@ -213,6 +214,7 @@ const courses = {
             },
           ],
           prices: ["150"],
+          location: "Earth",
         }),
       ],
     }),

--- a/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
@@ -1,4 +1,4 @@
-import { ResourceTypeEnum } from "api"
+import { DeliveryEnum, DeliveryEnumDescriptions, ResourceTypeEnum } from "api"
 import { factories } from "api/test-utils"
 
 const _makeResource = factories.learningResources.resource
@@ -41,6 +41,7 @@ const resources = {
   }),
 }
 
+const sameDataRun = factories.learningResources.run()
 const courses = {
   free: {
     noCertificate: makeResource({
@@ -150,6 +151,70 @@ const courses = {
     dated: makeResource({
       resource_type: ResourceTypeEnum.Course,
       availability: "dated",
+    }),
+  },
+  multipleRuns: {
+    sameData: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [
+        factories.learningResources.run({
+          delivery: sameDataRun.delivery,
+          prices: sameDataRun.prices,
+        }),
+        factories.learningResources.run({
+          delivery: sameDataRun.delivery,
+          prices: sameDataRun.prices,
+        }),
+        factories.learningResources.run({
+          delivery: sameDataRun.delivery,
+          prices: sameDataRun.prices,
+        }),
+        factories.learningResources.run({
+          delivery: sameDataRun.delivery,
+          prices: sameDataRun.prices,
+        }),
+      ],
+    }),
+    differentData: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [
+        factories.learningResources.run({
+          delivery: [
+            {
+              code: DeliveryEnum.Online,
+              name: DeliveryEnumDescriptions.online,
+            },
+          ],
+          prices: ["0", "100"],
+        }),
+        factories.learningResources.run({
+          delivery: [
+            {
+              code: DeliveryEnum.Online,
+              name: DeliveryEnumDescriptions.online,
+            },
+          ],
+          prices: ["0", "100"],
+        }),
+        factories.learningResources.run({
+          delivery: [
+            {
+              code: DeliveryEnum.InPerson,
+              name: DeliveryEnumDescriptions.in_person,
+            },
+          ],
+          prices: ["150"],
+        }),
+        factories.learningResources.run({
+          delivery: [
+            {
+              code: DeliveryEnum.InPerson,
+              name: DeliveryEnumDescriptions.in_person,
+            },
+          ],
+          prices: ["150"],
+        }),
+      ],
     }),
   },
 }

--- a/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
@@ -41,7 +41,12 @@ const resources = {
   }),
 }
 
-const sameDataRun = factories.learningResources.run()
+const sameDataRun = factories.learningResources.run({
+  resource_prices: [
+    { amount: "0", currency: "USD" },
+    { amount: "100", currency: "USD" },
+  ],
+})
 const courses = {
   free: {
     noCertificate: makeResource({
@@ -159,19 +164,23 @@ const courses = {
       runs: [
         factories.learningResources.run({
           delivery: sameDataRun.delivery,
-          prices: sameDataRun.prices,
+          resource_prices: sameDataRun.resource_prices,
+          location: sameDataRun.location,
         }),
         factories.learningResources.run({
           delivery: sameDataRun.delivery,
-          prices: sameDataRun.prices,
+          resource_prices: sameDataRun.resource_prices,
+          location: sameDataRun.location,
         }),
         factories.learningResources.run({
           delivery: sameDataRun.delivery,
-          prices: sameDataRun.prices,
+          resource_prices: sameDataRun.resource_prices,
+          location: sameDataRun.location,
         }),
         factories.learningResources.run({
           delivery: sameDataRun.delivery,
-          prices: sameDataRun.prices,
+          resource_prices: sameDataRun.resource_prices,
+          location: sameDataRun.location,
         }),
       ],
     }),
@@ -185,7 +194,10 @@ const courses = {
               name: DeliveryEnumDescriptions.online,
             },
           ],
-          prices: ["0", "100"],
+          resource_prices: [
+            { amount: "0", currency: "USD" },
+            { amount: "100", currency: "USD" },
+          ],
         }),
         factories.learningResources.run({
           delivery: [
@@ -194,7 +206,10 @@ const courses = {
               name: DeliveryEnumDescriptions.online,
             },
           ],
-          prices: ["0", "100"],
+          resource_prices: [
+            { amount: "0", currency: "USD" },
+            { amount: "100", currency: "USD" },
+          ],
         }),
         factories.learningResources.run({
           delivery: [
@@ -203,7 +218,7 @@ const courses = {
               name: DeliveryEnumDescriptions.in_person,
             },
           ],
-          prices: ["150"],
+          resource_prices: [{ amount: "150", currency: "USD" }],
           location: "Earth",
         }),
         factories.learningResources.run({
@@ -213,7 +228,7 @@ const courses = {
               name: DeliveryEnumDescriptions.in_person,
             },
           ],
-          prices: ["150"],
+          resource_prices: [{ amount: "150", currency: "USD" }],
           location: "Earth",
         }),
       ],

--- a/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.test.tsx
@@ -1,0 +1,40 @@
+import React from "react"
+import { render, screen, within } from "@testing-library/react"
+import { courses } from "../LearningResourceCard/testUtils"
+import InfoSectionV2 from "./InfoSectionV2"
+import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
+import { DeliveryEnumDescriptions } from "api"
+
+describe("Differing runs comparison table", () => {
+  test("Does not appear if data is the same", () => {
+    const course = courses.multipleRuns.sameData
+    render(<InfoSectionV2 resource={course} />, {
+      wrapper: ThemeProvider,
+    })
+    expect(screen.queryByTestId("differing-runs-table")).toBeNull()
+  })
+
+  test("Appears if data is different", () => {
+    const course = courses.multipleRuns.differentData
+    render(<InfoSectionV2 resource={course} />, {
+      wrapper: ThemeProvider,
+    })
+    const differingRunsTable = screen.getByTestId("differing-runs-table")
+    expect(differingRunsTable).toBeInTheDocument()
+    const onlineLabels = within(differingRunsTable).getAllByText(
+      DeliveryEnumDescriptions.online,
+    )
+    const inPersonLabels = within(differingRunsTable).getAllByText(
+      DeliveryEnumDescriptions.in_person,
+    )
+    const onlinePriceLabels =
+      within(differingRunsTable).getAllByText("$0, $100")
+    const inPersonPriceLabels = within(differingRunsTable).getAllByText("$150")
+    const earthLocationLabels = within(differingRunsTable).getAllByText("Earth")
+    expect(onlineLabels).toHaveLength(2)
+    expect(inPersonLabels).toHaveLength(2)
+    expect(onlinePriceLabels).toHaveLength(2)
+    expect(inPersonPriceLabels).toHaveLength(2)
+    expect(earthLocationLabels).toHaveLength(2)
+  })
+})

--- a/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.test.tsx
@@ -27,8 +27,7 @@ describe("Differing runs comparison table", () => {
     const inPersonLabels = within(differingRunsTable).getAllByText(
       DeliveryEnumDescriptions.in_person,
     )
-    const onlinePriceLabels =
-      within(differingRunsTable).getAllByText("$0, $100")
+    const onlinePriceLabels = within(differingRunsTable).getAllByText("$100")
     const inPersonPriceLabels = within(differingRunsTable).getAllByText("$150")
     const earthLocationLabels = within(differingRunsTable).getAllByText("Earth")
     expect(onlineLabels).toHaveLength(2)

--- a/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
@@ -1,8 +1,13 @@
 import React from "react"
 import styled from "@emotion/styled"
 import { theme } from "../ThemeProvider/ThemeProvider"
-import { LearningResource } from "api"
-import { formatRunDate, showStartAnytime } from "ol-utilities"
+import { LearningResource, LearningResourcePrice } from "api"
+import {
+  formatRunDate,
+  getDisplayPrice,
+  getRunPrices,
+  showStartAnytime,
+} from "ol-utilities"
 
 const DifferingRuns = styled.div({
   display: "flex",
@@ -64,12 +69,16 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
     return null
   }
   const asTaughtIn = resource ? showStartAnytime(resource) : false
-  const prices = []
+  const prices: LearningResourcePrice[] = []
   const deliveryMethods = []
   const locations = []
   for (const run of resource.runs) {
-    if (run.prices) {
-      prices.push(run.prices)
+    if (run.resource_prices) {
+      run.resource_prices.forEach((price) => {
+        if (price.amount !== "0") {
+          prices.push(price)
+        }
+      })
     }
     if (run.delivery) {
       deliveryMethods.push(run.delivery)
@@ -78,7 +87,8 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
       locations.push(run.location)
     }
   }
-  const distinctPrices = [...new Set(prices.flat())]
+  const distinctPrices = [...new Set(prices.map((p) => p.amount).flat())]
+  console.log(distinctPrices)
   const distinctDeliveryMethods = [
     ...new Set(deliveryMethods.flat().map((dm) => dm?.code)),
   ]
@@ -100,9 +110,9 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
             <DifferingRunData>
               {formatRunDate(run, asTaughtIn)}
             </DifferingRunData>
-            {run.prices && (
+            {run.resource_prices && (
               <DifferingRunData>
-                <span>{run.prices.map((p) => `$${p}`).join(", ")}</span>
+                <span>{getDisplayPrice(getRunPrices(run)["course"])}</span>
               </DifferingRunData>
             )}
             {run.delivery && (

--- a/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
@@ -1,0 +1,128 @@
+import React from "react"
+import styled from "@emotion/styled"
+import { theme } from "../ThemeProvider/ThemeProvider"
+import { LearningResource } from "api"
+import { formatRunDate, showStartAnytime } from "ol-utilities"
+
+const DifferingRuns = styled.div({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  borderRadius: "4px",
+  border: `1px solid ${theme.custom.colors.lightGray2}`,
+  borderBottom: "none",
+})
+
+const DifferingRun = styled.div({
+  display: "flex",
+  flexWrap: "wrap",
+  alignItems: "center",
+  gap: "16px",
+  padding: "12px",
+  alignSelf: "stretch",
+  borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
+})
+
+const DifferingRunHeader = styled.div({
+  display: "flex",
+  alignSelf: "stretch",
+  alignItems: "center",
+  flex: "1 0 0",
+  gap: "16px",
+  padding: "12px",
+  color: theme.custom.colors.darkGray2,
+  backgroundColor: theme.custom.colors.lightGray1,
+  ...theme.typography.subtitle3,
+})
+
+const DifferingRunData = styled.div({
+  display: "flex",
+  flexShrink: 0,
+  flex: "1 0 0",
+  color: theme.custom.colors.darkGray2,
+  ...theme.typography.body3,
+})
+
+const DifferingRunLabel = styled.strong({
+  display: "flex",
+  flex: "1 0 0",
+})
+
+const DifferingRunLocation = styled(DifferingRunData)({
+  flex: "1 0 100%",
+  alignSelf: "stretch",
+})
+
+const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
+  resource,
+}) => {
+  if (!resource.runs) {
+    return null
+  }
+  if (resource.runs.length === 1) {
+    return null
+  }
+  const asTaughtIn = resource ? showStartAnytime(resource) : false
+  const prices = []
+  const deliveryMethods = []
+  const locations = []
+  for (const run of resource.runs) {
+    if (run.prices) {
+      prices.push(run.prices)
+    }
+    if (run.delivery) {
+      deliveryMethods.push(run.delivery)
+    }
+    if (run.location) {
+      locations.push(run.location)
+    }
+  }
+  const distinctPrices = [...new Set(prices.flat())]
+  const distinctDeliveryMethods = [
+    ...new Set(deliveryMethods.flat().map((dm) => dm?.code)),
+  ]
+  const distinctLocations = [...new Set(locations.flat().map((l) => l))]
+  if (
+    distinctPrices.length > 1 ||
+    distinctDeliveryMethods.length > 1 ||
+    distinctLocations.length > 1
+  ) {
+    return (
+      <DifferingRuns data-testid="differing-runs-table">
+        <DifferingRunHeader>
+          <DifferingRunLabel>Date</DifferingRunLabel>
+          <DifferingRunLabel>Price</DifferingRunLabel>
+          <DifferingRunLabel>Format</DifferingRunLabel>
+        </DifferingRunHeader>
+        {resource.runs.map((run, index) => (
+          <DifferingRun key={index}>
+            <DifferingRunData>
+              {formatRunDate(run, asTaughtIn)}
+            </DifferingRunData>
+            {run.prices && (
+              <DifferingRunData>
+                <span>{run.prices.map((p) => `$${p}`).join(", ")}</span>
+              </DifferingRunData>
+            )}
+            {run.delivery && (
+              <DifferingRunData>
+                <span>{run.delivery?.map((dm) => dm?.name).join(", ")}</span>
+              </DifferingRunData>
+            )}
+            {run.delivery.filter((d) => d.code === "in_person").length > 0 &&
+              run.location && (
+                <DifferingRunLocation>
+                  <strong>Location:&nbsp;</strong>
+                  <span>{run.location}</span>
+                </DifferingRunLocation>
+              )}
+          </DifferingRun>
+        ))}
+      </DifferingRuns>
+    )
+  }
+  return null
+}
+
+export default DifferingRunsTable

--- a/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
@@ -88,7 +88,6 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
     }
   }
   const distinctPrices = [...new Set(prices.map((p) => p.amount).flat())]
-  console.log(distinctPrices)
   const distinctDeliveryMethods = [
     ...new Set(deliveryMethods.flat().map((dm) => dm?.code)),
   ]

--- a/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
@@ -56,6 +56,7 @@ const DifferingRunLabel = styled.strong({
 
 const DifferingRunLocation = styled(DifferingRunData)({
   flex: "1 0 100%",
+  flexDirection: "column",
   alignSelf: "stretch",
 })
 
@@ -122,7 +123,7 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
             {run.delivery.filter((d) => d.code === "in_person").length > 0 &&
               run.location && (
                 <DifferingRunLocation>
-                  <strong>Location:&nbsp;</strong>
+                  <strong>Location</strong>
                   <span>{run.location}</span>
                 </DifferingRunLocation>
               )}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.test.tsx
@@ -5,7 +5,6 @@ import InfoSectionV2 from "./InfoSectionV2"
 import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
 import { formatRunDate } from "ol-utilities"
 import invariant from "tiny-invariant"
-import { DeliveryEnumDescriptions } from "api"
 
 // This is a pipe followed by a zero-width space
 const SEPARATOR = "|​"
@@ -155,38 +154,5 @@ describe("Learning resource info section start date", () => {
     within(section).getByText((_content, node) => {
       return node?.textContent === expectedDateText || false
     })
-  })
-})
-describe("Differing runs comparison table", () => {
-  test("Does not appear if data is the same", () => {
-    const course = courses.multipleRuns.sameData
-    render(<InfoSectionV2 resource={course} />, {
-      wrapper: ThemeProvider,
-    })
-    expect(screen.queryByTestId("differing-runs-table")).toBeNull()
-  })
-
-  test("Appears if data is different", () => {
-    const course = courses.multipleRuns.differentData
-    render(<InfoSectionV2 resource={course} />, {
-      wrapper: ThemeProvider,
-    })
-    const differingRunsTable = screen.getByTestId("differing-runs-table")
-    expect(differingRunsTable).toBeInTheDocument()
-    const onlineLabels = within(differingRunsTable).getAllByText(
-      DeliveryEnumDescriptions.online,
-    )
-    const inPersonLabels = within(differingRunsTable).getAllByText(
-      DeliveryEnumDescriptions.in_person,
-    )
-    const onlinePriceLabels =
-      within(differingRunsTable).getAllByText("$0, $100")
-    const inPersonPriceLabels = within(differingRunsTable).getAllByText("$150")
-    const earthLocationLabels = within(differingRunsTable).getAllByText("Earth")
-    expect(onlineLabels).toHaveLength(2)
-    expect(inPersonLabels).toHaveLength(2)
-    expect(onlinePriceLabels).toHaveLength(2)
-    expect(inPersonPriceLabels).toHaveLength(2)
-    expect(earthLocationLabels).toHaveLength(2)
   })
 })

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.test.tsx
@@ -5,6 +5,7 @@ import InfoSectionV2 from "./InfoSectionV2"
 import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
 import { formatRunDate } from "ol-utilities"
 import invariant from "tiny-invariant"
+import { DeliveryEnumDescriptions } from "api"
 
 // This is a pipe followed by a zero-width space
 const SEPARATOR = "|​"
@@ -154,5 +155,36 @@ describe("Learning resource info section start date", () => {
     within(section).getByText((_content, node) => {
       return node?.textContent === expectedDateText || false
     })
+  })
+})
+describe("Differing runs comparison table", () => {
+  test("Does not appear if data is the same", () => {
+    const course = courses.multipleRuns.sameData
+    render(<InfoSectionV2 resource={course} />, {
+      wrapper: ThemeProvider,
+    })
+    expect(screen.queryByTestId("differing-runs-table")).toBeNull()
+  })
+
+  test("Appears if data is different", () => {
+    const course = courses.multipleRuns.differentData
+    render(<InfoSectionV2 resource={course} />, {
+      wrapper: ThemeProvider,
+    })
+    const differingRunsTable = screen.getByTestId("differing-runs-table")
+    expect(differingRunsTable).toBeInTheDocument()
+    const onlineLabels = within(differingRunsTable).getAllByText(
+      DeliveryEnumDescriptions.online,
+    )
+    const inPersonLabels = within(differingRunsTable).getAllByText(
+      DeliveryEnumDescriptions.in_person,
+    )
+    const onlinePriceLabels =
+      within(differingRunsTable).getAllByText("$0, $100")
+    const inPersonPriceLabels = within(differingRunsTable).getAllByText("$150")
+    expect(onlineLabels).toHaveLength(2)
+    expect(inPersonLabels).toHaveLength(2)
+    expect(onlinePriceLabels).toHaveLength(2)
+    expect(inPersonPriceLabels).toHaveLength(2)
   })
 })

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.test.tsx
@@ -182,9 +182,11 @@ describe("Differing runs comparison table", () => {
     const onlinePriceLabels =
       within(differingRunsTable).getAllByText("$0, $100")
     const inPersonPriceLabels = within(differingRunsTable).getAllByText("$150")
+    const earthLocationLabels = within(differingRunsTable).getAllByText("Earth")
     expect(onlineLabels).toHaveLength(2)
     expect(inPersonLabels).toHaveLength(2)
     expect(onlinePriceLabels).toHaveLength(2)
     expect(inPersonPriceLabels).toHaveLength(2)
+    expect(earthLocationLabels).toHaveLength(2)
   })
 })

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -45,7 +45,7 @@ const DifferingRuns = styled.div({
   alignItems: "flex-start",
   alignSelf: "stretch",
   borderRadius: "4px",
-  border: `1px solid ${theme.custom.colors.silverGrayLight}`,
+  border: `1px solid ${theme.custom.colors.lightGray2}`,
   borderBottom: "none",
 })
 
@@ -56,7 +56,19 @@ const DifferingRun = styled.div({
   gap: "16px",
   padding: "12px",
   alignSelf: "stretch",
-  borderBottom: `1px solid ${theme.custom.colors.silverGrayLight}`,
+  borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
+})
+
+const DifferingRunHeader = styled.div({
+  display: "flex",
+  alignSelf: "stretch",
+  alignItems: "center",
+  flex: "1 0 0",
+  gap: "16px",
+  padding: "12px",
+  color: theme.custom.colors.darkGray2,
+  backgroundColor: theme.custom.colors.lightGray1,
+  ...theme.typography.subtitle3,
 })
 
 const DifferingRunData = styled.div({
@@ -68,9 +80,8 @@ const DifferingRunData = styled.div({
 })
 
 const DifferingRunLabel = styled.strong({
-  [theme.breakpoints.down("sm")]: {
-    display: "none",
-  },
+  display: "flex",
+  flex: "1 0 0",
 })
 
 const DifferingRunLocation = styled(DifferingRunData)({
@@ -442,6 +453,11 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
   if (distinctPrices.length > 1 || distinctDeliveryMethods.length > 1) {
     return (
       <DifferingRuns>
+        <DifferingRunHeader>
+          <DifferingRunLabel>Date</DifferingRunLabel>
+          <DifferingRunLabel>Price</DifferingRunLabel>
+          <DifferingRunLabel>Format</DifferingRunLabel>
+        </DifferingRunHeader>
         {resource.runs.map((run, index) => (
           <DifferingRun key={index}>
             <DifferingRunData>
@@ -449,13 +465,11 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
             </DifferingRunData>
             {run.prices && (
               <DifferingRunData>
-                <DifferingRunLabel>Price:&nbsp;</DifferingRunLabel>
                 <span>{run.prices.map((p) => `$${p}`).join(", ")}</span>
               </DifferingRunData>
             )}
             {run.delivery && (
               <DifferingRunData>
-                <DifferingRunLabel>Format:&nbsp;</DifferingRunLabel>
                 <span>{run.delivery?.map((dm) => dm?.name).join(", ")}</span>
               </DifferingRunData>
             )}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -67,6 +67,12 @@ const DifferingRunData = styled.div({
   ...theme.typography.body3,
 })
 
+const DifferingRunLabel = styled.strong({
+  [theme.breakpoints.down("sm")]: {
+    display: "none",
+  },
+})
+
 const DifferingRunLocation = styled(DifferingRunData)({
   flex: "1 0 100%",
   alignSelf: "stretch",
@@ -443,13 +449,13 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
             </DifferingRunData>
             {run.prices && (
               <DifferingRunData>
-                <strong>Price:&nbsp;</strong>
+                <DifferingRunLabel>Price:&nbsp;</DifferingRunLabel>
                 <span>{run.prices.map((p) => `$${p}`).join(", ")}</span>
               </DifferingRunData>
             )}
             {run.delivery && (
               <DifferingRunData>
-                <strong>Format:&nbsp;</strong>
+                <DifferingRunLabel>Format:&nbsp;</DifferingRunLabel>
                 <span>{run.delivery?.map((dm) => dm?.name).join(", ")}</span>
               </DifferingRunData>
             )}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -438,6 +438,7 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
   const asTaughtIn = resource ? showStartAnytime(resource) : false
   const prices = []
   const deliveryMethods = []
+  const locations = []
   for (const run of resource.runs) {
     if (run.prices) {
       prices.push(run.prices)
@@ -445,12 +446,20 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
     if (run.delivery) {
       deliveryMethods.push(run.delivery)
     }
+    if (run.location) {
+      locations.push(run.location)
+    }
   }
   const distinctPrices = [...new Set(prices.flat())]
   const distinctDeliveryMethods = [
     ...new Set(deliveryMethods.flat().map((dm) => dm?.code)),
   ]
-  if (distinctPrices.length > 1 || distinctDeliveryMethods.length > 1) {
+  const distinctLocations = [...new Set(locations.flat().map((l) => l))]
+  if (
+    distinctPrices.length > 1 ||
+    distinctDeliveryMethods.length > 1 ||
+    distinctLocations.length > 1
+  ) {
     return (
       <DifferingRuns data-testid="differing-runs-table">
         <DifferingRunHeader>
@@ -474,10 +483,10 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
               </DifferingRunData>
             )}
             {run.delivery.filter((d) => d.code === "in_person").length > 0 &&
-              resource.location && (
+              run.location && (
                 <DifferingRunLocation>
                   <strong>Location:&nbsp;</strong>
-                  <span>{resource.location}</span>
+                  <span>{run.location}</span>
                 </DifferingRunLocation>
               )}
           </DifferingRun>

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -39,6 +39,39 @@ const Separator: React.FC = () => (
   <SeparatorContainer>|&#8203;</SeparatorContainer>
 )
 
+const DifferingRuns = styled.div({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  borderRadius: "4px",
+  border: `1px solid ${theme.custom.colors.silverGrayLight}`,
+  borderBottom: "none",
+})
+
+const DifferingRun = styled.div({
+  display: "flex",
+  flexWrap: "wrap",
+  alignItems: "center",
+  gap: "16px",
+  padding: "12px",
+  alignSelf: "stretch",
+  borderBottom: `1px solid ${theme.custom.colors.silverGrayLight}`,
+})
+
+const DifferingRunData = styled.div({
+  display: "flex",
+  flexShrink: 0,
+  flex: "1 0 0",
+  color: theme.custom.colors.darkGray2,
+  ...theme.typography.body3,
+})
+
+const DifferingRunLocation = styled(DifferingRunData)({
+  flex: "1 0 100%",
+  alignSelf: "stretch",
+})
+
 const InfoItems = styled.section({
   display: "flex",
   flexDirection: "column",
@@ -376,6 +409,65 @@ const InfoItem = ({ label, Icon, value }: InfoItemProps) => {
   )
 }
 
+const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
+  resource,
+}) => {
+  if (!resource.runs) {
+    return null
+  }
+  if (resource.runs.length === 1) {
+    return null
+  }
+  const asTaughtIn = resource ? showStartAnytime(resource) : false
+  const prices = []
+  const deliveryMethods = []
+  for (const run of resource.runs) {
+    if (run.prices) {
+      prices.push(run.prices)
+    }
+    if (run.delivery) {
+      deliveryMethods.push(run.delivery)
+    }
+  }
+  const distinctPrices = [...new Set(prices.flat())]
+  const distinctDeliveryMethods = [
+    ...new Set(deliveryMethods.flat().map((dm) => dm?.code)),
+  ]
+  if (distinctPrices.length > 1 || distinctDeliveryMethods.length > 1) {
+    return (
+      <DifferingRuns>
+        {resource.runs.map((run, index) => (
+          <DifferingRun key={index}>
+            <DifferingRunData>
+              {formatRunDate(run, asTaughtIn)}
+            </DifferingRunData>
+            {run.prices && (
+              <DifferingRunData>
+                <strong>Price:&nbsp;</strong>
+                <span>{run.prices.map((p) => `$${p}`).join(", ")}</span>
+              </DifferingRunData>
+            )}
+            {run.delivery && (
+              <DifferingRunData>
+                <strong>Format:&nbsp;</strong>
+                <span>{run.delivery?.map((dm) => dm?.name).join(", ")}</span>
+              </DifferingRunData>
+            )}
+            {run.delivery.filter((d) => d.code === "in_person").length > 0 &&
+              resource.location && (
+                <DifferingRunLocation>
+                  <strong>Location:&nbsp;</strong>
+                  <span>{resource.location}</span>
+                </DifferingRunLocation>
+              )}
+          </DifferingRun>
+        ))}
+      </DifferingRuns>
+    )
+  }
+  return null
+}
+
 const InfoSectionV2 = ({ resource }: { resource?: LearningResource }) => {
   if (!resource) {
     return null
@@ -392,11 +484,14 @@ const InfoSectionV2 = ({ resource }: { resource?: LearningResource }) => {
   }
 
   return (
-    <InfoItems data-testid="drawer-info-items">
-      {infoItems.map((props, index) => (
-        <InfoItem key={index} {...props} />
-      ))}
-    </InfoItems>
+    <>
+      <DifferingRunsTable resource={resource} />
+      <InfoItems data-testid="drawer-info-items">
+        {infoItems.map((props, index) => (
+          <InfoItem key={index} {...props} />
+        ))}
+      </InfoItems>
+    </>
   )
 }
 

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -22,6 +22,7 @@ import {
   showStartAnytime,
 } from "ol-utilities"
 import { theme } from "../ThemeProvider/ThemeProvider"
+import DifferingRunsTable from "./DifferingRunsTable"
 
 const SeparatorContainer = styled.span({
   padding: "0 8px",
@@ -38,56 +39,6 @@ const SeparatorContainer = styled.span({
 const Separator: React.FC = () => (
   <SeparatorContainer>|&#8203;</SeparatorContainer>
 )
-
-const DifferingRuns = styled.div({
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "flex-start",
-  alignSelf: "stretch",
-  borderRadius: "4px",
-  border: `1px solid ${theme.custom.colors.lightGray2}`,
-  borderBottom: "none",
-})
-
-const DifferingRun = styled.div({
-  display: "flex",
-  flexWrap: "wrap",
-  alignItems: "center",
-  gap: "16px",
-  padding: "12px",
-  alignSelf: "stretch",
-  borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
-})
-
-const DifferingRunHeader = styled.div({
-  display: "flex",
-  alignSelf: "stretch",
-  alignItems: "center",
-  flex: "1 0 0",
-  gap: "16px",
-  padding: "12px",
-  color: theme.custom.colors.darkGray2,
-  backgroundColor: theme.custom.colors.lightGray1,
-  ...theme.typography.subtitle3,
-})
-
-const DifferingRunData = styled.div({
-  display: "flex",
-  flexShrink: 0,
-  flex: "1 0 0",
-  color: theme.custom.colors.darkGray2,
-  ...theme.typography.body3,
-})
-
-const DifferingRunLabel = styled.strong({
-  display: "flex",
-  flex: "1 0 0",
-})
-
-const DifferingRunLocation = styled(DifferingRunData)({
-  flex: "1 0 100%",
-  alignSelf: "stretch",
-})
 
 const InfoItems = styled.section({
   display: "flex",
@@ -424,77 +375,6 @@ const InfoItem = ({ label, Icon, value }: InfoItemProps) => {
       <InfoValue>{value}</InfoValue>
     </InfoItemContainer>
   )
-}
-
-const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
-  resource,
-}) => {
-  if (!resource.runs) {
-    return null
-  }
-  if (resource.runs.length === 1) {
-    return null
-  }
-  const asTaughtIn = resource ? showStartAnytime(resource) : false
-  const prices = []
-  const deliveryMethods = []
-  const locations = []
-  for (const run of resource.runs) {
-    if (run.prices) {
-      prices.push(run.prices)
-    }
-    if (run.delivery) {
-      deliveryMethods.push(run.delivery)
-    }
-    if (run.location) {
-      locations.push(run.location)
-    }
-  }
-  const distinctPrices = [...new Set(prices.flat())]
-  const distinctDeliveryMethods = [
-    ...new Set(deliveryMethods.flat().map((dm) => dm?.code)),
-  ]
-  const distinctLocations = [...new Set(locations.flat().map((l) => l))]
-  if (
-    distinctPrices.length > 1 ||
-    distinctDeliveryMethods.length > 1 ||
-    distinctLocations.length > 1
-  ) {
-    return (
-      <DifferingRuns data-testid="differing-runs-table">
-        <DifferingRunHeader>
-          <DifferingRunLabel>Date</DifferingRunLabel>
-          <DifferingRunLabel>Price</DifferingRunLabel>
-          <DifferingRunLabel>Format</DifferingRunLabel>
-        </DifferingRunHeader>
-        {resource.runs.map((run, index) => (
-          <DifferingRun key={index}>
-            <DifferingRunData>
-              {formatRunDate(run, asTaughtIn)}
-            </DifferingRunData>
-            {run.prices && (
-              <DifferingRunData>
-                <span>{run.prices.map((p) => `$${p}`).join(", ")}</span>
-              </DifferingRunData>
-            )}
-            {run.delivery && (
-              <DifferingRunData>
-                <span>{run.delivery?.map((dm) => dm?.name).join(", ")}</span>
-              </DifferingRunData>
-            )}
-            {run.delivery.filter((d) => d.code === "in_person").length > 0 &&
-              run.location && (
-                <DifferingRunLocation>
-                  <strong>Location:&nbsp;</strong>
-                  <span>{run.location}</span>
-                </DifferingRunLocation>
-              )}
-          </DifferingRun>
-        ))}
-      </DifferingRuns>
-    )
-  }
-  return null
 }
 
 const InfoSectionV2 = ({ resource }: { resource?: LearningResource }) => {

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -452,7 +452,7 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
   ]
   if (distinctPrices.length > 1 || distinctDeliveryMethods.length > 1) {
     return (
-      <DifferingRuns>
+      <DifferingRuns data-testid="differing-runs-table">
         <DifferingRunHeader>
           <DifferingRunLabel>Date</DifferingRunLabel>
           <DifferingRunLabel>Price</DifferingRunLabel>

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -88,6 +88,7 @@ const Image = styled(NextImage)({
   borderRadius: "8px",
   width: "100%",
   objectFit: "cover",
+  zIndex: -1,
 })
 
 const SkeletonImage = styled(Skeleton)<{ aspect: number }>((aspect) => ({

--- a/frontends/ol-utilities/src/learning-resources/pricing.ts
+++ b/frontends/ol-utilities/src/learning-resources/pricing.ts
@@ -41,10 +41,6 @@ const getPrices = (prices: LearningResourcePrice[]) => {
       (a: LearningResourcePrice, b: LearningResourcePrice) =>
         Number(a.amount) - Number(b.amount),
     )
-    .sort(
-      (a: LearningResourcePrice, b: LearningResourcePrice) =>
-        Number(a.amount) - Number(b.amount),
-    )
     .filter((price: LearningResourcePrice) => Number(price.amount) > 0)
   const priceRange = sortedNonzero.filter(
     (price, index, arr) => index === 0 || index === arr.length - 1,


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5681#issuecomment-2450078182

### Description (What does it do?)
This PR adds a table to the new learning resource drawer comparing the price and format between runs of a course, if they are different.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/805e8467-99a1-49a9-8ac3-14153be15518)
![image](https://github.com/user-attachments/assets/8a686347-1e69-4a47-9576-a9fd5566909c)

### How can this be tested?
 - If you have Posthog set up locally, enable the `lr_drawer_v2` flag
 - If you don't have Posthog set up locally, you can force `drawerV2` to be `true` in `LearningResourceDrawer.tsx`
 - Spin up this branch of `mit-learn`
 - Ensure you have sufficient data backpopulated into your local instance, especially Sloan courses
 - Search for courses that have differing run data:
   - Leading the AI-Driven Organization
   - Becoming a More Digitally Savvy Board Member
   - Managing Product Platforms: Delivering Variety and Realizing Synergies
   - Communication and Persuasion in the Digital Age
 - Ensure that the differing runs table shows up on each of these courses and that the style matches the design
 - Click some other courses on the search page and ensure that they do not show the differing runs table
