### PR TITLE
Refactor date/time parsing for mitpe events

### DIFF
--- a/news_events/etl/mitpe_events.py
+++ b/news_events/etl/mitpe_events.py
@@ -8,7 +8,7 @@ from django.conf import settings
 
 from main.utils import now_in_utc
 from news_events.constants import ALL_AUDIENCES, FeedType
-from news_events.etl.utils import fetch_data_by_page, parse_date
+from news_events.etl.utils import fetch_data_by_page, parse_date_time_range
 
 log = logging.getLogger(__name__)
 MITPE_EVENTS_TITLE = "MIT Professional Education Events"
@@ -66,16 +66,9 @@ def transform_item(item: dict) -> dict:
 
     """
 
-    times = item.get("time_range", "").split("-")
-    start_dt = parse_date(
-        f"{item.get("start_date")} {times[0] if len(times) > 0 else ''}"
+    start_dt, end_dt = parse_date_time_range(
+        item.get("start_date"), item.get("end_date"), item.get("time_range")
     )
-    if not start_dt:
-        # Time range may be invalid, try without it
-        start_dt = parse_date(f"{item.get("start_date")}")
-    end_dt = parse_date(f"{item.get("end_date")} {times[1] if len(times) > 1 else ''}")
-    if not end_dt:
-        end_dt = parse_date(f"{item.get("end_date")}")
 
     # Do not bother transforming past events
     now = now_in_utc()

--- a/news_events/etl/mitpe_events_test.py
+++ b/news_events/etl/mitpe_events_test.py
@@ -64,8 +64,8 @@ def test_transform(mitpe_events_json_data):
         2024, 8, 15, 21, 0, 0, tzinfo=UTC
     )
     assert items[3]["detail"]["event_datetime"] == datetime(
-        2023, 5, 12, 4, 0, 0, tzinfo=UTC
+        2023, 5, 12, 16, 0, 0, tzinfo=UTC
     )
     assert items[3]["detail"]["event_end_datetime"] == datetime(
-        2023, 5, 12, 4, 0, 0, tzinfo=UTC
+        2023, 5, 12, 16, 0, 0, tzinfo=UTC
     )

--- a/news_events/etl/utils_test.py
+++ b/news_events/etl/utils_test.py
@@ -112,16 +112,16 @@ def test_get_request_json_error_raise(mocker):
         (
             "2024-07-15",
             "2024-07-15",
-            "3:30 PM - 5:45 PM",
+            "3:30 PM and ends at 5:45 PM",
             datetime(2024, 7, 15, 19, 30, 0, tzinfo=UTC),
             datetime(2024, 7, 15, 21, 45, 0, tzinfo=UTC),
         ),
         (
             "2024-07-15",
             "2024-07-15",
-            "3:30 PM - 5:30 PM pst",
-            datetime(2024, 7, 15, 23, 30, 0, tzinfo=UTC),
-            datetime(2024, 7, 16, 1, 30, 0, tzinfo=UTC),
+            "3:30 PM - 5:30 PM pdt",  # Should figure out this is Pacific Daylight Time
+            datetime(2024, 7, 15, 22, 30, 0, tzinfo=UTC),
+            datetime(2024, 7, 16, 0, 30, 0, tzinfo=UTC),
         ),
         (
             "Future date tbd",
@@ -134,8 +134,78 @@ def test_get_request_json_error_raise(mocker):
             "2024-07-15",
             "2024-07-30",
             "Every afternoon after end of class",
-            datetime(2024, 7, 15, 4, 0, 0, tzinfo=UTC),
-            datetime(2024, 7, 30, 4, 0, 0, tzinfo=UTC),
+            datetime(2024, 7, 15, 16, 0, 0, tzinfo=UTC),
+            datetime(2024, 7, 30, 16, 0, 0, tzinfo=UTC),
+        ),
+        (
+            "2024-07-15",
+            "2024-07-15",
+            "1pm",
+            datetime(2024, 7, 15, 17, 0, 0, tzinfo=UTC),
+            datetime(2024, 7, 15, 17, 0, 0, tzinfo=UTC),
+        ),
+        (
+            "2024-07-15",
+            "2024-07-15",
+            "8 to 1pm",  # Should correctly guess that 8 is AM
+            datetime(2024, 7, 15, 12, 0, 0, tzinfo=UTC),
+            datetime(2024, 7, 15, 17, 0, 0, tzinfo=UTC),
+        ),
+        (
+            "2024-07-15",
+            "2024-07-15",
+            "8 AM to 1",  # Should correctly guess that 1 is PM
+            datetime(2024, 7, 15, 12, 0, 0, tzinfo=UTC),
+            datetime(2024, 7, 15, 17, 0, 0, tzinfo=UTC),
+        ),
+        (
+            "2024-12-15",
+            "2024-12-15",
+            "11 to 12 pm",  # Should correctly guess that 11 is AM
+            datetime(2024, 12, 15, 16, 0, 0, tzinfo=UTC),
+            datetime(2024, 12, 15, 17, 0, 0, tzinfo=UTC),
+        ),
+        (
+            "2024-07-15",
+            "2024-07-15",
+            "Beginning at 4:30 and ending at about 6pm",
+            datetime(2024, 7, 15, 20, 30, 0, tzinfo=UTC),
+            datetime(2024, 7, 15, 22, 0, 0, tzinfo=UTC),
+        ),
+        (
+            "2024-07-15",
+            "2024-07-15",
+            "3:00pm; weather permitting",
+            datetime(2024, 7, 15, 19, 0, 0, tzinfo=UTC),
+            datetime(2024, 7, 15, 19, 0, 0, tzinfo=UTC),
+        ),
+        (
+            "2024-07-15",
+            "2024-07-15",
+            "3:00pm; doors open at 2:30pm",  # Ignore any end time before the start time
+            datetime(2024, 7, 15, 19, 0, 0, tzinfo=UTC),
+            datetime(2024, 7, 15, 19, 0, 0, tzinfo=UTC),
+        ),
+        (
+            "2024-07-15",
+            "2024-07-15",
+            "Beginning at 4:30",  # No AM/PM, so take it literally as is
+            datetime(2024, 7, 15, 8, 30, 0, tzinfo=UTC),
+            datetime(2024, 7, 15, 8, 30, 0, tzinfo=UTC),
+        ),
+        (
+            "2024-07-15",
+            "2024-07-30",
+            "Beginning at 16:30",  # No AM/PM, so take it literally as is
+            datetime(2024, 7, 15, 20, 30, 0, tzinfo=UTC),
+            datetime(2024, 7, 30, 20, 30, 0, tzinfo=UTC),
+        ),
+        (
+            None,
+            "2024-11-30",
+            "Bldg. 123, E52nd Street, Salon MIT",  # Invalid time, default to noon Eastern time, convert to UTC
+            datetime(2024, 11, 30, 17, 0, 0, tzinfo=UTC),
+            datetime(2024, 11, 30, 17, 0, 0, tzinfo=UTC),
         ),
     ],
 )

--- a/news_events/etl/utils_test.py
+++ b/news_events/etl/utils_test.py
@@ -123,6 +123,20 @@ def test_get_request_json_error_raise(mocker):
             datetime(2024, 7, 15, 23, 30, 0, tzinfo=UTC),
             datetime(2024, 7, 16, 1, 30, 0, tzinfo=UTC),
         ),
+        (
+            "Future date tbd",
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "2024-07-15",
+            "2024-07-30",
+            "Every afternoon after end of class",
+            datetime(2024, 7, 15, 4, 0, 0, tzinfo=UTC),
+            datetime(2024, 7, 30, 4, 0, 0, tzinfo=UTC),
+        ),
     ],
 )
 def test_parse_date_time_range(

--- a/news_events/etl/utils_test.py
+++ b/news_events/etl/utils_test.py
@@ -1,5 +1,6 @@
 """Tests for utils functions"""
 
+from datetime import UTC, datetime
 from pathlib import Path
 from time import struct_time
 from urllib.error import HTTPError
@@ -82,3 +83,52 @@ def test_get_request_json_error_raise(mocker):
     )
     with pytest.raises(HTTPError):
         utils.get_request_json("https://test.mit.edu", raise_on_error=True)
+
+
+@pytest.mark.parametrize(
+    ("start_date_str", "end_date_str", "time_range_str", "start_dt", "end_dt"),
+    [
+        (
+            "2024-01-15",
+            "2024-01-15",
+            "9-10 AM",
+            datetime(2024, 1, 15, 14, 0, 0, tzinfo=UTC),
+            datetime(2024, 1, 15, 15, 0, 0, tzinfo=UTC),
+        ),
+        (
+            "2024-01-15",
+            None,
+            "9-10 AM",
+            datetime(2024, 1, 15, 14, 0, 0, tzinfo=UTC),
+            datetime(2024, 1, 15, 15, 0, 0, tzinfo=UTC),
+        ),
+        (
+            "2024-07-15",
+            "2024-07-16",
+            "9 - 12 PM",
+            datetime(2024, 7, 15, 13, 0, 0, tzinfo=UTC),
+            datetime(2024, 7, 16, 16, 0, 0, tzinfo=UTC),
+        ),
+        (
+            "2024-07-15",
+            "2024-07-15",
+            "3:30 PM - 5:45 PM",
+            datetime(2024, 7, 15, 19, 30, 0, tzinfo=UTC),
+            datetime(2024, 7, 15, 21, 45, 0, tzinfo=UTC),
+        ),
+        (
+            "2024-07-15",
+            "2024-07-15",
+            "3:30 PM - 5:30 PM pst",
+            datetime(2024, 7, 15, 23, 30, 0, tzinfo=UTC),
+            datetime(2024, 7, 16, 1, 30, 0, tzinfo=UTC),
+        ),
+    ],
+)
+def test_parse_date_time_range(
+    start_date_str, end_date_str, time_range_str, start_dt, end_dt
+):
+    """parse_date_time_range should return the expected start and end datetimes"""
+    assert utils.parse_date_time_range(
+        start_date_str, end_date_str, time_range_str
+    ) == (start_dt, end_dt)


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6114

### Description (What does it do?)
Refactors the functions for mitpe event date/time parsing so they better handle the formats in the mitpe events api.


### How can this be tested?
- Run `./manage.py  backpopulate_news_events --pipelines mitpe_events_etl` on the main branch, you will see lots of errors about the date/time being unparseable.
- Switch to this branch and try again you should see very few or no errors.  If any errors do occur, they should be for very badly formatted time_range values from the mitpe api.


