### PR TITLE
HTTPS for YouTube iframe src

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceExpanded/VideoFrame.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/VideoFrame.tsx
@@ -18,7 +18,7 @@ const VideoFrame: React.FC<{
     const videoId = src?.split("v=")[1]
     return (
       <IFrame
-        src={`http://www.youtube.com/embed/${videoId}`}
+        src={`https://www.youtube.com/embed/${videoId}`}
         title={title}
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
         referrerPolicy="strict-origin-when-cross-origin"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->

Fixes an issue where we try to load YouTube videos over HTTP in a page loaded over TLS causing the video not to display and error e.g. 

```
Mixed Content: The page at 'https://rc.learn.mit.edu/?resource=17315' was loaded over HTTPS, 
but requested an insecure frame 'http://www.youtube.com/embed/BYM_Bko4Tnc'. 
This request has been blocked; the content must be served over HTTPS.
```

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

On RC, videos should display correctly in the learning resource drawer (it's impractical to serve on HTTPS locally - we have `yarn dev --experimental-https` but would also need  backend to do same):

<img width="382" alt="image" src="https://github.com/user-attachments/assets/1b9fcfee-a2cc-4311-9b36-9f6b9e560060">


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
