### PR TITLE
upgrade stories & events grid to grid2

### DIFF
--- a/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
+++ b/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
@@ -4,7 +4,7 @@ import {
   styled,
   theme,
   Typography,
-  Grid,
+  Grid2,
   Card,
   TypographyProps,
 } from "ol-components"
@@ -286,9 +286,12 @@ const NewsEventsSection: React.FC = () => {
               <Typography component="h3" variant="h4">
                 Stories
               </Typography>
-              <Grid container columnSpacing="24px" rowSpacing="28px">
+              <Grid2 container columnSpacing="24px" rowSpacing="28px">
                 {stories.map((item, index) => (
-                  <Grid item key={item.id} xs={12} sm={12} md={6} lg={4} xl={4}>
+                  <Grid2
+                    key={item.id}
+                    size={{ xs: 12, sm: 12, md: 6, lg: 4, xl: 4 }}
+                  >
                     {index >= 4 ? (
                       <AboveLgOnly>
                         <Story item={item as NewsFeedItem} mobile={false} />
@@ -296,9 +299,9 @@ const NewsEventsSection: React.FC = () => {
                     ) : (
                       <Story item={item as NewsFeedItem} mobile={false} />
                     )}
-                  </Grid>
+                  </Grid2>
                 ))}
-              </Grid>
+              </Grid2>
             </StoriesContainer>
             <EventsContainer>
               <Typography component="h3" variant="h4">

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -77,6 +77,8 @@ export type { DrawerProps } from "@mui/material/Drawer"
 
 export { default as Grid } from "@mui/material/Grid"
 export type { GridProps } from "@mui/material/Grid"
+export { default as Grid2 } from "@mui/material/Grid2"
+export type { Grid2Props } from "@mui/material/Grid2"
 export { default as InputLabel } from "@mui/material/InputLabel"
 
 export { default as List } from "@mui/material/List"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6007

### Description (What does it do?)
This PR fixes a bug that was introduced when MUI was updated from v5 to v6 as part of #1776.

MUI v5 had `Grid` and `Unstable_Grid2` components. In v6, Grid2 was stabilized Grid was deprecated. Additionally, v6 seems to have introduced a bug in `Grid`. The bug only affects Grid usage that has string-values for `columnSpacing`. We had exactly one instance of string-valued `columnSpacing`. So I've upgraded that particular usage to `Grid2` and everything looks fine now.

See https://github.com/mui/material-ui/issues/44321 for MUI bug.

### How can this be tested?
1. On this branch, compare styles of Stories & Events section of the homepage with that on https://learn.mit.edu/. (The bug has not yet made it to production). When comparing styles, I recommend:
    - Put local branch in browser Tab 1, production in Tab 2
    - Ensure zoom level is same in both tabs
    - Ensure both tabs have same widths (e.g., close dev tools on both tabs)
    - swap between Tab 1 and Tab 2.
2. Suggest doing additional style comparison of other pages, e.g. `/departments`, `/topics`, `/units`, `/search`, `/dashboard` + its tabs, and channel pages.
    - when comparing, ensure both tabs have scrollbar or both tabs do not have scrollbar. E.g., if viewing `/dashboard/my-lists`, if one tab has 1 list and the other has 10 lists, scrollbar might affect positioning in the longer list.

