### PR TITLE
v2 learning resource drawer formats and location

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
@@ -261,6 +261,43 @@ const courses = {
       ],
     }),
   },
+  multipleFormats: makeResource({
+    resource_type: ResourceTypeEnum.Course,
+    location: "Earth",
+    delivery: [
+      {
+        code: DeliveryEnum.Online,
+        name: DeliveryEnumDescriptions.online,
+      },
+      {
+        code: DeliveryEnum.InPerson,
+        name: DeliveryEnumDescriptions.in_person,
+      },
+    ],
+    runs: [
+      factories.learningResources.run({
+        delivery: sameDataRun.delivery,
+        resource_prices: sameDataRun.resource_prices,
+        location: sameDataRun.location,
+      }),
+    ],
+  }),
+  singleFormat: makeResource({
+    resource_type: ResourceTypeEnum.Course,
+    delivery: [
+      {
+        code: DeliveryEnum.Online,
+        name: DeliveryEnumDescriptions.online,
+      },
+    ],
+    runs: [
+      factories.learningResources.run({
+        delivery: sameDataRun.delivery,
+        resource_prices: sameDataRun.resource_prices,
+        location: sameDataRun.location,
+      }),
+    ],
+  }),
 }
 
 const resourceArgType = {

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.test.tsx
@@ -165,7 +165,7 @@ describe("Learning resource info section start date", () => {
     })
   })
 
-  test("If data is different, dates and prices are not shown", () => {
+  test("If data is different then dates, formats, locations and prices are not shown", () => {
     const course = courses.multipleRuns.differentData
     render(<InfoSectionV2 resource={course} />, {
       wrapper: ThemeProvider,
@@ -173,6 +173,8 @@ describe("Learning resource info section start date", () => {
     const section = screen.getByTestId("drawer-info-items")
     expect(within(section).queryByText("Start Date:")).toBeNull()
     expect(within(section).queryByText("Price:")).toBeNull()
+    expect(within(section).queryByText("Format:")).toBeNull()
+    expect(within(section).queryByText("Location:")).toBeNull()
   })
 
   test("Clicking the show more button should show more dates", async () => {
@@ -187,5 +189,36 @@ describe("Learning resource info section start date", () => {
     const showMoreLink = within(runDates).getByText("Show more")
     await user.click(showMoreLink)
     expect(runDates.children.length).toBe(totalRuns + 1)
+  })
+})
+
+describe("Learning resource info section format and location", () => {
+  test("Multiple formats", () => {
+    const course = courses.multipleFormats
+    render(<InfoSectionV2 resource={course} />, {
+      wrapper: ThemeProvider,
+    })
+
+    const section = screen.getByTestId("drawer-info-items")
+    within(section).getAllByText((_content, node) => {
+      // The pipe in this string is followed by a zero width space
+      return node?.textContent === "Format:Online|​In person" || false
+    })
+    within(section).getAllByText((_content, node) => {
+      return node?.textContent === "Location:Earth" || false
+    })
+  })
+
+  test("Single format", () => {
+    const course = courses.singleFormat
+    render(<InfoSectionV2 resource={course} />, {
+      wrapper: ThemeProvider,
+    })
+
+    const section = screen.getByTestId("drawer-info-items")
+    within(section).getAllByText((_content, node) => {
+      return node?.textContent === "Format:Online" || false
+    })
+    expect(within(section).queryByText("In person")).toBeNull()
   })
 })

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -238,7 +238,8 @@ const shouldShowFormat = (resource: LearningResource) => {
   return (
     (resource.resource_type === ResourceTypeEnum.Course ||
       resource.resource_type === ResourceTypeEnum.Program) &&
-    allRunsAreIdentical(resource)
+    allRunsAreIdentical(resource) &&
+    resource.delivery
   )
 }
 

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -284,8 +284,10 @@ const INFO_ITEMS: InfoItemConfig = [
     selector: (resource: LearningResource) => {
       if (
         shouldShowFormat(resource) &&
-        resource.delivery?.filter((d) => d.code === DeliveryEnum.InPerson)
-          .length > 0 &&
+        resource.delivery?.filter(
+          (d) =>
+            d.code === DeliveryEnum.InPerson || d.code === DeliveryEnum.Hybrid,
+        ).length > 0 &&
         resource.location
       ) {
         return <InfoItemValue label={resource.location} index={1} total={1} />

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -15,8 +15,9 @@ import {
   RiAwardFill,
   RiAwardLine,
   RiComputerLine,
+  RiMapPinLine,
 } from "@remixicon/react"
-import { LearningResource, ResourceTypeEnum } from "api"
+import { DeliveryEnum, LearningResource, ResourceTypeEnum } from "api"
 import {
   allRunsAreIdentical,
   formatDurationClockTime,
@@ -233,6 +234,14 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
   }
 }
 
+const shouldShowFormat = (resource: LearningResource) => {
+  return (
+    (resource.resource_type === ResourceTypeEnum.Course ||
+      resource.resource_type === ResourceTypeEnum.Program) &&
+    allRunsAreIdentical(resource)
+  )
+}
+
 const INFO_ITEMS: InfoItemConfig = [
   {
     label: (resource: LearningResource) => {
@@ -253,11 +262,7 @@ const INFO_ITEMS: InfoItemConfig = [
     label: "Format:",
     Icon: RiComputerLine,
     selector: (resource: LearningResource) => {
-      if (
-        (resource.resource_type === ResourceTypeEnum.Course ||
-          resource.resource_type === ResourceTypeEnum.Program) &&
-        allRunsAreIdentical(resource)
-      ) {
+      if (shouldShowFormat(resource)) {
         const totalFormats = resource.delivery?.length || 0
         return resource.delivery.map((format, index) => {
           return (
@@ -269,6 +274,20 @@ const INFO_ITEMS: InfoItemConfig = [
             />
           )
         })
+      } else return null
+    },
+  },
+  {
+    label: "Location:",
+    Icon: RiMapPinLine,
+    selector: (resource: LearningResource) => {
+      if (
+        shouldShowFormat(resource) &&
+        resource.delivery?.filter((d) => d.code === DeliveryEnum.InPerson)
+          .length > 0 &&
+        resource.location
+      ) {
+        return <InfoItemValue label={resource.location} index={1} total={1} />
       } else return null
     },
   },

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -14,6 +14,7 @@ import {
   RiPresentationLine,
   RiAwardFill,
   RiAwardLine,
+  RiComputerLine,
 } from "@remixicon/react"
 import { LearningResource, ResourceTypeEnum } from "api"
 import {
@@ -245,6 +246,29 @@ const INFO_ITEMS: InfoItemConfig = [
         resource.runs?.filter((run) => run.start_date !== null).length || 0
       if (allRunsAreIdentical(resource) && totalDatesWithRuns > 0) {
         return <RunDates resource={resource} />
+      } else return null
+    },
+  },
+  {
+    label: "Format:",
+    Icon: RiComputerLine,
+    selector: (resource: LearningResource) => {
+      if (
+        (resource.resource_type === ResourceTypeEnum.Course ||
+          resource.resource_type === ResourceTypeEnum.Program) &&
+        allRunsAreIdentical(resource)
+      ) {
+        const totalFormats = resource.delivery?.length || 0
+        return resource.delivery.map((format, index) => {
+          return (
+            <InfoItemValue
+              key={`format-${index}`}
+              label={format.name}
+              index={index}
+              total={totalFormats}
+            />
+          )
+        })
       } else return null
     },
   },


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6019

### Description (What does it do?)
This PR displays the `format` and `location` properties of a course or program in the info section of the new drawer. If any of items in `location` contain `in_person`, then the `location` data is displayed. If differing runs are detected, neither of these are displayed. If `location` is unavailable for `in_person` courses then it is simply not shown.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/b4424278-03b2-45a8-87b9-a63a83f9324b)
![image](https://github.com/user-attachments/assets/601ebbfe-3206-4def-bcf6-de8d0226dbff)
![image](https://github.com/user-attachments/assets/7eadab87-a992-4403-b66b-a8af6dcb35af)
![image](https://github.com/user-attachments/assets/e43e4434-0f86-4de1-9438-87d0beed7726)

### How can this be tested?
 - If you have Posthog set up locally, enable the `lr_drawer_v2` flag
 - If you don't have Posthog set up locally, you can force `drawerV2` to be `true` in `LearningResourceDrawer.tsx`
 - Spin up this branch of `mit-learn`
 - Ensure you have the following courses in your database:
   - Leading the AI-Driven Organization
   - Communication and Persuasion in the Digital Age
 - Load the search page at http://localhost:8062/search
 - Search for "Leading the AI-Driven Organization"
 - Bring up the drawer and verify that "Format: In person" is shown with "Location: Cambridge, MA" below it
 - Close the drawer and search for Communication and Persuasion in the Digital Age
 - Bring up the drawer and verify that the differing runs table is shown, and the format and location info items are *not* shown
