### PR TITLE
Consistent qdrant point ids

### DIFF
--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -474,6 +474,9 @@ class LearningResource(TimestampedModel):
     )
     location = models.CharField(max_length=256, blank=True)
 
+    def vector_point_id(self):
+        return uuid.uuid5(uuid.NAMESPACE_DNS, self.readable_id)
+
     @property
     def audience(self) -> str | None:
         """Returns the audience for the learning resource"""

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -474,9 +474,6 @@ class LearningResource(TimestampedModel):
     )
     location = models.CharField(max_length=256, blank=True)
 
-    def vector_point_id(self):
-        return uuid.uuid5(uuid.NAMESPACE_DNS, self.readable_id)
-
     @property
     def audience(self) -> str | None:
         """Returns the audience for the learning resource"""

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -922,19 +922,17 @@ def _qdrant_similar_results(doc, num_resources):
         list of dict:
             list of serialized resources
     """
-    from learning_resources_search.indexing_api import qdrant_client
+    from learning_resources_search.indexing_api import qdrant_client, vector_point_id
 
     client = qdrant_client()
     return [
-        hit.metadata
-        for hit in client.query(
+        hit.payload
+        for hit in client.query_points(
             collection_name=f"{settings.QDRANT_BASE_COLLECTION_NAME}.resources",
-            query_text=(
-                f'{doc.get("title")} {doc.get("description")} '
-                f'{doc.get("full_description")} {doc.get("content")}'
-            ),
+            query=vector_point_id(doc["readable_id"]),
             limit=num_resources,
-        )
+            using=settings.QDRANT_SEARCH_VECTOR_NAME,
+        ).points
     ]
 
 

--- a/learning_resources_search/indexing_api.py
+++ b/learning_resources_search/indexing_api.py
@@ -4,6 +4,7 @@ Functions and constants for OpenSearch indexing
 
 import json
 import logging
+import uuid
 from math import ceil
 
 from django.conf import settings
@@ -143,6 +144,10 @@ def create_qdrand_collections(force_recreate):
         )
 
 
+def vector_point_id(readable_id):
+    return str(uuid.uuid5(uuid.NAMESPACE_DNS, readable_id))
+
+
 def embed_learning_resources(ids, resource_type):
     # update embeddings
     client = qdrant_client()
@@ -151,8 +156,10 @@ def embed_learning_resources(ids, resource_type):
         f"{settings.QDRANT_BASE_COLLECTION_NAME}.content_files"
     )
     if resource_type == CONTENT_FILE_TYPE:
+        readable_id_field = "resource_readable_id"
         serialized_resources = serialize_bulk_content_files(ids)
     else:
+        readable_id_field = "readable_id"
         serialized_resources = serialize_bulk_learning_resources(ids)
     create_qdrand_collections(force_recreate=False)
     if resource_type != CONTENT_FILE_TYPE:
@@ -168,7 +175,7 @@ def embed_learning_resources(ids, resource_type):
             f'{doc.get("full_description")} {doc.get("content")}'
         )
         metadata.append(doc)
-        ids.append(doc["id"])
+        ids.append(vector_point_id(doc[readable_id_field]))
     client.add(
         collection_name=collection_name,
         ids=ids,

--- a/learning_resources_search/indexing_api.py
+++ b/learning_resources_search/indexing_api.py
@@ -156,10 +156,8 @@ def embed_learning_resources(ids, resource_type):
         f"{settings.QDRANT_BASE_COLLECTION_NAME}.content_files"
     )
     if resource_type == CONTENT_FILE_TYPE:
-        readable_id_field = "resource_readable_id"
         serialized_resources = serialize_bulk_content_files(ids)
     else:
-        readable_id_field = "readable_id"
         serialized_resources = serialize_bulk_learning_resources(ids)
     create_qdrand_collections(force_recreate=False)
     if resource_type != CONTENT_FILE_TYPE:
@@ -175,7 +173,13 @@ def embed_learning_resources(ids, resource_type):
             f'{doc.get("full_description")} {doc.get("content")}'
         )
         metadata.append(doc)
-        ids.append(vector_point_id(doc[readable_id_field]))
+        if resource_type != CONTENT_FILE_TYPE:
+            vector_point_key = doc["readable_id"]
+        else:
+            vector_point_key = (
+                f"{doc['key']}.{doc['run_readable_id']}.{doc['resource_readable_id']}"
+            )
+        ids.append(vector_point_id(vector_point_key))
     client.add(
         collection_name=collection_name,
         ids=ids,

--- a/learning_resources_search/indexing_api_test.py
+++ b/learning_resources_search/indexing_api_test.py
@@ -924,4 +924,4 @@ def test_vector_point_id_used_for_embed(mocker, content_type):
             vector_point_id(resource.run.learning_resource.readable_id)
             for resource in resources
         ]
-    assert mock_qdrant.add.mock_calls[0].kwargs["ids"] == point_ids
+    assert sorted(mock_qdrant.add.mock_calls[0].kwargs["ids"]) == sorted(point_ids)

--- a/learning_resources_search/indexing_api_test.py
+++ b/learning_resources_search/indexing_api_test.py
@@ -50,6 +50,7 @@ from learning_resources_search.indexing_api import (
     vector_point_id,
 )
 from learning_resources_search.models import PercolateQuery
+from learning_resources_search.serializers import serialize_bulk_content_files
 from learning_resources_search.utils import remove_child_queries
 from main.utils import chunks
 
@@ -921,7 +922,9 @@ def test_vector_point_id_used_for_embed(mocker, content_type):
         point_ids = [vector_point_id(resource.readable_id) for resource in resources]
     else:
         point_ids = [
-            vector_point_id(resource.run.learning_resource.readable_id)
-            for resource in resources
+            vector_point_id(
+                f"{resource['key']}.{resource['run_readable_id']}.{resource['resource_readable_id']}"
+            )
+            for resource in serialize_bulk_content_files([r.id for r in resources])
         ]
     assert sorted(mock_qdrant.add.mock_calls[0].kwargs["ids"]) == sorted(point_ids)

--- a/learning_resources_search/indexing_api_test.py
+++ b/learning_resources_search/indexing_api_test.py
@@ -13,6 +13,7 @@ from opensearchpy.exceptions import ConflictError, NotFoundError
 from learning_resources.factories import (
     ContentFileFactory,
     CourseFactory,
+    LearningResourceFactory,
     LearningResourceRunFactory,
 )
 from learning_resources.models import ContentFile
@@ -37,6 +38,7 @@ from learning_resources_search.indexing_api import (
     deindex_percolators,
     deindex_run_content_files,
     delete_orphaned_indexes,
+    embed_learning_resources,
     get_reindexing_alias_name,
     index_content_files,
     index_course_content_files,
@@ -45,6 +47,7 @@ from learning_resources_search.indexing_api import (
     index_run_content_files,
     switch_indices,
     update_document_with_partial,
+    vector_point_id,
 )
 from learning_resources_search.models import PercolateQuery
 from learning_resources_search.utils import remove_child_queries
@@ -896,3 +899,29 @@ def test_clear_featured_rank(mocked_es, mocker, clear_all_greater_than):
             "query": query,
         },
     )
+
+
+@pytest.mark.parametrize("content_type", ["learning_resource", "content_file"])
+def test_vector_point_id_used_for_embed(mocker, content_type):
+    # test the vector ids we generate for embedding resources and files
+    if content_type == "learning_resource":
+        resources = LearningResourceFactory.create_batch(5)
+    else:
+        resources = ContentFileFactory.create_batch(5)
+    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
+    mock_qdrant.query.return_value = []
+    mocker.patch(
+        "learning_resources_search.indexing_api.qdrant_client",
+        return_value=mock_qdrant,
+    )
+
+    embed_learning_resources([resource.id for resource in resources], content_type)
+
+    if content_type == "learning_resource":
+        point_ids = [vector_point_id(resource.readable_id) for resource in resources]
+    else:
+        point_ids = [
+            vector_point_id(resource.run.learning_resource.readable_id)
+            for resource in resources
+        ]
+    assert mock_qdrant.add.mock_calls[0].kwargs["ids"] == point_ids

--- a/main/settings.py
+++ b/main/settings.py
@@ -794,6 +794,9 @@ QDRANT_BASE_COLLECTION_NAME = get_string(
     name="QDRANT_COLLECTION_NAME", default="resource_embeddings"
 )
 
+QDRANT_SEARCH_VECTOR_NAME = get_string(
+    name="QDRANT_SEARCH_VECTOR_NAME", default="fast-bge-small-en"
+)
 
 QDRANT_DENSE_MODEL = get_string(
     name="QDRANT_DENSE_MODEL", default="sentence-transformers/all-MiniLM-L6-v2"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/6094


### Description (What does it do?)
This PR generates reproducible uuids off of the resource readable id for vector points stored in Qdrant. What this lets us do, is directly reference and check for existing embeddings in Qdrant if we have a learning resource or content file. Currently for vector similarity, the endpoint unnecessarily re-embeds the referenced document even though the embeddings for that already exist in qdrant (causes a slight delay when loading /api/v1/learning_resources/181/vector_similar/) - this is resolved in this PR since we can re-use the existing embedding


### How can this be tested?

1. Checkout main and make sure you have learning resources locally
2. clear existing collections and generate the embeddings via `python manage.py generate_embeddings --all --skip-contentfiles`
3. find some learning resource id and load the vector similarity endpoint `/api/v1/learning_resources/{resource id}/vector_similar/`- note the delay in loading
4. Checkout this branch
5. make sure you have learning resources locally
6. clear existing collections and generate the embeddings via `python manage.py generate_embeddings --all --skip-contentfiles`
7. find some learning resource and load the vector similarity endpoint `/api/v1/learning_resources/{resource id}/vector_similar/` -  note how much faster it loads


### Additional Context
- We generate the uuid off of the resource "readable_id" instead of the "id" so that if we had some "master embeddings" snapshot - it can be instantly re-used in any environment.
