### PR TITLE
calculate min_score before score adjustments

### DIFF
--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -138,7 +138,7 @@ def generate_sort_clause(search_params):
         return sort
 
 
-def wrap_text_clause(text_query):
+def wrap_text_clause(text_query, min_score=None):
     """
     Wrap the text subqueries in a bool query
     Shared by generate_content_file_text_clause and
@@ -149,7 +149,13 @@ def wrap_text_clause(text_query):
     Returns:
         dict: dictionary with the opensearch text clause
     """
-    text_bool_clause = [{"bool": text_query}] if text_query else []
+    if min_score and text_query:
+        text_bool_clause = [
+            {"function_score": {"query": {"bool": text_query}, "min_score": min_score}}
+        ]
+
+    else:
+        text_bool_clause = [{"bool": text_query}] if text_query else []
 
     return {
         "bool": {
@@ -200,7 +206,7 @@ def generate_content_file_text_clause(text):
 
 
 def generate_learning_resources_text_clause(
-    text, search_mode, slop, content_file_score_weight
+    text, search_mode, slop, content_file_score_weight, min_score
 ):
     """
     Return text clause for the query
@@ -324,7 +330,7 @@ def generate_learning_resources_text_clause(
     else:
         text_query = {}
 
-    return wrap_text_clause(text_query)
+    return wrap_text_clause(text_query, min_score)
 
 
 def generate_filter_clause(
@@ -571,15 +577,15 @@ def add_text_query_to_search(search, text, search_params, query_type_query):
             search_params.get("search_mode"),
             search_params.get("slop"),
             search_params.get("content_file_score_weight"),
+            search_params.get("min_score"),
         )
 
     yearly_decay_percent = search_params.get("yearly_decay_percent")
-    min_score = search_params.get("min_score")
     max_incompleteness_penalty = (
         search_params.get("max_incompleteness_penalty", 0) / 100
     )
 
-    if yearly_decay_percent or min_score or max_incompleteness_penalty:
+    if yearly_decay_percent or max_incompleteness_penalty:
         script_query = {
             "script_score": {
                 "query": {"bool": {"must": [text_query], "filter": query_type_query}}
@@ -615,9 +621,6 @@ def add_text_query_to_search(search, text, search_params, query_type_query):
             "source": source,
             "params": params,
         }
-
-        if min_score:
-            script_query["script_score"]["min_score"] = min_score
 
         search = search.query(script_query)
     else:

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -146,6 +146,8 @@ def test_generate_learning_resources_text_clause(
     if search_mode == "phrase" and slop:
         extra_params["slop"] = slop
 
+    min_score = 0
+
     if content_file_score_weight is None:
         content_file_fields = [
             "content.english",
@@ -605,13 +607,516 @@ def test_generate_learning_resources_text_clause(
     }
     assert (
         generate_learning_resources_text_clause(
-            "math", search_mode, slop, content_file_score_weight
+            "math", search_mode, slop, content_file_score_weight, min_score
         )
         == result1
     )
     assert (
         generate_learning_resources_text_clause(
-            '"math"', search_mode, slop, content_file_score_weight
+            '"math"', search_mode, slop, content_file_score_weight, min_score
+        )
+        == result2
+    )
+
+
+def test_generate_learning_resources_text_clause_with_min_score():
+    search_mode = "phrase"
+    slop = 2
+    content_file_score_weight = 0.5
+    min_score = 10
+
+    result1 = {
+        "bool": {
+            "filter": {
+                "bool": {
+                    "must": [
+                        {
+                            "function_score": {
+                                "query": {
+                                    "bool": {
+                                        "should": [
+                                            {
+                                                "multi_match": {
+                                                    "query": "math",
+                                                    "fields": [
+                                                        "title.english^3",
+                                                        "description.english^2",
+                                                        "full_description.english",
+                                                        "platform.name",
+                                                        "readable_id",
+                                                        "offered_by",
+                                                        "course_feature",
+                                                        "video.transcript.english",
+                                                    ],
+                                                    "type": "phrase",
+                                                    "slop": 2,
+                                                }
+                                            },
+                                            {
+                                                "nested": {
+                                                    "path": "topics",
+                                                    "query": {
+                                                        "multi_match": {
+                                                            "query": "math",
+                                                            "fields": ["topics.name"],
+                                                            "type": "phrase",
+                                                            "slop": 2,
+                                                        }
+                                                    },
+                                                }
+                                            },
+                                            {
+                                                "nested": {
+                                                    "path": "departments",
+                                                    "query": {
+                                                        "multi_match": {
+                                                            "query": "math",
+                                                            "fields": [
+                                                                "departments.department_id",
+                                                                "departments.name",
+                                                            ],
+                                                            "type": "phrase",
+                                                            "slop": 2,
+                                                        }
+                                                    },
+                                                }
+                                            },
+                                            {
+                                                "nested": {
+                                                    "path": "course.course_numbers",
+                                                    "query": {
+                                                        "multi_match": {
+                                                            "query": "math",
+                                                            "fields": [
+                                                                "course.course_numbers.value"
+                                                            ],
+                                                            "type": "phrase",
+                                                            "slop": 2,
+                                                        }
+                                                    },
+                                                }
+                                            },
+                                            {
+                                                "nested": {
+                                                    "path": "runs",
+                                                    "query": {
+                                                        "multi_match": {
+                                                            "query": "math",
+                                                            "fields": [
+                                                                "runs.year",
+                                                                "runs.semester",
+                                                                "runs.level",
+                                                            ],
+                                                            "type": "phrase",
+                                                            "slop": 2,
+                                                        }
+                                                    },
+                                                }
+                                            },
+                                            {
+                                                "nested": {
+                                                    "path": "runs",
+                                                    "query": {
+                                                        "nested": {
+                                                            "path": "runs.instructors",
+                                                            "query": {
+                                                                "multi_match": {
+                                                                    "query": "math",
+                                                                    "fields": [
+                                                                        "runs.instructors.last_name^5",
+                                                                        "runs.instructors.full_name^5",
+                                                                    ],
+                                                                    "type": "best_fields",
+                                                                }
+                                                            },
+                                                        }
+                                                    },
+                                                }
+                                            },
+                                            {
+                                                "has_child": {
+                                                    "type": "content_file",
+                                                    "query": {
+                                                        "multi_match": {
+                                                            "query": "math",
+                                                            "fields": [
+                                                                "content.english^0.5",
+                                                                "title.english^0.5",
+                                                                "content_title.english^0.5",
+                                                                "description.english^0.5",
+                                                                "content_feature_type^0.5",
+                                                            ],
+                                                            "type": "phrase",
+                                                            "slop": 2,
+                                                        }
+                                                    },
+                                                    "score_mode": "avg",
+                                                }
+                                            },
+                                        ]
+                                    }
+                                },
+                                "min_score": 10,
+                            }
+                        }
+                    ]
+                }
+            },
+            "should": [
+                {
+                    "multi_match": {
+                        "query": "math",
+                        "fields": [
+                            "title.english^3",
+                            "description.english^2",
+                            "full_description.english",
+                            "platform.name",
+                            "readable_id",
+                            "offered_by",
+                            "course_feature",
+                            "video.transcript.english",
+                        ],
+                        "type": "phrase",
+                        "slop": 2,
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "topics",
+                        "query": {
+                            "multi_match": {
+                                "query": "math",
+                                "fields": ["topics.name"],
+                                "type": "phrase",
+                                "slop": 2,
+                            }
+                        },
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "departments",
+                        "query": {
+                            "multi_match": {
+                                "query": "math",
+                                "fields": [
+                                    "departments.department_id",
+                                    "departments.name",
+                                ],
+                                "type": "phrase",
+                                "slop": 2,
+                            }
+                        },
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "course.course_numbers",
+                        "query": {
+                            "multi_match": {
+                                "query": "math",
+                                "fields": ["course.course_numbers.value"],
+                                "type": "phrase",
+                                "slop": 2,
+                            }
+                        },
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "runs",
+                        "query": {
+                            "multi_match": {
+                                "query": "math",
+                                "fields": ["runs.year", "runs.semester", "runs.level"],
+                                "type": "phrase",
+                                "slop": 2,
+                            }
+                        },
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "runs",
+                        "query": {
+                            "nested": {
+                                "path": "runs.instructors",
+                                "query": {
+                                    "multi_match": {
+                                        "query": "math",
+                                        "fields": [
+                                            "runs.instructors.last_name^5",
+                                            "runs.instructors.full_name^5",
+                                        ],
+                                        "type": "best_fields",
+                                    }
+                                },
+                            }
+                        },
+                    }
+                },
+                {
+                    "has_child": {
+                        "type": "content_file",
+                        "query": {
+                            "multi_match": {
+                                "query": "math",
+                                "fields": [
+                                    "content.english^0.5",
+                                    "title.english^0.5",
+                                    "content_title.english^0.5",
+                                    "description.english^0.5",
+                                    "content_feature_type^0.5",
+                                ],
+                                "type": "phrase",
+                                "slop": 2,
+                            }
+                        },
+                        "score_mode": "avg",
+                    }
+                },
+            ],
+        }
+    }
+    result2 = {
+        "bool": {
+            "filter": {
+                "bool": {
+                    "must": [
+                        {
+                            "function_score": {
+                                "query": {
+                                    "bool": {
+                                        "should": [
+                                            {
+                                                "query_string": {
+                                                    "query": '"math"',
+                                                    "fields": [
+                                                        "title.english^3",
+                                                        "description.english^2",
+                                                        "full_description.english",
+                                                        "platform.name",
+                                                        "readable_id",
+                                                        "offered_by",
+                                                        "course_feature",
+                                                        "video.transcript.english",
+                                                    ],
+                                                }
+                                            },
+                                            {
+                                                "nested": {
+                                                    "path": "topics",
+                                                    "query": {
+                                                        "query_string": {
+                                                            "query": '"math"',
+                                                            "fields": ["topics.name"],
+                                                        }
+                                                    },
+                                                }
+                                            },
+                                            {
+                                                "nested": {
+                                                    "path": "departments",
+                                                    "query": {
+                                                        "query_string": {
+                                                            "query": '"math"',
+                                                            "fields": [
+                                                                "departments.department_id",
+                                                                "departments.name",
+                                                            ],
+                                                        }
+                                                    },
+                                                }
+                                            },
+                                            {
+                                                "nested": {
+                                                    "path": "course.course_numbers",
+                                                    "query": {
+                                                        "query_string": {
+                                                            "query": '"math"',
+                                                            "fields": [
+                                                                "course.course_numbers.value"
+                                                            ],
+                                                        }
+                                                    },
+                                                }
+                                            },
+                                            {
+                                                "nested": {
+                                                    "path": "runs",
+                                                    "query": {
+                                                        "query_string": {
+                                                            "query": '"math"',
+                                                            "fields": [
+                                                                "runs.year",
+                                                                "runs.semester",
+                                                                "runs.level",
+                                                            ],
+                                                        }
+                                                    },
+                                                }
+                                            },
+                                            {
+                                                "nested": {
+                                                    "path": "runs",
+                                                    "query": {
+                                                        "nested": {
+                                                            "path": "runs.instructors",
+                                                            "query": {
+                                                                "query_string": {
+                                                                    "query": '"math"',
+                                                                    "fields": [
+                                                                        "runs.instructors.last_name^5",
+                                                                        "runs.instructors.full_name^5",
+                                                                    ],
+                                                                    "type": "best_fields",
+                                                                }
+                                                            },
+                                                        }
+                                                    },
+                                                }
+                                            },
+                                            {
+                                                "has_child": {
+                                                    "type": "content_file",
+                                                    "query": {
+                                                        "query_string": {
+                                                            "query": '"math"',
+                                                            "fields": [
+                                                                "content.english^0.5",
+                                                                "title.english^0.5",
+                                                                "content_title.english^0.5",
+                                                                "description.english^0.5",
+                                                                "content_feature_type^0.5",
+                                                            ],
+                                                        }
+                                                    },
+                                                    "score_mode": "avg",
+                                                }
+                                            },
+                                        ]
+                                    }
+                                },
+                                "min_score": 10,
+                            }
+                        }
+                    ]
+                }
+            },
+            "should": [
+                {
+                    "query_string": {
+                        "query": '"math"',
+                        "fields": [
+                            "title.english^3",
+                            "description.english^2",
+                            "full_description.english",
+                            "platform.name",
+                            "readable_id",
+                            "offered_by",
+                            "course_feature",
+                            "video.transcript.english",
+                        ],
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "topics",
+                        "query": {
+                            "query_string": {
+                                "query": '"math"',
+                                "fields": ["topics.name"],
+                            }
+                        },
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "departments",
+                        "query": {
+                            "query_string": {
+                                "query": '"math"',
+                                "fields": [
+                                    "departments.department_id",
+                                    "departments.name",
+                                ],
+                            }
+                        },
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "course.course_numbers",
+                        "query": {
+                            "query_string": {
+                                "query": '"math"',
+                                "fields": ["course.course_numbers.value"],
+                            }
+                        },
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "runs",
+                        "query": {
+                            "query_string": {
+                                "query": '"math"',
+                                "fields": ["runs.year", "runs.semester", "runs.level"],
+                            }
+                        },
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "runs",
+                        "query": {
+                            "nested": {
+                                "path": "runs.instructors",
+                                "query": {
+                                    "query_string": {
+                                        "query": '"math"',
+                                        "fields": [
+                                            "runs.instructors.last_name^5",
+                                            "runs.instructors.full_name^5",
+                                        ],
+                                        "type": "best_fields",
+                                    }
+                                },
+                            }
+                        },
+                    }
+                },
+                {
+                    "has_child": {
+                        "type": "content_file",
+                        "query": {
+                            "query_string": {
+                                "query": '"math"',
+                                "fields": [
+                                    "content.english^0.5",
+                                    "title.english^0.5",
+                                    "content_title.english^0.5",
+                                    "description.english^0.5",
+                                    "content_feature_type^0.5",
+                                ],
+                            }
+                        },
+                        "score_mode": "avg",
+                    }
+                },
+            ],
+        }
+    }
+
+    assert (
+        generate_learning_resources_text_clause(
+            "math", search_mode, slop, content_file_score_weight, min_score
+        )
+        == result1
+    )
+    assert (
+        generate_learning_resources_text_clause(
+            '"math"', search_mode, slop, content_file_score_weight, min_score
         )
         == result2
     )
@@ -1343,8 +1848,8 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                 {
                                     "term": {
                                         "free": {
-                                            "case_insensitive": True,
                                             "value": True,
+                                            "case_insensitive": True,
                                         }
                                     }
                                 }
@@ -1432,8 +1937,8 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                         {
                                             "term": {
                                                 "free": {
-                                                    "case_insensitive": True,
                                                     "value": True,
+                                                    "case_insensitive": True,
                                                 }
                                             }
                                         }
@@ -1968,17 +2473,17 @@ def test_execute_learn_search_with_min_score(mocker, settings, opensearch):
 
     query = {
         "query": {
-            "script_score": {
-                "query": {
-                    "bool": {
-                        "must": [
-                            {
-                                "bool": {
-                                    "filter": [
-                                        {
-                                            "bool": {
-                                                "must": [
-                                                    {
+            "bool": {
+                "must": [
+                    {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "bool": {
+                                        "must": [
+                                            {
+                                                "function_score": {
+                                                    "query": {
                                                         "bool": {
                                                             "should": [
                                                                 {
@@ -2097,133 +2602,132 @@ def test_execute_learn_search_with_min_score(mocker, settings, opensearch):
                                                                 },
                                                             ]
                                                         }
-                                                    }
-                                                ]
+                                                    },
+                                                    "min_score": 5,
+                                                }
                                             }
-                                        }
-                                    ],
-                                    "should": [
-                                        {
+                                        ]
+                                    }
+                                }
+                            ],
+                            "should": [
+                                {
+                                    "multi_match": {
+                                        "query": "math",
+                                        "fields": [
+                                            "title.english^3",
+                                            "description.english^2",
+                                            "full_description.english",
+                                            "platform.name",
+                                            "readable_id",
+                                            "offered_by",
+                                            "course_feature",
+                                            "video.transcript.english",
+                                        ],
+                                        "type": "best_fields",
+                                    }
+                                },
+                                {
+                                    "nested": {
+                                        "path": "topics",
+                                        "query": {
+                                            "multi_match": {
+                                                "query": "math",
+                                                "fields": ["topics.name"],
+                                                "type": "best_fields",
+                                            }
+                                        },
+                                    }
+                                },
+                                {
+                                    "nested": {
+                                        "path": "departments",
+                                        "query": {
                                             "multi_match": {
                                                 "query": "math",
                                                 "fields": [
-                                                    "title.english^3",
-                                                    "description.english^2",
-                                                    "full_description.english",
-                                                    "platform.name",
-                                                    "readable_id",
-                                                    "offered_by",
-                                                    "course_feature",
-                                                    "video.transcript.english",
+                                                    "departments.department_id",
+                                                    "departments.name",
                                                 ],
                                                 "type": "best_fields",
                                             }
                                         },
-                                        {
-                                            "nested": {
-                                                "path": "topics",
-                                                "query": {
-                                                    "multi_match": {
-                                                        "query": "math",
-                                                        "fields": ["topics.name"],
-                                                        "type": "best_fields",
-                                                    }
-                                                },
+                                    }
+                                },
+                                {
+                                    "nested": {
+                                        "path": "course.course_numbers",
+                                        "query": {
+                                            "multi_match": {
+                                                "query": "math",
+                                                "fields": [
+                                                    "course.course_numbers.value"
+                                                ],
+                                                "type": "best_fields",
                                             }
                                         },
-                                        {
+                                    }
+                                },
+                                {
+                                    "nested": {
+                                        "path": "runs",
+                                        "query": {
+                                            "multi_match": {
+                                                "query": "math",
+                                                "fields": [
+                                                    "runs.year",
+                                                    "runs.semester",
+                                                    "runs.level",
+                                                ],
+                                                "type": "best_fields",
+                                            }
+                                        },
+                                    }
+                                },
+                                {
+                                    "nested": {
+                                        "path": "runs",
+                                        "query": {
                                             "nested": {
-                                                "path": "departments",
+                                                "path": "runs.instructors",
                                                 "query": {
                                                     "multi_match": {
                                                         "query": "math",
                                                         "fields": [
-                                                            "departments.department_id",
-                                                            "departments.name",
+                                                            "runs.instructors.last_name^5",
+                                                            "runs.instructors.full_name^5",
                                                         ],
                                                         "type": "best_fields",
                                                     }
                                                 },
                                             }
                                         },
-                                        {
-                                            "nested": {
-                                                "path": "course.course_numbers",
-                                                "query": {
-                                                    "multi_match": {
-                                                        "query": "math",
-                                                        "fields": [
-                                                            "course.course_numbers.value"
-                                                        ],
-                                                        "type": "best_fields",
-                                                    }
-                                                },
+                                    }
+                                },
+                                {
+                                    "has_child": {
+                                        "type": "content_file",
+                                        "query": {
+                                            "multi_match": {
+                                                "query": "math",
+                                                "fields": [
+                                                    "content.english",
+                                                    "title.english",
+                                                    "content_title.english",
+                                                    "description.english",
+                                                    "content_feature_type",
+                                                ],
+                                                "type": "best_fields",
                                             }
                                         },
-                                        {
-                                            "nested": {
-                                                "path": "runs",
-                                                "query": {
-                                                    "multi_match": {
-                                                        "query": "math",
-                                                        "fields": [
-                                                            "runs.year",
-                                                            "runs.semester",
-                                                            "runs.level",
-                                                        ],
-                                                        "type": "best_fields",
-                                                    }
-                                                },
-                                            }
-                                        },
-                                        {
-                                            "nested": {
-                                                "path": "runs",
-                                                "query": {
-                                                    "nested": {
-                                                        "path": "runs.instructors",
-                                                        "query": {
-                                                            "multi_match": {
-                                                                "query": "math",
-                                                                "fields": [
-                                                                    "runs.instructors.last_name^5",
-                                                                    "runs.instructors.full_name^5",
-                                                                ],
-                                                                "type": "best_fields",
-                                                            }
-                                                        },
-                                                    }
-                                                },
-                                            }
-                                        },
-                                        {
-                                            "has_child": {
-                                                "type": "content_file",
-                                                "query": {
-                                                    "multi_match": {
-                                                        "query": "math",
-                                                        "fields": [
-                                                            "content.english",
-                                                            "title.english",
-                                                            "content_title.english",
-                                                            "description.english",
-                                                            "content_feature_type",
-                                                        ],
-                                                        "type": "best_fields",
-                                                    }
-                                                },
-                                                "score_mode": "avg",
-                                            }
-                                        },
-                                    ],
-                                }
-                            }
-                        ],
-                        "filter": [{"exists": {"field": "resource_type"}}],
+                                        "score_mode": "avg",
+                                    }
+                                },
+                            ],
+                        }
                     }
-                },
-                "script": {"params": {}, "source": "_score"},
-                "min_score": 5,
+                ],
+                "filter": [{"exists": {"field": "resource_type"}}],
             }
         },
         "post_filter": {


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/6020

### Description (What does it do?)
This pr adjusts the search query to take the minimum score cutoff based on the original scores calculated for a text query, not the scores adjusted for staleness and completeness


### How can this be tested?
On the main branch

1) Make a text search query and take a screen shot of the results
2) Log in as an admin. Set "Resource Score Staleness Penalty" to 0 and "Maximum Incompleteness Penalty" to 0 for the same query as 1. Take a screen shot of the results

Switch to this branch. Make the same query as above. You should have the same results in the front page as you see in the screen shot for 1) and the same counts for All resources, courses, programs and learning materials as you see in your screen shot for 2). Changing the "Resource Score Staleness Penalty" and "Maximum Incompleteness Penalty"  should change the result order but not the counts of available resources