### PR TITLE
Add playlist id to video results

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -6611,6 +6611,12 @@ export interface VideoResource {
    */
   video: Video
   /**
+   * Get the playlist id(s) the video belongs to
+   * @type {Array<string>}
+   * @memberof VideoResource
+   */
+  playlists: Array<string>
+  /**
    *
    * @type {string}
    * @memberof VideoResource

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -639,6 +639,16 @@ class VideoResourceSerializer(LearningResourceBaseSerializer):
 
     video = VideoSerializer(read_only=True)
 
+    playlists = serializers.SerializerMethodField()
+
+    def get_playlists(self, instance) -> list[str]:
+        """Get the playlist id(s) the video belongs to"""
+        return list(
+            instance.parents.filter(
+                relation_type=constants.LearningResourceRelationTypes.PLAYLIST_VIDEOS.value
+            ).values_list("parent__id", flat=True)
+        )
+
 
 class VideoPlaylistResourceSerializer(LearningResourceBaseSerializer):
     """Serializer for video playlist resources"""

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -827,6 +827,29 @@ def test_list_video_endpoint(client, url, params):
 
 
 @pytest.mark.parametrize(
+    ("url", "params"),
+    [
+        ("lr:v1:videos_api-list", ""),
+        ("lr:v1:learning_resources_api-list", "resource_type=video"),
+    ],
+)
+def test_list_video_endpoint_returns_playlists(client, url, params):
+    """Test video endpoint returns playlist ids"""
+
+    playlist = VideoPlaylistFactory.create().learning_resource
+    videos = VideoFactory.create_batch(2)
+    playlist.resources.set(
+        [video.learning_resource for video in videos],
+        through_defaults={
+            "relation_type": LearningResourceRelationTypes.PLAYLIST_VIDEOS
+        },
+    )
+    resp = client.get(f"{reverse(url)}?{params}")
+    for item in resp.data["results"]:
+        assert playlist.id in item["playlists"]
+
+
+@pytest.mark.parametrize(
     "url", ["lr:v1:videos_api-detail", "lr:v1:learning_resources_api-detail"]
 )
 def test_get_video_detail_endpoint(client, url):

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -13303,6 +13303,12 @@ components:
           allOf:
           - $ref: '#/components/schemas/Video'
           readOnly: true
+        playlists:
+          type: array
+          items:
+            type: string
+          description: Get the playlist id(s) the video belongs to
+          readOnly: true
         readable_id:
           type: string
           maxLength: 512
@@ -13376,6 +13382,7 @@ components:
       - offered_by
       - pace
       - platform
+      - playlists
       - position
       - prices
       - professional


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/5881

### Description (What does it do?)
This PR adds a list of playlist ids to the video api results /api/v1/videos/

### How can this be tested?
1. Checkout this branch
2. make sure you have videos loaded up locally or run ` python manage.py backpopulate_youtube_data fetch`
3. visit the videos endpoint at /api/v1/videos/ and note that each result has a "playlists" attribute that contains playlist ids
4. take one of the playlist ids and see other videos in the playlist by going to  /api/v1/video_playlists/{playlist id}/items/
