### PR TITLE
[For Discussion] Assistanthub AI demo

### DIFF
--- a/frontends/main/src/app/layout.tsx
+++ b/frontends/main/src/app/layout.tsx
@@ -33,6 +33,23 @@ export default function RootLayout({
             <Footer />
           </PageWrapper>
         </Providers>
+        <div
+          dangerouslySetInnerHTML={{
+            __html: `<iframe
+          title="Einstein Assistant"
+          src="https://www.assistantshub.ai/embed/asst_t72CbOBs7RViy12ge9pFtwXY"
+          style="right: 0;
+                position: fixed;
+                overflow: hidden;
+                height: 100vh;
+                border: 0 none;
+                width: 480px;
+                bottom: -30px;"
+          allowFullScreen
+          allowTransparency
+        ></iframe>`,
+          }}
+        />
       </body>
       {process.env.NEXT_PUBLIC_APPZI_URL ? (
         <Script async src={process.env.NEXT_PUBLIC_APPZI_URL} />


### PR DESCRIPTION
### Description (What does it do?)
This PR adds one of the demo assistants from https://www.assistantshub.ai/ to all MIT Learn pages.

### Screenshots (if appropriate):

**Note:** The iframe has its full size even in first two pictures, so part of the screen is not clickable.

<img width="1274" alt="Screenshot 2024-11-14 at 4 41 30 PM" src="https://github.com/user-attachments/assets/a6a1367e-21e4-47e4-8da1-9e2d9f592007">
<img width="1406" alt="Screenshot 2024-11-14 at 4 41 16 PM" src="https://github.com/user-attachments/assets/f11c03d4-d62f-44e5-90d0-e9adc27b88f6">
<img width="1298" alt="Screenshot 2024-11-14 at 4 42 47 PM" src="https://github.com/user-attachments/assets/699f3a7a-3f46-47ca-837b-c858b1bc30c4">

