### PR TITLE
Remove unnecessary percolate calls

### DIFF
--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -73,7 +73,7 @@ def update_index(learning_resource, newly_created):
     if not newly_created and not learning_resource.published:
         resource_unpublished_actions(learning_resource)
     elif learning_resource.published:
-        resource_upserted_actions(learning_resource, percolate=newly_created)
+        resource_upserted_actions(learning_resource, percolate=True)
 
 
 def load_topics(resource, topics_data):

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -73,7 +73,7 @@ def update_index(learning_resource, newly_created):
     if not newly_created and not learning_resource.published:
         resource_unpublished_actions(learning_resource)
     elif learning_resource.published:
-        resource_upserted_actions(learning_resource, percolate=True)
+        resource_upserted_actions(learning_resource, percolate=False)
 
 
 def load_topics(resource, topics_data):

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -264,9 +264,7 @@ def test_load_program(  # noqa: PLR0913
             result.id, result.resource_type
         )
     elif is_published:
-        mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
-            result.id
-        )
+        mock_upsert_tasks.upsert_learning_resource.assert_called_with(result.id)
     else:
         mock_upsert_tasks.upsert_learning_resource.assert_not_called()
 
@@ -420,9 +418,7 @@ def test_load_course(  # noqa: PLR0913,PLR0912,PLR0915
             result.id, result.resource_type
         )
     elif is_published and is_run_published and not blocklisted:
-        mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
-            result.id
-        )
+        mock_upsert_tasks.upsert_learning_resource.assert_called_with(result.id)
     else:
         mock_upsert_tasks.deindex_learning_resource.assert_not_called()
         mock_upsert_tasks.upsert_learning_resource.assert_not_called()
@@ -553,7 +549,7 @@ def test_load_duplicate_course(
     else:
         mock_upsert_tasks.deindex_learning_resource.assert_not_called()
     if course.learning_resource.id:
-        mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
+        mock_upsert_tasks.upsert_learning_resource.assert_called_with(
             course.learning_resource.id
         )
 
@@ -1113,9 +1109,7 @@ def test_load_podcast_episode(
             result.id, result.resource_type
         )
     elif is_published:
-        mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
-            result.id
-        )
+        mock_upsert_tasks.upsert_learning_resource.assert_called_with(result.id)
     else:
         mock_upsert_tasks.upsert_learning_resource.assert_not_called()
         mock_upsert_tasks.deindex_learning_resource.assert_not_called()
@@ -1190,9 +1184,7 @@ def test_load_podcast(
             result.id, result.resource_type
         )
     elif is_published:
-        mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
-            result.id
-        )
+        mock_upsert_tasks.upsert_learning_resource.assert_called_with(result.id)
     else:
         mock_upsert_tasks.deindex_learning_resource.assert_not_called()
         mock_upsert_tasks.upsert_learning_resource.assert_not_called()
@@ -1503,9 +1495,7 @@ def test_load_course_percolation(
 
     blocklist = [learning_resource.readable_id] if blocklisted else []
     result = load_course(props, blocklist, [], config=CourseLoaderConfig(prune=True))
-    mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
-        result.id
-    )
+    mock_upsert_tasks.upsert_learning_resource.assert_called_with(result.id)
 
 
 @pytest.mark.parametrize("certification", [True, False])

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -264,12 +264,9 @@ def test_load_program(  # noqa: PLR0913
             result.id, result.resource_type
         )
     elif is_published:
-        if program_exists:
-            mock_upsert_tasks.upsert_learning_resource.assert_called_with(result.id)
-        else:
-            mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
-                result.id
-            )
+        mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
+            result.id
+        )
     else:
         mock_upsert_tasks.upsert_learning_resource.assert_not_called()
 
@@ -423,12 +420,9 @@ def test_load_course(  # noqa: PLR0913,PLR0912,PLR0915
             result.id, result.resource_type
         )
     elif is_published and is_run_published and not blocklisted:
-        if course_exists:
-            mock_upsert_tasks.upsert_learning_resource.assert_called_with(result.id)
-        else:
-            mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
-                result.id
-            )
+        mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
+            result.id
+        )
     else:
         mock_upsert_tasks.deindex_learning_resource.assert_not_called()
         mock_upsert_tasks.upsert_learning_resource.assert_not_called()
@@ -559,14 +553,9 @@ def test_load_duplicate_course(
     else:
         mock_upsert_tasks.deindex_learning_resource.assert_not_called()
     if course.learning_resource.id:
-        if course_exists:
-            mock_upsert_tasks.upsert_learning_resource.assert_called_with(
-                course.learning_resource.id
-            )
-        else:
-            mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
-                course.learning_resource.id
-            )
+        mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
+            course.learning_resource.id
+        )
 
     assert Course.objects.count() == (2 if duplicate_course_exists else 1)
 
@@ -1124,12 +1113,9 @@ def test_load_podcast_episode(
             result.id, result.resource_type
         )
     elif is_published:
-        if podcast_episode_exists:
-            mock_upsert_tasks.upsert_learning_resource.assert_called_with(result.id)
-        else:
-            mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
-                result.id
-            )
+        mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
+            result.id
+        )
     else:
         mock_upsert_tasks.upsert_learning_resource.assert_not_called()
         mock_upsert_tasks.deindex_learning_resource.assert_not_called()
@@ -1204,12 +1190,9 @@ def test_load_podcast(
             result.id, result.resource_type
         )
     elif is_published:
-        if podcast_exists:
-            mock_upsert_tasks.upsert_learning_resource.assert_called_with(result.id)
-        else:
-            mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
-                result.id
-            )
+        mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
+            result.id
+        )
     else:
         mock_upsert_tasks.deindex_learning_resource.assert_not_called()
         mock_upsert_tasks.upsert_learning_resource.assert_not_called()
@@ -1507,7 +1490,6 @@ def test_load_course_percolation(
         "url": learning_resource.url,
         "published": is_published,
     }
-
     if is_run_published:
         run = {
             "run_id": run.run_id,
@@ -1520,16 +1502,10 @@ def test_load_course_percolation(
         props["runs"] = []
 
     blocklist = [learning_resource.readable_id] if blocklisted else []
-
     result = load_course(props, blocklist, [], config=CourseLoaderConfig(prune=True))
-
-    if course_exists:
-        mock_upsert_tasks.upsert_learning_resource.assert_called_with(result.id)
-        mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_not_called()
-    else:
-        mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
-            result.id
-        )
+    mock_upsert_tasks.upsert_learning_resource_immutable_signature.assert_called_with(
+        result.id
+    )
 
 
 @pytest.mark.parametrize("certification", [True, False])


### PR DESCRIPTION
### Description (What does it do?)
This PR removes calling percolate on newly inserted documents.During the initial implementation of the subscription feature we had a plugin hook that percolated new documents on creation which is currently unused (we switched to a celery task that manually does this when needed). I think the plugin hook and parameter percolate=False is still a useful placeholder for when we do need something to trigger off of this down the road.

### How can this be tested?
I noticed that there was a stream of percolate operations when pulling down lots of new items via etl pipelines. 

To see this issue:
1. checkout main
2. make sure you have your settings in place (copy it from rc) to fetch content from youtube (YOUTUBE_DEVELOPER_KEY, YOUTUBE_CONFIG_URL) 
3. run `python manage.py backpopulate_youtube_data fetch`
4. sometime after this completes notice a stream of percolate operations in the celery logs that follow
5. check out this branch and restart containers and note that this does not happen
