### PR TITLE
Add data-ph- elements to CTA buttons

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV1.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV1.test.tsx
@@ -104,6 +104,7 @@ describe("Learning Resource Expanded", () => {
         }) as HTMLAnchorElement
 
         expect(link.href).toMatch(new RegExp(`^${resource.url}/?$`))
+        expect(link.getAttribute("data-ph-action")).toBe("click-cta")
       }
     },
   )

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV1.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV1.tsx
@@ -244,6 +244,10 @@ const CallToActionSection = ({
       <StyledLink
         target="_blank"
         size="medium"
+        data-ph-action="click-cta"
+        data-ph-offered-by={offeredBy?.code}
+        data-ph-resource-type={resource.resource_type}
+        data-ph-resource-id={resource.id}
         endIcon={<RiExternalLinkLine />}
         href={getCallToActionUrl(resource) || ""}
       >

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.test.tsx
@@ -98,13 +98,14 @@ describe("Learning Resource Expanded", () => {
 
       setup(resource)
 
-      const linkName = "Learn More"
+      const linkName = "Learn More About"
       if (linkName) {
         const link = screen.getByRole("link", {
           name: linkName,
         }) as HTMLAnchorElement
 
         expect(link.href).toMatch(new RegExp(`^${resource.url}/?$`))
+        expect(link.getAttribute("data-ph-action")).toBe("click-cta")
       }
     },
   )

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.test.tsx
@@ -98,7 +98,7 @@ describe("Learning Resource Expanded", () => {
 
       setup(resource)
 
-      const linkName = "Learn More About"
+      const linkName = "Learn More"
       if (linkName) {
         const link = screen.getByRole("link", {
           name: linkName,

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -285,7 +285,7 @@ const getCallToActionText = (resource: LearningResource): string => {
   const accessCourseMaterials = "Access Course Materials"
   const watchOnYouTube = "Watch on YouTube"
   const listenToPodcast = "Listen to Podcast"
-  const learnMore = "Learn More About"
+  const learnMore = "Learn More"
   const callsToAction = {
     [ResourceTypeEnum.Course]: learnMore,
     [ResourceTypeEnum.Program]: learnMore,

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -285,7 +285,7 @@ const getCallToActionText = (resource: LearningResource): string => {
   const accessCourseMaterials = "Access Course Materials"
   const watchOnYouTube = "Watch on YouTube"
   const listenToPodcast = "Listen to Podcast"
-  const learnMore = "Learn More"
+  const learnMore = "Learn More About"
   const callsToAction = {
     [ResourceTypeEnum.Course]: learnMore,
     [ResourceTypeEnum.Program]: learnMore,
@@ -355,6 +355,10 @@ const CallToActionSection = ({
       <StyledLink
         target="_blank"
         size="medium"
+        data-ph-action="click-cta"
+        data-ph-offered-by={offeredBy?.code}
+        data-ph-resource-type={resource.resource_type}
+        data-ph-resource-id={resource.id}
         endIcon={<RiExternalLinkLine />}
         href={getCallToActionUrl(resource) || ""}
       >


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/5989

### Description (What does it do?)

We need a clear way to identify when users click on the CTA button in the Learning Resource drawer - this adds that, in the form of `data-ph-` attributes. 

The attributes that are added are:
- `data-ph-action` - set to `click-cta` (this is the standard PostHog attribute we decided on)
- `data-ph-offered-by` - set to the offeror code
- `data-ph-resource-type` - set to the resource type
- `data-ph-resource-id` - set to the resource ID

These are added to both the V1 and V2 LearningResourceExpanded components since the v2 one isn't rolled out yet.

### How can this be tested?

This does not handle video resources - videos will require more work (due to the CTA being the embedded video itself). So, choose resources that aren't videos. These will be handled in a future PR.

The easiest way to test this is to create an Action in PostHog's Data Management tab. Set up an Action that has one Match Group. The Match Group should be set to Autocapture and the "Element matches HTML selector" should be set to `[data-ph-action="click-cta"]`. 

Then, load some resources and click the CTA buttons in the drawers. You should see events match in the Action after some delay.
