### PR TITLE
LocalDate and NoSSR components to render localized dates only on client

### DIFF
--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "PORT=${PORT:-8062} next dev",
+    "dev": "PORT=${PORT:-8062} TZ=UTC next dev",
     "build": "next build",
     "build:no-lint": "next build --no-lint",
-    "start": "next start",
+    "start": "TZ=UTC next start",
     "lint": "next lint"
   },
   "dependencies": {

--- a/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
+++ b/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
@@ -13,7 +13,7 @@ import {
   NewsEventsListFeedTypeEnum,
 } from "api/hooks/newsEvents"
 import type { NewsFeedItem, EventFeedItem } from "api/v0"
-import { formatDate } from "ol-utilities"
+import { LocalDate } from "ol-utilities"
 import { RiArrowRightSLine } from "@remixicon/react"
 import Link from "next/link"
 
@@ -196,7 +196,7 @@ const Story: React.FC<{ item: NewsFeedItem; mobile: boolean }> = ({
         {item.title}
       </Card.Title>
       <Card.Footer>
-        Published: {formatDate(item.news_details?.publish_date)}
+        Published: <LocalDate date={item.news_details?.publish_date} />
       </Card.Footer>
     </StoryCard>
   )
@@ -226,16 +226,16 @@ const NewsEventsSection: React.FC = () => {
       <Card.Content>
         <EventDate>
           <EventDay>
-            {formatDate(
-              (item as EventFeedItem).event_details?.event_datetime,
-              "D",
-            )}
+            <LocalDate
+              date={(item as EventFeedItem).event_details?.event_datetime}
+              format="D"
+            />
           </EventDay>
           <EventMonth>
-            {formatDate(
-              (item as EventFeedItem).event_details?.event_datetime,
-              "MMM",
-            )}
+            <LocalDate
+              date={(item as EventFeedItem).event_details?.event_datetime}
+              format="MMM"
+            />
           </EventMonth>
         </EventDate>
         <Link href={item.url} data-card-link>

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -9,7 +9,7 @@ import {
 } from "@remixicon/react"
 import { LearningResource } from "api"
 import {
-  formatDate,
+  LocalDate,
   getReadableResourceType,
   DEFAULT_RESOURCE_IMG,
   getLearningResourcePrices,
@@ -149,7 +149,8 @@ const StartDate: React.FC<{ resource: LearningResource; size?: Size }> = ({
   const format = size === "small" ? "MMM DD, YYYY" : "MMMM DD, YYYY"
   const formatted = anytime
     ? "Anytime"
-    : startDate && formatDate(startDate, format)
+    : startDate && <LocalDate date={startDate} format={format} />
+
   if (!formatted) return null
 
   const showLabel = size !== "small" || anytime

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -9,7 +9,7 @@ import {
 } from "@remixicon/react"
 import { ResourceTypeEnum, LearningResource } from "api"
 import {
-  formatDate,
+  LocalDate,
   getReadableResourceType,
   DEFAULT_RESOURCE_IMG,
   pluralize,
@@ -151,7 +151,7 @@ export const StartDate: React.FC<{ resource: LearningResource }> = ({
   const startDate = getResourceDate(resource)
   const formatted = anytime
     ? "Anytime"
-    : startDate && formatDate(startDate, "MMMM DD, YYYY")
+    : startDate && <LocalDate date={startDate} format="MMMM DD, YYYY" />
   if (!formatted) return null
 
   return (

--- a/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
@@ -8,6 +8,7 @@ import {
   getDisplayPrice,
   getRunPrices,
   showStartAnytime,
+  NoSSR,
 } from "ol-utilities"
 
 const DifferingRuns = styled.div({
@@ -103,7 +104,9 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
         </DifferingRunHeader>
         {resource.runs?.map((run, index) => (
           <DifferingRun key={index}>
-            <DateData>{formatRunDate(run, asTaughtIn)}</DateData>
+            <DateData>
+              <NoSSR>{formatRunDate(run, asTaughtIn)}</NoSSR>
+            </DateData>
             {run.resource_prices && (
               <PriceData>
                 <span>{getDisplayPrice(getRunPrices(run)["course"])}</span>

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -24,6 +24,7 @@ import {
   formatRunDate,
   getLearningResourcePrices,
   showStartAnytime,
+  NoSSR,
 } from "ol-utilities"
 import { theme } from "../ThemeProvider/ThemeProvider"
 import DifferingRunsTable from "./DifferingRunsTable"
@@ -255,7 +256,11 @@ const INFO_ITEMS: InfoItemConfig = [
       const totalDatesWithRuns =
         resource.runs?.filter((run) => run.start_date !== null).length || 0
       if (allRunsAreIdentical(resource) && totalDatesWithRuns > 0) {
-        return <RunDates resource={resource} />
+        return (
+          <NoSSR>
+            <RunDates resource={resource} />
+          </NoSSR>
+        )
       } else return null
     },
   },

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV1.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV1.tsx
@@ -7,6 +7,7 @@ import { ButtonLink } from "../Button/Button"
 import type { LearningResource, LearningResourceRun } from "api"
 import { ResourceTypeEnum, PlatformEnum } from "api"
 import {
+  NoSSR,
   formatDate,
   capitalize,
   DEFAULT_RESOURCE_IMG,
@@ -299,7 +300,7 @@ const ResourceDescription = ({ resource }: { resource?: LearningResource }) => {
   return (
     <Description
       /**
-       * Resource descriptions can contain HTML. They are santiized on the
+       * Resource descriptions can contain HTML. They are sanitized on the
        * backend during ETL. This is safe to render.
        */
       dangerouslySetInnerHTML={{ __html: resource.description || "" }}
@@ -384,7 +385,7 @@ const LearningResourceExpandedV1: React.FC<LearningResourceExpandedV1Props> = ({
         .map((run) => {
           return {
             value: run.id.toString(),
-            label: formatRunDate(run, asTaughtIn),
+            label: <NoSSR>{formatRunDate(run, asTaughtIn)}</NoSSR>,
           }
         }) ?? []
 
@@ -415,7 +416,7 @@ const LearningResourceExpandedV1: React.FC<LearningResourceExpandedV1Props> = ({
     return (
       <DateSingle>
         <DateLabel>{label}</DateLabel>
-        {formatted ?? ""}
+        <NoSSR>{formatted ?? ""}</NoSSR>
       </DateSingle>
     )
   }

--- a/frontends/ol-utilities/src/date/LocalDate.tsx
+++ b/frontends/ol-utilities/src/date/LocalDate.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import { NoSSR } from "../ssr/NoSSR"
+import { formatDate } from "./format"
+
+type LocalDateProps = {
+  date?: string | Date | null
+  /**
+   * A Moment.js format string. See https://momentjs.com/docs/#/displaying/format/
+   */
+  format?: string
+}
+
+/* Component to render dates only on the client as these are displayed
+ * according to the user's locale (generally, not all Moment.js format tokens
+ * are localized) causing an error due to hydration mismatch.
+ */
+export const LocalDate = ({ date, format = "MMM D, YYYY" }: LocalDateProps) => {
+  if (!date) return null
+  return <NoSSR>{formatDate(date, format)}</NoSSR>
+}

--- a/frontends/ol-utilities/src/date/format.ts
+++ b/frontends/ol-utilities/src/date/format.ts
@@ -1,12 +1,14 @@
 import moment from "moment"
 
+/* Instances must be wrapped in <NoSSR> to avoid SSR hydration mismatches.
+ */
 export const formatDate = (
   /**
    * Date string or date.
    */
   date: string | Date,
   /**
-   * A momentjs format string. See https://momentjs.com/docs/#/displaying/format/
+   * A Moment.js format string. See https://momentjs.com/docs/#/displaying/format/
    */
   format = "MMM D, YYYY",
 ) => {

--- a/frontends/ol-utilities/src/index.ts
+++ b/frontends/ol-utilities/src/index.ts
@@ -6,6 +6,7 @@
 export * from "./styles"
 
 export * from "./date/format"
+export * from "./date/LocalDate"
 export * from "./learning-resources/learning-resources"
 export * from "./learning-resources/pricing"
 export * from "./strings/html"
@@ -14,3 +15,4 @@ export * from "./hooks"
 export * from "./querystrings"
 export * from "./lib"
 export * from "./images/backgroundImages"
+export * from "./ssr/NoSSR"

--- a/frontends/ol-utilities/src/ssr/NoSSR.tsx
+++ b/frontends/ol-utilities/src/ssr/NoSSR.tsx
@@ -5,12 +5,12 @@ type NoSSRProps = {
   onSSR?: ReactNode
 }
 
-export const NoSSR: React.FC<NoSSRProps> = ({ children, onSSR = <></> }) => {
+export const NoSSR: React.FC<NoSSRProps> = ({ children, onSSR = null }) => {
   const [isClient, setClient] = useState(false)
 
   useEffect(() => {
     setClient(true)
   }, [])
 
-  return <>{isClient ? children : onSSR}</>
+  return isClient ? children : onSSR
 }

--- a/frontends/ol-utilities/src/ssr/NoSSR.tsx
+++ b/frontends/ol-utilities/src/ssr/NoSSR.tsx
@@ -1,0 +1,16 @@
+import React, { useState, useEffect, ReactNode } from "react"
+
+type NoSSRProps = {
+  children: ReactNode
+  onSSR?: ReactNode
+}
+
+export const NoSSR: React.FC<NoSSRProps> = ({ children, onSSR = <></> }) => {
+  const [isClient, setClient] = useState(false)
+
+  useEffect(() => {
+    setClient(true)
+  }, [])
+
+  return <>{isClient ? children : onSSR}</>
+}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Fixes https://github.com/mitodl/hq/issues/6083

### Description (What does it do?)
<!--- Describe your changes in detail -->

Provides a \<NoSSR\> utility component that renders children only after it has first rendered (ie. always on the client).

Provides \<LocalDate\> component that for displaying dates adjusted to the user's timezone with the \<NoSSR\> wrapper, that may otherwise cause a hydration error due a mismatch between the server and client rendered display dates.

Wraps all uses of `moment().format()` with \<LocalDate\> or \<NoSSR\>.

Sets `TZ=UTC` on the Next.js server environment to that hydration errors will be triggered during development (for anyone not on GMT+0).


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Find a course that has a start time between midnight and midnight minus your UTC offset (ie. 5am in EST), e.g. "Professional Certificate in Data Engineering".

Ensure that the start date renders correctly without any hydration error in the console. The above course has a start date of 2024-11-27T00:00:00Z, so should display "November 26, 2024" in EST, though would otherwise render on the UTC server as "November 27, 2024", causing the hydration error.





<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
