### PR TITLE
show more button for v2 drawer dates

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
@@ -42,6 +42,12 @@ const resources = {
 }
 
 const sameDataRun = factories.learningResources.run({
+  delivery: [
+    {
+      code: DeliveryEnum.Online,
+      name: DeliveryEnumDescriptions.online,
+    },
+  ],
   resource_prices: [
     { amount: "0", currency: "USD" },
     { amount: "100", currency: "USD" },

--- a/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
@@ -42,7 +42,6 @@ const resources = {
 }
 
 const sameDataRun = factories.learningResources.run({
-  start_date: new Date().toISOString().split("T")[0],
   delivery: [
     {
       code: DeliveryEnum.Online,
@@ -171,25 +170,21 @@ const courses = {
       free: true,
       runs: [
         factories.learningResources.run({
-          start_date: sameDataRun.start_date,
           delivery: sameDataRun.delivery,
           resource_prices: sameDataRun.resource_prices,
           location: sameDataRun.location,
         }),
         factories.learningResources.run({
-          start_date: sameDataRun.start_date,
           delivery: sameDataRun.delivery,
           resource_prices: sameDataRun.resource_prices,
           location: sameDataRun.location,
         }),
         factories.learningResources.run({
-          start_date: sameDataRun.start_date,
           delivery: sameDataRun.delivery,
           resource_prices: sameDataRun.resource_prices,
           location: sameDataRun.location,
         }),
         factories.learningResources.run({
-          start_date: sameDataRun.start_date,
           delivery: sameDataRun.delivery,
           resource_prices: sameDataRun.resource_prices,
           location: sameDataRun.location,

--- a/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
@@ -42,6 +42,7 @@ const resources = {
 }
 
 const sameDataRun = factories.learningResources.run({
+  start_date: new Date().toISOString().split("T")[0],
   delivery: [
     {
       code: DeliveryEnum.Online,
@@ -167,23 +168,28 @@ const courses = {
   multipleRuns: {
     sameData: makeResource({
       resource_type: ResourceTypeEnum.Course,
+      free: true,
       runs: [
         factories.learningResources.run({
+          start_date: sameDataRun.start_date,
           delivery: sameDataRun.delivery,
           resource_prices: sameDataRun.resource_prices,
           location: sameDataRun.location,
         }),
         factories.learningResources.run({
+          start_date: sameDataRun.start_date,
           delivery: sameDataRun.delivery,
           resource_prices: sameDataRun.resource_prices,
           location: sameDataRun.location,
         }),
         factories.learningResources.run({
+          start_date: sameDataRun.start_date,
           delivery: sameDataRun.delivery,
           resource_prices: sameDataRun.resource_prices,
           location: sameDataRun.location,
         }),
         factories.learningResources.run({
+          start_date: sameDataRun.start_date,
           delivery: sameDataRun.delivery,
           resource_prices: sameDataRun.resource_prices,
           location: sameDataRun.location,

--- a/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
@@ -1,8 +1,9 @@
 import React from "react"
 import styled from "@emotion/styled"
 import { theme } from "../ThemeProvider/ThemeProvider"
-import { LearningResource, LearningResourcePrice } from "api"
+import { LearningResource } from "api"
 import {
+  allRunsAreIdentical,
   formatRunDate,
   getDisplayPrice,
   getRunPrices,
@@ -63,41 +64,8 @@ const DifferingRunLocation = styled(DifferingRunData)({
 const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
   resource,
 }) => {
-  if (!resource.runs) {
-    return null
-  }
-  if (resource.runs.length === 1) {
-    return null
-  }
   const asTaughtIn = resource ? showStartAnytime(resource) : false
-  const prices: LearningResourcePrice[] = []
-  const deliveryMethods = []
-  const locations = []
-  for (const run of resource.runs) {
-    if (run.resource_prices) {
-      run.resource_prices.forEach((price) => {
-        if (price.amount !== "0") {
-          prices.push(price)
-        }
-      })
-    }
-    if (run.delivery) {
-      deliveryMethods.push(run.delivery)
-    }
-    if (run.location) {
-      locations.push(run.location)
-    }
-  }
-  const distinctPrices = [...new Set(prices.map((p) => p.amount).flat())]
-  const distinctDeliveryMethods = [
-    ...new Set(deliveryMethods.flat().map((dm) => dm?.code)),
-  ]
-  const distinctLocations = [...new Set(locations.flat().map((l) => l))]
-  if (
-    distinctPrices.length > 1 ||
-    distinctDeliveryMethods.length > 1 ||
-    distinctLocations.length > 1
-  ) {
+  if (allRunsAreIdentical(resource)) {
     return (
       <DifferingRuns data-testid="differing-runs-table">
         <DifferingRunHeader>
@@ -105,7 +73,7 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
           <DifferingRunLabel>Price</DifferingRunLabel>
           <DifferingRunLabel>Format</DifferingRunLabel>
         </DifferingRunHeader>
-        {resource.runs.map((run, index) => (
+        {resource.runs?.map((run, index) => (
           <DifferingRun key={index}>
             <DifferingRunData>
               {formatRunDate(run, asTaughtIn)}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
@@ -65,7 +65,7 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
   resource,
 }) => {
   const asTaughtIn = resource ? showStartAnytime(resource) : false
-  if (allRunsAreIdentical(resource)) {
+  if (!allRunsAreIdentical(resource)) {
     return (
       <DifferingRuns data-testid="differing-runs-table">
         <DifferingRunHeader>

--- a/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
@@ -34,7 +34,6 @@ const DifferingRunHeader = styled.div({
   display: "flex",
   alignSelf: "stretch",
   alignItems: "center",
-  flex: "1 0 0",
   gap: "16px",
   padding: "12px",
   color: theme.custom.colors.darkGray2,
@@ -44,16 +43,45 @@ const DifferingRunHeader = styled.div({
 
 const DifferingRunData = styled.div({
   display: "flex",
-  flexShrink: 0,
-  flex: "1 0 0",
   color: theme.custom.colors.darkGray2,
   ...theme.typography.body3,
 })
 
 const DifferingRunLabel = styled.strong({
   display: "flex",
-  flex: "1 0 0",
 })
+
+const dateColumnStyle = {
+  width: "130px",
+  [theme.breakpoints.down("sm")]: {
+    width: "auto",
+    flex: "2 0 0",
+  },
+}
+
+const priceColumnStyle = {
+  width: "110px",
+  [theme.breakpoints.down("sm")]: {
+    width: "auto",
+    flex: "1 0 0",
+  },
+}
+
+const formatStyle = {
+  flex: "1 0 0",
+}
+
+const DateLabel = styled(DifferingRunLabel)(dateColumnStyle)
+
+const PriceLabel = styled(DifferingRunLabel)(priceColumnStyle)
+
+const FormatLabel = styled(DifferingRunLabel)(formatStyle)
+
+const DateData = styled(DifferingRunData)(dateColumnStyle)
+
+const PriceData = styled(DifferingRunData)(priceColumnStyle)
+
+const FormatData = styled(DifferingRunData)(formatStyle)
 
 const DifferingRunLocation = styled(DifferingRunData)({
   flex: "1 0 100%",
@@ -69,24 +97,22 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
     return (
       <DifferingRuns data-testid="differing-runs-table">
         <DifferingRunHeader>
-          <DifferingRunLabel>Date</DifferingRunLabel>
-          <DifferingRunLabel>Price</DifferingRunLabel>
-          <DifferingRunLabel>Format</DifferingRunLabel>
+          <DateLabel>Date</DateLabel>
+          <PriceLabel>Price</PriceLabel>
+          <FormatLabel>Format</FormatLabel>
         </DifferingRunHeader>
         {resource.runs?.map((run, index) => (
           <DifferingRun key={index}>
-            <DifferingRunData>
-              {formatRunDate(run, asTaughtIn)}
-            </DifferingRunData>
+            <DateData>{formatRunDate(run, asTaughtIn)}</DateData>
             {run.resource_prices && (
-              <DifferingRunData>
+              <PriceData>
                 <span>{getDisplayPrice(getRunPrices(run)["course"])}</span>
-              </DifferingRunData>
+              </PriceData>
             )}
             {run.delivery && (
-              <DifferingRunData>
+              <FormatData>
                 <span>{run.delivery?.map((dm) => dm?.name).join(", ")}</span>
-              </DifferingRunData>
+              </FormatData>
             )}
             {run.delivery.filter((d) => d.code === "in_person").length > 0 &&
               run.location && (

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.test.tsx
@@ -158,6 +158,15 @@ describe("Learning resource info section start date", () => {
     })
   })
 
+  test("If data is different, dates are not shown", () => {
+    const course = courses.multipleRuns.differentData
+    render(<InfoSectionV2 resource={course} />, {
+      wrapper: ThemeProvider,
+    })
+    const section = screen.getByTestId("drawer-info-items")
+    expect(within(section).queryByText("Start Date:")).toBeNull()
+  })
+
   test("Clicking the show more button should show more dates", async () => {
     const course = courses.multipleRuns.sameData
     const totalRuns = course.runs?.length ? course.runs.length : 0

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.test.tsx
@@ -146,7 +146,7 @@ describe("Learning resource info section start date", () => {
       })
       .map((run) => formatRunDate(run, false))
       .slice(0, 2)
-      .join(SEPARATOR)}${SEPARATOR}Show more`
+      .join(SEPARATOR)}Show more`
     invariant(expectedDateText)
     render(<InfoSectionV2 resource={course} />, {
       wrapper: ThemeProvider,

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -89,7 +89,7 @@ const InfoValue = styled.div({
   ...theme.typography.body3,
 })
 
-const DateWrapper = styled.span({
+const NoWrap = styled.span({
   whiteSpace: "nowrap",
 })
 
@@ -170,38 +170,40 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
   const showMore = allRunsAreIdentical(resource) && sortedDates.length > 2
   if (showMore) {
     const showMoreLink = (
-      <ShowMoreLink
-        color="red"
-        size="small"
-        onClick={() => setShowingMore(!showingMore)}
-      >
-        {showingMore ? "Show less" : "Show more"}
-      </ShowMoreLink>
+      <NoWrap>
+        <ShowMoreLink
+          color="red"
+          size="small"
+          onClick={() => setShowingMore(!showingMore)}
+        >
+          {showingMore ? "Show less" : "Show more"}
+        </ShowMoreLink>
+      </NoWrap>
     )
     return (
       <span data-testid="drawer-run-dates">
         {sortedDates.slice(0, 2).map((runDate, index) => {
           return (
-            <DateWrapper key={`run-${index}`}>
+            <NoWrap key={`run-${index}`}>
               <InfoItemValue
                 label={runDate}
                 index={index}
                 total={showingMore ? 3 : 2}
               />
-            </DateWrapper>
+            </NoWrap>
           )
         })}
         {!showingMore && showMoreLink}
         {showingMore &&
           sortedDates.slice(2).map((runDate, index) => {
             return (
-              <DateWrapper key={`run-${index + 2}`}>
+              <NoWrap key={`run-${index + 2}`}>
                 <InfoItemValue
                   label={runDate}
                   index={index}
                   total={sortedDates.length - 2}
                 />
-              </DateWrapper>
+              </NoWrap>
             )
           })}
         {showingMore && showMoreLink}
@@ -211,13 +213,13 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
     const runDates =
       sortedDates.map((runDate, index) => {
         return (
-          <DateWrapper key={`run-${index}`}>
+          <NoWrap key={`run-${index}`}>
             <InfoItemValue
               label={runDate}
               index={index}
               total={sortedDates.length}
             />
-          </DateWrapper>
+          </NoWrap>
         )
       }) ?? []
     return <span data-testid="drawer-run-dates">{runDates}</span>

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -174,16 +174,16 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
       .map((run) => formatRunDate(run, asTaughtIn)) ?? []
   const showMore = sortedDates.length > 2
   if (showMore) {
-    const LinkType = showingMore ? ShowLessLink : ShowMoreLink
+    const ShowHideLink = showingMore ? ShowLessLink : ShowMoreLink
     const showMoreLink = (
       <NoWrap>
-        <LinkType
+        <ShowHideLink
           color="red"
           size="small"
           onClick={() => setShowingMore(!showingMore)}
         >
           {showingMore ? "Show less" : "Show more"}
-        </LinkType>
+        </ShowHideLink>
       </NoWrap>
     )
     return (

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -187,7 +187,6 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
     )
     const showLessLink = (
       <NoWrap>
-        <br />
         <ShowLessLink
           color="red"
           size="small"

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -89,6 +89,10 @@ const InfoValue = styled.div({
   ...theme.typography.body3,
 })
 
+const DateWrapper = styled.span({
+  whiteSpace: "nowrap",
+})
+
 const ShowMoreLink = styled(Link)({
   paddingLeft: "12px",
 })
@@ -178,24 +182,26 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
       <span data-testid="drawer-run-dates">
         {sortedDates.slice(0, 2).map((runDate, index) => {
           return (
-            <InfoItemValue
-              key={`run-${index}`}
-              label={runDate}
-              index={index}
-              total={showingMore ? 3 : 2}
-            />
+            <DateWrapper key={`run-${index}`}>
+              <InfoItemValue
+                label={runDate}
+                index={index}
+                total={showingMore ? 3 : 2}
+              />
+            </DateWrapper>
           )
         })}
         {!showingMore && showMoreLink}
         {showingMore &&
           sortedDates.slice(2).map((runDate, index) => {
             return (
-              <InfoItemValue
-                key={`run-${index}`}
-                label={runDate}
-                index={index}
-                total={sortedDates.length - 2}
-              />
+              <DateWrapper key={`run-${index + 2}`}>
+                <InfoItemValue
+                  label={runDate}
+                  index={index}
+                  total={sortedDates.length - 2}
+                />
+              </DateWrapper>
             )
           })}
         {showingMore && showMoreLink}
@@ -205,12 +211,13 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
     const runDates =
       sortedDates.map((runDate, index) => {
         return (
-          <InfoItemValue
-            key={`run-${index}`}
-            label={runDate}
-            index={index}
-            total={sortedDates.length}
-          />
+          <DateWrapper key={`run-${index}`}>
+            <InfoItemValue
+              label={runDate}
+              index={index}
+              total={sortedDates.length}
+            />
+          </DateWrapper>
         )
       }) ?? []
     return <span data-testid="drawer-run-dates">{runDates}</span>

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -89,6 +89,10 @@ const InfoValue = styled.div({
   ...theme.typography.body3,
 })
 
+const ShowMoreLink = styled(Link)({
+  paddingLeft: "12px",
+})
+
 const PriceDisplay = styled.div({
   display: "flex",
   alignItems: "center",
@@ -162,13 +166,13 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
   const showMore = allRunsAreIdentical(resource) && sortedDates.length > 2
   if (showMore) {
     const showMoreLink = (
-      <Link
+      <ShowMoreLink
         color="red"
         size="small"
         onClick={() => setShowingMore(!showingMore)}
       >
         {showingMore ? "Show less" : "Show more"}
-      </Link>
+      </ShowMoreLink>
     )
     return (
       <span data-testid="drawer-run-dates">
@@ -178,7 +182,7 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
               key={`run-${index}`}
               label={runDate}
               index={index}
-              total={sortedDates.length}
+              total={showingMore ? 3 : 2}
             />
           )
         })}
@@ -190,7 +194,7 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
                 key={`run-${index}`}
                 label={runDate}
                 index={index}
-                total={sortedDates.length}
+                total={sortedDates.length - 2}
               />
             )
           })}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -174,26 +174,16 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
       .map((run) => formatRunDate(run, asTaughtIn)) ?? []
   const showMore = sortedDates.length > 2
   if (showMore) {
+    const LinkType = showingMore ? ShowLessLink : ShowMoreLink
     const showMoreLink = (
       <NoWrap>
-        <ShowMoreLink
+        <LinkType
           color="red"
           size="small"
           onClick={() => setShowingMore(!showingMore)}
         >
           {showingMore ? "Show less" : "Show more"}
-        </ShowMoreLink>
-      </NoWrap>
-    )
-    const showLessLink = (
-      <NoWrap>
-        <ShowLessLink
-          color="red"
-          size="small"
-          onClick={() => setShowingMore(!showingMore)}
-        >
-          Show less
-        </ShowLessLink>
+        </LinkType>
       </NoWrap>
     )
     return (
@@ -222,7 +212,7 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
               </NoWrap>
             )
           })}
-        {showingMore && showLessLink}
+        {showingMore && showMoreLink}
       </span>
     )
   } else {

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -240,7 +240,9 @@ const INFO_ITEMS: InfoItemConfig = [
     },
     Icon: RiCalendarLine,
     selector: (resource: LearningResource) => {
-      if (allRunsAreIdentical(resource)) {
+      const totalDatesWithRuns =
+        resource.runs?.filter((run) => run.start_date !== null).length || 0
+      if (allRunsAreIdentical(resource) && totalDatesWithRuns > 0) {
         return <RunDates resource={resource} />
       } else return null
     },

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -97,6 +97,11 @@ const ShowMoreLink = styled(Link)({
   paddingLeft: "12px",
 })
 
+const ShowLessLink = styled(Link)({
+  display: "flex",
+  paddingTop: "8px",
+})
+
 const PriceDisplay = styled.div({
   display: "flex",
   alignItems: "center",
@@ -180,6 +185,18 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
         </ShowMoreLink>
       </NoWrap>
     )
+    const showLessLink = (
+      <NoWrap>
+        <br />
+        <ShowLessLink
+          color="red"
+          size="small"
+          onClick={() => setShowingMore(!showingMore)}
+        >
+          Show less
+        </ShowLessLink>
+      </NoWrap>
+    )
     return (
       <span data-testid="drawer-run-dates">
         {sortedDates.slice(0, 2).map((runDate, index) => {
@@ -206,7 +223,7 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
               </NoWrap>
             )
           })}
-        {showingMore && showMoreLink}
+        {showingMore && showLessLink}
       </span>
     )
   } else {

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -99,7 +99,7 @@ const ShowMoreLink = styled(Link)({
 
 const ShowLessLink = styled(Link)({
   display: "flex",
-  paddingTop: "8px",
+  paddingTop: "4px",
 })
 
 const PriceDisplay = styled.div({

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -167,7 +167,7 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
         return 0
       })
       .map((run) => formatRunDate(run, asTaughtIn)) ?? []
-  const showMore = allRunsAreIdentical(resource) && sortedDates.length > 2
+  const showMore = sortedDates.length > 2
   if (showMore) {
     const showMoreLink = (
       <NoWrap>
@@ -235,7 +235,9 @@ const INFO_ITEMS: InfoItemConfig = [
     },
     Icon: RiCalendarLine,
     selector: (resource: LearningResource) => {
-      return <RunDates resource={resource} />
+      if (allRunsAreIdentical(resource)) {
+        return <RunDates resource={resource} />
+      } else return null
     },
   },
   {
@@ -450,9 +452,11 @@ const InfoSectionV2 = ({ resource }: { resource?: LearningResource }) => {
     <>
       <DifferingRunsTable resource={resource} />
       <InfoItems data-testid="drawer-info-items">
-        {infoItems.map((props, index) => (
-          <InfoItem key={index} {...props} />
-        ))}
+        {infoItems
+          .filter((props) => props.value !== null)
+          .map((props, index) => (
+            <InfoItem key={index} {...props} />
+          ))}
       </InfoItems>
     </>
   )

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -163,16 +163,16 @@ const InfoItemValue: React.FC<InfoItemValueProps> = ({
 const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
   const [showingMore, setShowingMore] = useState(false)
   const asTaughtIn = showStartAnytime(resource)
-  const sortedDates =
-    resource.runs
-      ?.sort((a, b) => {
-        if (a?.start_date && b?.start_date) {
-          return Date.parse(a.start_date) - Date.parse(b.start_date)
-        }
-        return 0
-      })
-      .map((run) => formatRunDate(run, asTaughtIn)) ?? []
-  const showMore = sortedDates.length > 2
+  const sortedDates = resource.runs
+    ?.sort((a, b) => {
+      if (a?.start_date && b?.start_date) {
+        return Date.parse(a.start_date) - Date.parse(b.start_date)
+      }
+      return 0
+    })
+    .map((run) => formatRunDate(run, asTaughtIn))
+  const totalDates = sortedDates?.length || 0
+  const showMore = totalDates > 2
   if (showMore) {
     const ShowHideLink = showingMore ? ShowLessLink : ShowMoreLink
     const showMoreLink = (
@@ -188,7 +188,7 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
     )
     return (
       <span data-testid="drawer-run-dates">
-        {sortedDates.slice(0, 2).map((runDate, index) => {
+        {sortedDates?.slice(0, 2).map((runDate, index) => {
           return (
             <NoWrap key={`run-${index}`}>
               <InfoItemValue
@@ -201,7 +201,7 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
         })}
         {!showingMore && showMoreLink}
         {showingMore &&
-          sortedDates.slice(2).map((runDate, index) => {
+          sortedDates?.slice(2).map((runDate, index) => {
             return (
               <NoWrap key={`run-${index + 2}`}>
                 <InfoItemValue
@@ -216,18 +216,17 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
       </span>
     )
   } else {
-    const runDates =
-      sortedDates.map((runDate, index) => {
-        return (
-          <NoWrap key={`run-${index}`}>
-            <InfoItemValue
-              label={runDate}
-              index={index}
-              total={sortedDates.length}
-            />
-          </NoWrap>
-        )
-      }) ?? []
+    const runDates = sortedDates?.map((runDate, index) => {
+      return (
+        <NoWrap key={`run-${index}`}>
+          <InfoItemValue
+            label={runDate}
+            index={index}
+            total={sortedDates.length}
+          />
+        </NoWrap>
+      )
+    })
     return <span data-testid="drawer-run-dates">{runDates}</span>
   }
 }

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -78,15 +78,15 @@ const RightContainer = styled.div({
   },
 })
 
-const ImageContainer = styled.div<{ aspect: number }>((props) => ({
+const ImageContainer = styled.div({
   width: "100%",
-  aspectRatio: `${props.aspect}`,
-}))
+})
 
-const Image = styled(NextImage)`
+const Image = styled(NextImage)<{ aspect: number }>`
   position: relative !important;
   border-radius: 8px;
   width: 100%;
+  aspect-ratio: ${({ aspect }) => aspect};
   object-fit: cover;
   z-index: -1;
 `
@@ -244,20 +244,22 @@ const ImageSection: React.FC<{
     )
   } else if (resource?.image) {
     return (
-      <ImageContainer aspect={aspect}>
+      <ImageContainer>
         <Image
           src={resource.image?.url ?? DEFAULT_RESOURCE_IMG}
           alt={resource?.image.alt ?? ""}
+          aspect={aspect}
           fill
         />
       </ImageContainer>
     )
   } else if (resource) {
     return (
-      <ImageContainer aspect={aspect}>
+      <ImageContainer>
         <Image
           src={DEFAULT_RESOURCE_IMG}
           alt={resource.image?.alt ?? ""}
+          aspect={aspect}
           fill
         />
       </ImageContainer>

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -78,18 +78,18 @@ const RightContainer = styled.div({
   },
 })
 
-const ImageContainer = styled.div<{ aspect: number }>`
-  position: relative;
-  width: 100%;
-  padding-bottom: ${({ aspect }) => 100 / aspect}%;
-`
-
-const Image = styled(NextImage)({
-  borderRadius: "8px",
+const ImageContainer = styled.div<{ aspect: number }>((props) => ({
   width: "100%",
-  objectFit: "cover",
-  zIndex: -1,
-})
+  aspectRatio: `${props.aspect}`,
+}))
+
+const Image = styled(NextImage)`
+  position: relative !important;
+  border-radius: 8px;
+  width: 100%;
+  object-fit: cover;
+  z-index: -1;
+`
 
 const SkeletonImage = styled(Skeleton)<{ aspect: number }>((aspect) => ({
   borderRadius: "8px",

--- a/frontends/ol-utilities/src/learning-resources/learning-resources.test.ts
+++ b/frontends/ol-utilities/src/learning-resources/learning-resources.test.ts
@@ -97,7 +97,6 @@ describe("allRunsAreIdentical", () => {
 
   test("returns true if all runs are identical", () => {
     const resource = factories.learningResources.resource()
-    const startDate = new Date().toISOString().split("T")[0]
     const prices = [{ amount: "100", currency: "USD" }]
     const delivery = [
       { code: CourseResourceDeliveryInnerCodeEnum.InPerson, name: "In person" },
@@ -105,19 +104,16 @@ describe("allRunsAreIdentical", () => {
     const location = "New York"
     resource.runs = [
       makeRun({
-        start_date: startDate,
         resource_prices: prices,
         delivery: delivery,
         location: location,
       }),
       makeRun({
-        start_date: startDate,
         resource_prices: prices,
         delivery: delivery,
         location: location,
       }),
       makeRun({
-        start_date: startDate,
         resource_prices: prices,
         delivery: delivery,
         location: location,

--- a/frontends/ol-utilities/src/learning-resources/learning-resources.test.ts
+++ b/frontends/ol-utilities/src/learning-resources/learning-resources.test.ts
@@ -1,6 +1,7 @@
-import { findBestRun } from "./learning-resources"
+import { allRunsAreIdentical, findBestRun } from "./learning-resources"
 import * as factories from "api/test-utils/factories"
 import { faker } from "@faker-js/faker/locale/en"
+import { CourseResourceDeliveryInnerCodeEnum } from "api"
 
 const makeRun = factories.learningResources.run
 const fromNow = (days: number): string => {
@@ -78,5 +79,129 @@ describe("findBestRun", () => {
     const expected = undated
     const actual = findBestRun(shuffle(runs))
     expect(actual).toEqual(expected)
+  })
+})
+
+describe("allRunsAreIdentical", () => {
+  test("returns false if no runs", () => {
+    const resource = factories.learningResources.resource()
+    resource.runs = []
+    expect(allRunsAreIdentical(resource)).toBe(false)
+  })
+
+  test("returns false if only one run", () => {
+    const resource = factories.learningResources.resource()
+    resource.runs = [makeRun()]
+    expect(allRunsAreIdentical(resource)).toBe(false)
+  })
+
+  test("returns true if all runs are identical", () => {
+    const resource = factories.learningResources.resource()
+    const prices = [{ amount: "100", currency: "USD" }]
+    const delivery = [
+      { code: CourseResourceDeliveryInnerCodeEnum.InPerson, name: "In person" },
+    ]
+    const location = "New York"
+    resource.runs = [
+      makeRun({
+        resource_prices: prices,
+        delivery: delivery,
+        location: location,
+      }),
+      makeRun({
+        resource_prices: prices,
+        delivery: delivery,
+        location: location,
+      }),
+      makeRun({
+        resource_prices: prices,
+        delivery: delivery,
+        location: location,
+      }),
+    ]
+    expect(allRunsAreIdentical(resource)).toBe(true)
+  })
+
+  test("returns false if prices differ", () => {
+    const resource = factories.learningResources.resource()
+    const prices = [{ amount: "100", currency: "USD" }]
+    const delivery = [
+      { code: CourseResourceDeliveryInnerCodeEnum.InPerson, name: "In person" },
+    ]
+    const location = "New York"
+    resource.runs = [
+      makeRun({
+        resource_prices: prices,
+        delivery: delivery,
+        location: location,
+      }),
+      makeRun({
+        resource_prices: prices,
+        delivery: delivery,
+        location: location,
+      }),
+      makeRun({
+        resource_prices: [{ amount: "150", currency: "USD" }],
+        delivery: delivery,
+        location: location,
+      }),
+    ]
+    expect(allRunsAreIdentical(resource)).toBe(false)
+  })
+
+  test("returns false if delivery methods differ", () => {
+    const resource = factories.learningResources.resource()
+    const prices = [{ amount: "100", currency: "USD" }]
+    const delivery = [
+      { code: CourseResourceDeliveryInnerCodeEnum.InPerson, name: "In person" },
+    ]
+    const location = "New York"
+    resource.runs = [
+      makeRun({
+        resource_prices: prices,
+        delivery: delivery,
+        location: location,
+      }),
+      makeRun({
+        resource_prices: prices,
+        delivery: delivery,
+        location: location,
+      }),
+      makeRun({
+        resource_prices: prices,
+        delivery: [
+          { code: CourseResourceDeliveryInnerCodeEnum.Online, name: "Online" },
+        ],
+        location: location,
+      }),
+    ]
+    expect(allRunsAreIdentical(resource)).toBe(false)
+  })
+
+  test("returns false if locations differ", () => {
+    const resource = factories.learningResources.resource()
+    const prices = [{ amount: "100", currency: "USD" }]
+    const delivery = [
+      { code: CourseResourceDeliveryInnerCodeEnum.InPerson, name: "In person" },
+    ]
+    const location = "New York"
+    resource.runs = [
+      makeRun({
+        resource_prices: prices,
+        delivery: delivery,
+        location: location,
+      }),
+      makeRun({
+        resource_prices: prices,
+        delivery: delivery,
+        location: location,
+      }),
+      makeRun({
+        resource_prices: prices,
+        delivery: delivery,
+        location: "San Francisco",
+      }),
+    ]
+    expect(allRunsAreIdentical(resource)).toBe(false)
   })
 })

--- a/frontends/ol-utilities/src/learning-resources/learning-resources.test.ts
+++ b/frontends/ol-utilities/src/learning-resources/learning-resources.test.ts
@@ -97,6 +97,7 @@ describe("allRunsAreIdentical", () => {
 
   test("returns true if all runs are identical", () => {
     const resource = factories.learningResources.resource()
+    const startDate = new Date().toISOString().split("T")[0]
     const prices = [{ amount: "100", currency: "USD" }]
     const delivery = [
       { code: CourseResourceDeliveryInnerCodeEnum.InPerson, name: "In person" },
@@ -104,16 +105,19 @@ describe("allRunsAreIdentical", () => {
     const location = "New York"
     resource.runs = [
       makeRun({
+        start_date: startDate,
         resource_prices: prices,
         delivery: delivery,
         location: location,
       }),
       makeRun({
+        start_date: startDate,
         resource_prices: prices,
         delivery: delivery,
         location: location,
       }),
       makeRun({
+        start_date: startDate,
         resource_prices: prices,
         delivery: delivery,
         location: location,

--- a/frontends/ol-utilities/src/learning-resources/learning-resources.test.ts
+++ b/frontends/ol-utilities/src/learning-resources/learning-resources.test.ts
@@ -83,16 +83,16 @@ describe("findBestRun", () => {
 })
 
 describe("allRunsAreIdentical", () => {
-  test("returns false if no runs", () => {
+  test("returns true if no runs", () => {
     const resource = factories.learningResources.resource()
     resource.runs = []
-    expect(allRunsAreIdentical(resource)).toBe(false)
+    expect(allRunsAreIdentical(resource)).toBe(true)
   })
 
-  test("returns false if only one run", () => {
+  test("returns true if only one run", () => {
     const resource = factories.learningResources.resource()
     resource.runs = [makeRun()]
-    expect(allRunsAreIdentical(resource)).toBe(false)
+    expect(allRunsAreIdentical(resource)).toBe(true)
   })
 
   test("returns true if all runs are identical", () => {

--- a/frontends/ol-utilities/src/learning-resources/learning-resources.ts
+++ b/frontends/ol-utilities/src/learning-resources/learning-resources.ts
@@ -4,7 +4,7 @@ import type {
   LearningResourcePrice,
   LearningResourceRun,
 } from "api"
-import { ResourceTypeEnum } from "api"
+import { DeliveryEnum, ResourceTypeEnum } from "api"
 import { capitalize } from "lodash"
 import { formatDate } from "../date/format"
 
@@ -128,10 +128,10 @@ const formatRunDate = (
  */
 const allRunsAreIdentical = (resource: LearningResource) => {
   if (!resource.runs) {
-    return false
+    return true
   }
-  if (resource.runs.length === 1) {
-    return false
+  if (resource.runs.length <= 1) {
+    return true
   }
   const prices: LearningResourcePrice[] = []
   const deliveryMethods = []
@@ -155,11 +155,14 @@ const allRunsAreIdentical = (resource: LearningResource) => {
   const distinctDeliveryMethods = [
     ...new Set(deliveryMethods.flat().map((dm) => dm?.code)),
   ]
+  const hasInPerson = distinctDeliveryMethods.includes(DeliveryEnum.InPerson)
   const distinctLocations = [...new Set(locations.flat().map((l) => l))]
   return (
     distinctPrices.length === 1 &&
     distinctDeliveryMethods.length === 1 &&
-    distinctLocations.length === 1
+    (hasInPerson
+      ? distinctLocations.length === 1
+      : distinctLocations.length === 0)
   )
 }
 

--- a/frontends/ol-utilities/src/learning-resources/learning-resources.ts
+++ b/frontends/ol-utilities/src/learning-resources/learning-resources.ts
@@ -1,5 +1,9 @@
 import moment from "moment"
-import type { LearningResource, LearningResourceRun } from "api"
+import type {
+  LearningResource,
+  LearningResourcePrice,
+  LearningResourceRun,
+} from "api"
 import { ResourceTypeEnum } from "api"
 import { capitalize } from "lodash"
 import { formatDate } from "../date/format"
@@ -116,6 +120,49 @@ const formatRunDate = (
   return null
 }
 
+/**
+ * Checks if all runs of a given learning resource are identical in terms of price, delivery method, and location.
+ *
+ * @param resource - The learning resource to check.
+ * @returns `true` if all runs have the same price, delivery method, and location; otherwise, `false`.
+ */
+const allRunsAreIdentical = (resource: LearningResource) => {
+  if (!resource.runs) {
+    return false
+  }
+  if (resource.runs.length === 1) {
+    return false
+  }
+  const prices: LearningResourcePrice[] = []
+  const deliveryMethods = []
+  const locations = []
+  for (const run of resource.runs) {
+    if (run.resource_prices) {
+      run.resource_prices.forEach((price) => {
+        if (price.amount !== "0") {
+          prices.push(price)
+        }
+      })
+    }
+    if (run.delivery) {
+      deliveryMethods.push(run.delivery)
+    }
+    if (run.location) {
+      locations.push(run.location)
+    }
+  }
+  const distinctPrices = [...new Set(prices.map((p) => p.amount).flat())]
+  const distinctDeliveryMethods = [
+    ...new Set(deliveryMethods.flat().map((dm) => dm?.code)),
+  ]
+  const distinctLocations = [...new Set(locations.flat().map((l) => l))]
+  return (
+    distinctPrices.length === 1 &&
+    distinctDeliveryMethods.length === 1 &&
+    distinctLocations.length === 1
+  )
+}
+
 export {
   DEFAULT_RESOURCE_IMG,
   embedlyCroppedImage,
@@ -123,5 +170,6 @@ export {
   getReadableResourceType,
   findBestRun,
   formatRunDate,
+  allRunsAreIdentical,
 }
 export type { EmbedlyConfig }

--- a/frontends/ol-utilities/src/learning-resources/learning-resources.ts
+++ b/frontends/ol-utilities/src/learning-resources/learning-resources.ts
@@ -129,15 +129,11 @@ const allRunsAreIdentical = (resource: LearningResource) => {
   if (resource.runs.length <= 1) {
     return true
   }
-  const dates = new Set<string>()
   const amounts = new Set<string>()
   const currencies = new Set<string>()
   const deliveryMethods = new Set<string>()
   const locations = new Set<string>()
   for (const run of resource.runs) {
-    if (run.start_date) {
-      dates.add(run.start_date)
-    }
     if (run.resource_prices) {
       run.resource_prices.forEach((price) => {
         if (!(resource.free && price.amount === "0")) {
@@ -159,7 +155,6 @@ const allRunsAreIdentical = (resource: LearningResource) => {
     (dm) => dm === DeliveryEnum.InPerson,
   )
   return (
-    dates.size === 1 &&
     amounts.size === 1 &&
     currencies.size === 1 &&
     deliveryMethods.size === 1 &&


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5874

### Description (What does it do?)
This PR adds a "show more" link to the start dates section of the info displayed in the v2 learning resource drawer. This expands and collapses the start dates for the course.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/b488049a-6e6a-420e-a8ed-bd828d11e4a0)
![image](https://github.com/user-attachments/assets/78ae23af-f782-45c4-a5d7-721baaf628d0)
![image](https://github.com/user-attachments/assets/2af1dea2-768a-40de-ba21-7a18473db678)
![image](https://github.com/user-attachments/assets/e38deb2f-3e42-451c-87ae-64377778d3cb)

### How can this be tested?
 - If you have Posthog set up locally, enable the `lr_drawer_v2` flag
 - If you don't have Posthog set up locally, you can force `drawerV2` to be `true` in `LearningResourceDrawer.tsx`
 - Spin up this branch of `mit-learn`
 - Ensure you have sufficient data backpopulated into your local instance, especially Sloan courses
 - Search for a course with identical data but with multiple start dates, like "Artificial Intelligence in Pharma and Biotech" for example
 - Confirm that you can click "Show more" to expand the rest of the start dates, that the link text changes to "Show less" after it expands, and that you can click "Show less" to collapse back down
 - Search for a course with different data and multiple start dates, such as "Leading the AI-Driven Organization"
 - Confirm that all of the start dates are shown without the show more button