### PR TITLE
separate starts and as taught in, show anytime availability

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
@@ -105,7 +105,12 @@ const courses = {
     }),
     anytime: makeResource({
       resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
+      runs: [
+        factories.learningResources.run({
+          year: 2022,
+          semester: "Spring",
+        }),
+      ],
       free: true,
       certification: false,
       prices: ["0"],

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.test.tsx
@@ -112,7 +112,7 @@ describe("Learning resource info section pricing", () => {
 })
 
 describe("Learning resource info section start date", () => {
-  test("Start date", () => {
+  test("Start date(s)", () => {
     const course = courses.free.dated
     const run = course.runs?.[0]
     invariant(run)
@@ -123,11 +123,11 @@ describe("Learning resource info section start date", () => {
     })
 
     const section = screen.getByTestId("drawer-info-items")
-    within(section).getByText("Start Date:")
+    within(section).getByText("Starts:")
     within(section).getByText(runDate)
   })
 
-  test("As taught in", () => {
+  test("As taught in date(s)", () => {
     const course = courses.free.anytime
     const run = course.runs?.[0]
     invariant(run)
@@ -138,8 +138,10 @@ describe("Learning resource info section start date", () => {
     })
 
     const section = screen.getByTestId("drawer-info-items")
-    within(section).getByText("As taught in:")
-    within(section).getByText(runDate)
+    const expectedDateText = `As taught in:${runDate}`
+    within(section).getAllByText((_content, node) => {
+      return node?.textContent === expectedDateText || false
+    })
   })
 
   test("Multiple run dates", () => {
@@ -171,7 +173,7 @@ describe("Learning resource info section start date", () => {
       wrapper: ThemeProvider,
     })
     const section = screen.getByTestId("drawer-info-items")
-    expect(within(section).queryByText("Start Date:")).toBeNull()
+    expect(within(section).queryByText("Starts:")).toBeNull()
     expect(within(section).queryByText("Price:")).toBeNull()
     expect(within(section).queryByText("Format:")).toBeNull()
     expect(within(section).queryByText("Location:")).toBeNull()

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -306,7 +306,7 @@ const INFO_ITEMS: InfoItemConfig = [
         resource.location
       ) {
         return <InfoItemValue label={resource.location} index={1} total={1} />
-      }
+      } else return null
     },
   },
   {

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -16,6 +16,7 @@ import {
   RiAwardLine,
   RiComputerLine,
   RiMapPinLine,
+  RiCalendarScheduleLine,
 } from "@remixicon/react"
 import { DeliveryEnum, LearningResource, ResourceTypeEnum } from "api"
 import {
@@ -164,9 +165,16 @@ const InfoItemValue: React.FC<InfoItemValueProps> = ({
   )
 }
 
+const totalRunsWithDates = (resource: LearningResource) => {
+  return (
+    resource.runs
+      ?.map((run) => formatRunDate(run, showStartAnytime(resource)))
+      .filter((date) => date !== null).length || 0
+  )
+}
+
 const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
   const [showingMore, setShowingMore] = useState(false)
-  const asTaughtIn = showStartAnytime(resource)
   const sortedDates = resource.runs
     ?.sort((a, b) => {
       if (a?.start_date && b?.start_date) {
@@ -174,7 +182,8 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
       }
       return 0
     })
-    .map((run) => formatRunDate(run, asTaughtIn))
+    .map((run) => formatRunDate(run, showStartAnytime(resource)))
+    .filter((date) => date !== null)
   const totalDates = sortedDates?.length || 0
   const showMore = totalDates > 2
   if (showMore) {
@@ -246,21 +255,22 @@ const shouldShowFormat = (resource: LearningResource) => {
 
 const INFO_ITEMS: InfoItemConfig = [
   {
-    label: (resource: LearningResource) => {
-      const asTaughtIn = resource ? showStartAnytime(resource) : false
-      const label = asTaughtIn ? "As taught in:" : "Start Date:"
-      return label
-    },
+    label: "Starts:",
     Icon: RiCalendarLine,
     selector: (resource: LearningResource) => {
-      const totalDatesWithRuns =
-        resource.runs?.filter((run) => run.start_date !== null).length || 0
-      if (allRunsAreIdentical(resource) && totalDatesWithRuns > 0) {
+      const anytime = showStartAnytime(resource)
+      if (
+        allRunsAreIdentical(resource) &&
+        totalRunsWithDates(resource) > 0 &&
+        !anytime
+      ) {
         return (
           <NoSSR>
             <RunDates resource={resource} />
           </NoSSR>
         )
+      } else if (anytime) {
+        return <InfoItemValue label="Anytime" index={1} total={1} />
       } else return null
     },
   },
@@ -296,7 +306,7 @@ const INFO_ITEMS: InfoItemConfig = [
         resource.location
       ) {
         return <InfoItemValue label={resource.location} index={1} total={1} />
-      } else return null
+      }
     },
   },
   {
@@ -341,6 +351,15 @@ const INFO_ITEMS: InfoItemConfig = [
           total={1}
         />
       ) : null
+    },
+  },
+  {
+    label: "As taught in:",
+    Icon: RiCalendarScheduleLine,
+    selector: (resource: LearningResource) => {
+      if (totalRunsWithDates(resource) > 0 && showStartAnytime(resource)) {
+        return <RunDates resource={resource} />
+      } else return null
     },
   },
   {


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6075

### Description (What does it do?)
This PR revises the logic surrounding dates. Previously, we were showing *either* the "Starts" or "As taught in" fields, based on the output of `shouldShowAnytime`. This function takes a `LearningResource` and returns `true` if its `availability` property is set to "anytime" and its `resource_type` is "course" or "program." Now, if `availability` is "anytime" then the "Starts" field will show "Anytime," otherwise it will show the start dates. The "As taught in" field also appears if `availability` is "anytime," but if no dates are returned from `totalRunsWithDates`, then it will be hidden.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/324fe2db-459c-439e-8acb-30626f2b3b14)
![image](https://github.com/user-attachments/assets/46cf4472-c1b3-4b89-985c-d125e862a0d3)

### How can this be tested?
 - If you have Posthog set up locally, enable the `lr_drawer_v2` flag
 - If you don't have Posthog set up locally, you can force `drawerV2` to be `true` in `LearningResourceDrawer.tsx`
 - Spin up this branch of `mit-learn`
 - Ensure you have sufficient data backpopulated into your local instance, including some OCW and Sloan courses
 - Go to the search page at http://localhost:8062/search and filter on OCW courses
 - Browse through the courses, clicking them to bring up the drawer
 - All OCW courses should have "Starts: Anytime" and if there is a year and semester available for the course, it should show under "As taught in"
 - Look for a Sloan course with "anytime" `availability`, such as "Generative AI Business Sprint"
 - Ensure that "Starts: Anytime" is shown, but "As taught in" does not