### PR TITLE
Remove some unused exports from ol-components

### DIFF
--- a/frontends/main/src/app-pages/ChannelPage/UnitChannelTemplate.tsx
+++ b/frontends/main/src/app-pages/ChannelPage/UnitChannelTemplate.tsx
@@ -176,7 +176,7 @@ const UnitChannelTemplate: React.FC<UnitChannelTemplateProps> = ({
           </BannerContent>
         </Container>
       </StyledBannerBackground>
-      <Container id="foo" component="section">
+      <Container component="section">
         <FeaturedCoursesCarousel
           title="Featured Courses"
           titleComponent="h2"

--- a/frontends/main/src/app-pages/ChannelPage/UnitChannelTemplate.tsx
+++ b/frontends/main/src/app-pages/ChannelPage/UnitChannelTemplate.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from "react"
 import {
   styled,
   Container,
-  Box,
   Breadcrumbs,
   Stack,
   BannerBackground,
@@ -147,8 +146,7 @@ const UnitChannelTemplate: React.FC<UnitChannelTemplateProps> = ({
                   {displayConfiguration?.sub_heading}
                 </Typography>
               </Stack>
-              <Box
-                display="flex"
+              <Stack
                 flexDirection="row"
                 alignItems="end"
                 sx={{
@@ -172,13 +170,13 @@ const UnitChannelTemplate: React.FC<UnitChannelTemplateProps> = ({
                     />
                   ) : null}
                 </ChannelControls>
-              </Box>
+              </Stack>
             </Stack>
             {channel.data ? <ChannelDetails channel={channel.data} /> : null}
           </BannerContent>
         </Container>
       </StyledBannerBackground>
-      <Container component="section">
+      <Container id="foo" component="section">
         <FeaturedCoursesCarousel
           title="Featured Courses"
           titleComponent="h2"

--- a/frontends/main/src/app-pages/ErrorPage/ErrorPageTemplate.tsx
+++ b/frontends/main/src/app-pages/ErrorPage/ErrorPageTemplate.tsx
@@ -1,11 +1,5 @@
 import React from "react"
-import {
-  Container,
-  MuiCard,
-  CardContent,
-  CardActions,
-  ButtonLink,
-} from "ol-components"
+import { Container, ButtonLink, Typography, styled } from "ol-components"
 import { HOME } from "@/common/urls"
 
 type ErrorPageTemplateProps = {
@@ -13,18 +7,34 @@ type ErrorPageTemplateProps = {
   children: React.ReactNode
 }
 
-const ErrorPageTemplate: React.FC<ErrorPageTemplateProps> = ({ children }) => {
+const ErrorContainer = styled(Container)(({ theme }) => ({
+  backgroundColor: theme.custom.colors.white,
+  borderRadius: "8px",
+  marginTop: "4rem",
+  padding: "16px",
+  boxShadow:
+    "1px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
+}))
+const Footer = styled.div({
+  marginTop: "16px",
+})
+
+const ErrorPageTemplate: React.FC<ErrorPageTemplateProps> = ({
+  children,
+  title,
+}) => {
   return (
-    <Container maxWidth="sm">
-      <MuiCard sx={{ marginTop: "4rem" }}>
-        <CardContent>{children}</CardContent>
-        <CardActions>
-          <ButtonLink variant="secondary" href={HOME}>
-            Home
-          </ButtonLink>
-        </CardActions>
-      </MuiCard>
-    </Container>
+    <ErrorContainer maxWidth="sm">
+      <Typography variant="h3" component="h1">
+        {title}
+      </Typography>
+      {children}
+      <Footer>
+        <ButtonLink variant="secondary" href={HOME}>
+          Home
+        </ButtonLink>
+      </Footer>
+    </ErrorContainer>
   )
 }
 

--- a/frontends/main/src/app-pages/ErrorPage/FallbackErrorPage.tsx
+++ b/frontends/main/src/app-pages/ErrorPage/FallbackErrorPage.tsx
@@ -2,14 +2,10 @@
 
 import React from "react"
 import ErrorPageTemplate from "./ErrorPageTemplate"
-import { Typography } from "ol-components"
 
 const FallbackErrorPage = ({ error }: { error: Pick<Error, "message"> }) => {
   return (
-    <ErrorPageTemplate title="Unexpected Error">
-      <Typography variant="h3" component="h1">
-        Something went wrong.
-      </Typography>
+    <ErrorPageTemplate title="Something went wrong">
       {error.message}
     </ErrorPageTemplate>
   )

--- a/frontends/main/src/app-pages/ErrorPage/FallbackErrorPage.tsx
+++ b/frontends/main/src/app-pages/ErrorPage/FallbackErrorPage.tsx
@@ -5,7 +5,7 @@ import ErrorPageTemplate from "./ErrorPageTemplate"
 
 const FallbackErrorPage = ({ error }: { error: Pick<Error, "message"> }) => {
   return (
-    <ErrorPageTemplate title="Something went wrong">
+    <ErrorPageTemplate title="Something went wrong.">
       {error.message}
     </ErrorPageTemplate>
   )

--- a/frontends/main/src/app-pages/ErrorPage/ForbiddenPage.tsx
+++ b/frontends/main/src/app-pages/ErrorPage/ForbiddenPage.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from "react"
 import ErrorPageTemplate from "./ErrorPageTemplate"
 import { useUserMe } from "api/hooks/user"
-import { Typography } from "ol-components"
 import { redirect } from "next/navigation"
 import * as urls from "@/common/urls"
 
@@ -16,9 +15,6 @@ const ForbiddenPage: React.FC = () => {
   }, [user])
   return (
     <ErrorPageTemplate title="Not Allowed">
-      <Typography variant="h3" component="h1">
-        Not Allowed
-      </Typography>
       You do not have permission to access this resource.
     </ErrorPageTemplate>
   )

--- a/frontends/main/src/app-pages/ErrorPage/NotFoundPage.tsx
+++ b/frontends/main/src/app-pages/ErrorPage/NotFoundPage.tsx
@@ -2,14 +2,10 @@
 
 import React from "react"
 import ErrorPageTemplate from "./ErrorPageTemplate"
-import { Typography } from "ol-components"
 
 const NotFoundPage: React.FC = () => {
   return (
-    <ErrorPageTemplate title="Not Found">
-      <Typography variant="h3" component="h1">
-        404 Not Found Error
-      </Typography>
+    <ErrorPageTemplate title="404 Not Found Error">
       Resource Not Found
     </ErrorPageTemplate>
   )

--- a/frontends/main/src/app/error.tsx
+++ b/frontends/main/src/app/error.tsx
@@ -14,6 +14,11 @@ import * as Sentry from "@sentry/nextjs"
 import FallbackErrorPage from "@/app-pages/ErrorPage/FallbackErrorPage"
 import { ForbiddenError } from "@/common/permissions"
 import ForbiddenPage from "@/app-pages/ErrorPage/ForbiddenPage"
+
+export const metadata = {
+  title: "Error",
+}
+
 const Error = ({ error }: { error: Error }) => {
   useEffect(() => {
     Sentry.captureException(error)

--- a/frontends/main/src/app/not-found.tsx
+++ b/frontends/main/src/app/not-found.tsx
@@ -1,6 +1,10 @@
 import React from "react"
 import NotFoundPage from "@/app-pages/ErrorPage/NotFoundPage"
 
+export const metadata = {
+  title: "Not Found",
+}
+
 const Page: React.FC = () => {
   return <NotFoundPage />
 }

--- a/frontends/main/src/page-components/ChannelDetails/ChannelDetails.tsx
+++ b/frontends/main/src/page-components/ChannelDetails/ChannelDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react"
-import { styled, Typography, Box } from "ol-components"
+import { styled, Typography } from "ol-components"
 import { capitalize } from "ol-utilities"
 import { ChannelTypeEnum, Channel } from "api/v0"
 import { RiExternalLinkLine } from "@remixicon/react"
@@ -142,7 +142,7 @@ const getChannelDetails = (channel: Channel) => {
 const InfoLabel = styled(Typography)(({ theme }) => ({
   color: theme.custom.colors.mitRed,
 }))
-const ChannelDetailsCard = styled(Box)(({ theme }) => ({
+const ChannelDetailsCard = styled.div(({ theme }) => ({
   borderRadius: "12px",
   backgroundColor: "white",
   padding: "36px",
@@ -186,7 +186,7 @@ const ChannelDetails: React.FC<ChannelDetailsProps> = (props) => {
           : detailValue
 
         return (
-          <Box key={value.title}>
+          <div key={value.title}>
             <InfoLabel
               variant="subtitle2"
               sx={{ marginBottom: (theme) => theme.typography.pxToRem(4) }}
@@ -196,7 +196,7 @@ const ChannelDetails: React.FC<ChannelDetailsProps> = (props) => {
             <Typography variant="body3" color="text.secondary">
               {Array.isArray(label) ? label.join(" | ") : label}
             </Typography>
-          </Box>
+          </div>
         )
       }
       return null

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -3,8 +3,6 @@ import {
   styled,
   Pagination,
   PaginationItem,
-  MuiCard,
-  CardContent,
   PlainList,
   Container,
   Typography,
@@ -459,6 +457,14 @@ const AdminTitleContainer = styled.div`
   ${({ theme }) => css({ ...theme.typography.subtitle3 })}
   margin-top: 20px;
 `
+const NoneFound = styled.div(({ theme }) => ({
+  backgroundColor: theme.custom.colors.white,
+  borderRadius: "8px",
+  padding: "16px",
+  paddingBottom: "24px",
+  boxShadow:
+    "1px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
+}))
 
 const PAGE_SIZE = 20
 const MAX_PAGE = 50
@@ -963,9 +969,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                     ))}
                   </PlainList>
                 ) : (
-                  <MuiCard>
-                    <CardContent>No results found for your query.</CardContent>
-                  </MuiCard>
+                  <NoneFound>No results found for your query.</NoneFound>
                 )}
               </StyledResultsContainer>
               <PaginationContainer>

--- a/frontends/ol-components/package.json
+++ b/frontends/ol-components/package.json
@@ -18,7 +18,7 @@
     "@emotion/styled": "^11.11.0",
     "@mui/base": "5.0.0-beta.61",
     "@mui/lab": "6.0.0-beta.15",
-    "@mui/material": "^6.1.6",
+    "@mui/material": "^6.1.8",
     "@mui/material-nextjs": "^6.1.6",
     "@mui/system": "^6.1.6",
     "@remixicon/react": "^4.2.0",

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -49,15 +49,6 @@ export type { ClickAwayListenerProps } from "@mui/material/ClickAwayListener"
 export { default as Container } from "@mui/material/Container"
 export type { ContainerProps } from "@mui/material/Container"
 
-export { default as MuiDialog } from "@mui/material/Dialog"
-export type { DialogProps as MuiDialogProps } from "@mui/material/Dialog"
-export { default as MuiDialogActions } from "@mui/material/DialogActions"
-export type { DialogActionsProps } from "@mui/material/DialogActions"
-export { default as MuiDialogContent } from "@mui/material/DialogContent"
-export type { DialogContentProps } from "@mui/material/DialogContent"
-export { default as MuiDialogTitle } from "@mui/material/DialogTitle"
-export type { DialogTitleProps } from "@mui/material/DialogTitle"
-
 export { default as Divider } from "@mui/material/Divider"
 export type { DividerProps } from "@mui/material/Divider"
 

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -12,12 +12,6 @@
  *    functionality.
  */
 
-export { default as Avatar } from "@mui/material/Avatar"
-export type { AvatarProps } from "@mui/material/Avatar"
-
-export { default as Badge } from "@mui/material/Badge"
-export type { BadgeProps } from "@mui/material/Badge"
-
 export { default as AppBar } from "@mui/material/AppBar"
 export type { AppBarProps } from "@mui/material/AppBar"
 
@@ -45,11 +39,6 @@ export { default as CardActions } from "@mui/material/CardActions"
 export type { CardActionsProps } from "@mui/material/CardActions"
 export { default as CardContent } from "@mui/material/CardContent"
 export type { CardContentProps } from "@mui/material/CardContent"
-export { default as CardMedia } from "@mui/material/CardMedia"
-export type { CardMediaProps } from "@mui/material/CardMedia"
-
-export { default as MuiCheckbox } from "@mui/material/Checkbox"
-export type { CheckboxProps as MuiCheckboxProps } from "@mui/material/Checkbox"
 
 export { default as Chip } from "@mui/material/Chip"
 export type { ChipProps } from "@mui/material/Chip"
@@ -79,7 +68,6 @@ export { default as Grid } from "@mui/material/Grid"
 export type { GridProps } from "@mui/material/Grid"
 export { default as Grid2 } from "@mui/material/Grid2"
 export type { Grid2Props } from "@mui/material/Grid2"
-export { default as InputLabel } from "@mui/material/InputLabel"
 
 export { default as List } from "@mui/material/List"
 export type { ListProps } from "@mui/material/List"
@@ -87,8 +75,6 @@ export { default as ListItem } from "@mui/material/ListItem"
 export type { ListItemProps } from "@mui/material/ListItem"
 export { ListItemLink } from "./components/Lists/ListItemLink"
 export type { ListItemLinkProps } from "./components/Lists/ListItemLink"
-export { default as ListItemButton } from "@mui/material/ListItemButton"
-export type { ListItemButtonProps } from "@mui/material/ListItemButton"
 export { default as ListItemText } from "@mui/material/ListItemText"
 export type { ListItemTextProps } from "@mui/material/ListItemText"
 
@@ -123,22 +109,9 @@ export type { ToolbarProps } from "@mui/material/Toolbar"
 // Mui Form Inputs
 export { default as Autocomplete } from "@mui/material/Autocomplete"
 export type { AutocompleteProps } from "@mui/material/Autocomplete"
-export { default as MuiRadio } from "@mui/material/Radio"
-export type { RadioProps as MuiRadioProps } from "@mui/material/Radio"
-export { default as RadioGroup } from "@mui/material/RadioGroup"
-export type { RadioGroupProps } from "@mui/material/RadioGroup"
 export { default as ToggleButton } from "@mui/material/ToggleButton"
 export { default as ToggleButtonGroup } from "@mui/material/ToggleButtonGroup"
 
-// Mui Custom Form Inputs
-export { default as FormControl } from "@mui/material/FormControl"
-export type { FormControlProps } from "@mui/material/FormControl"
-export { default as FormControlLabel } from "@mui/material/FormControlLabel"
-export type { FormControlLabelProps } from "@mui/material/FormControlLabel"
-export { default as FormHelperText } from "@mui/material/FormHelperText"
-export type { FormHelperTextProps } from "@mui/material/FormHelperText"
-export { default as FormLabel } from "@mui/material/FormLabel"
-export type { FormLabelProps } from "@mui/material/FormLabel"
 export { default as Pagination } from "@mui/material/Pagination"
 export type { PaginationProps } from "@mui/material/Pagination"
 export { default as Typography } from "@mui/material/Typography"
@@ -147,8 +120,6 @@ export { default as PaginationItem } from "@mui/material/PaginationItem"
 
 export { default as Collapse } from "@mui/material/Collapse"
 
-export { default as Menu } from "@mui/material/Menu"
-export type { MenuProps } from "@mui/material/Menu"
 export * from "./components/MenuItem/MenuItem"
 
 export { default as Stepper } from "@mui/material/Stepper"

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -31,15 +31,6 @@ export { ListCard, ListCardActionButton } from "./components/Card/ListCard"
 
 export type { ButtonProps, ButtonLinkProps } from "./components/Button/Button"
 
-export { default as MuiCard } from "@mui/material/Card"
-export type { CardProps as MuiCardProps } from "@mui/material/Card"
-export { default as Box } from "@mui/material/Box"
-export type { BoxProps } from "@mui/material/Box"
-export { default as CardActions } from "@mui/material/CardActions"
-export type { CardActionsProps } from "@mui/material/CardActions"
-export { default as CardContent } from "@mui/material/CardContent"
-export type { CardContentProps } from "@mui/material/CardContent"
-
 export { default as Chip } from "@mui/material/Chip"
 export type { ChipProps } from "@mui/material/Chip"
 

--- a/frontends/ol-widgets/package.json
+++ b/frontends/ol-widgets/package.json
@@ -5,6 +5,7 @@
   "main": "./src/index.ts",
   "dependencies": {
     "@faker-js/faker": "^9.0.0",
+    "@mui/material": "^6.1.8",
     "@remixicon/react": "^4.2.0",
     "classnames": "^2.3.2",
     "formik": "^2.4.5",

--- a/frontends/ol-widgets/src/components/Widget.tsx
+++ b/frontends/ol-widgets/src/components/Widget.tsx
@@ -1,6 +1,12 @@
 import React, { useCallback } from "react"
 import classNames from "classnames"
-import { Divider, MuiCard, CardContent, CardActions } from "ol-components"
+import { Divider } from "ol-components"
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import MuiCard from "@mui/material/Card"
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import CardContent from "@mui/material/CardContent"
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import CardActions from "@mui/material/CardActions"
 import {
   RiPencilFill,
   RiDeleteBin7Fill,

--- a/frontends/ol-widgets/src/components/editing/ManageWidgetDialog.tsx
+++ b/frontends/ol-widgets/src/components/editing/ManageWidgetDialog.tsx
@@ -1,12 +1,13 @@
 import React, { useId, useCallback, useEffect, useMemo, useState } from "react"
-import {
-  MuiDialog,
-  MuiDialogActions,
-  MuiDialogContent,
-  MuiDialogTitle,
-  Button,
-  RadioChoiceField,
-} from "ol-components"
+import { Button, RadioChoiceField } from "ol-components"
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import MuiDialog from "@mui/material/Dialog"
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import MuiDialogActions from "@mui/material/DialogActions"
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import MuiDialogContent from "@mui/material/DialogContent"
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import MuiDialogTitle from "@mui/material/DialogTitle"
 import { Formik, Form, Field, ErrorMessage, FieldProps } from "formik"
 import { isNil } from "lodash"
 import { AnonymousWidget, WidgetSpec, WidgetTypes } from "../../interfaces"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3602,10 +3602,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/core-downloads-tracker@npm:^6.1.6":
-  version: 6.1.6
-  resolution: "@mui/core-downloads-tracker@npm:6.1.6"
-  checksum: 10/c09af6c9888756ae4bef802ef6fe9a23504731d6181790fdcb3ff41a6c936ef1fc0a1afe28320f4696bdc136ddefea4f89b230f0ee4e47e294dcdec8293d5d07
+"@mui/core-downloads-tracker@npm:^6.1.8":
+  version: 6.1.8
+  resolution: "@mui/core-downloads-tracker@npm:6.1.8"
+  checksum: 10/87e10a09909d32f9a1618fe23d5f7bf8981a942431be3432ae5cb24c31502af93eca38204e46619a3546f13a5c32b1741c80f24657a29a6e7a9e53d4384d042d
   languageName: node
   linkType: hard
 
@@ -3664,15 +3664,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/material@npm:^6.1.6":
-  version: 6.1.6
-  resolution: "@mui/material@npm:6.1.6"
+"@mui/material@npm:^6.1.8":
+  version: 6.1.8
+  resolution: "@mui/material@npm:6.1.8"
   dependencies:
     "@babel/runtime": "npm:^7.26.0"
-    "@mui/core-downloads-tracker": "npm:^6.1.6"
-    "@mui/system": "npm:^6.1.6"
+    "@mui/core-downloads-tracker": "npm:^6.1.8"
+    "@mui/system": "npm:^6.1.8"
     "@mui/types": "npm:^7.2.19"
-    "@mui/utils": "npm:^6.1.6"
+    "@mui/utils": "npm:^6.1.8"
     "@popperjs/core": "npm:^2.11.8"
     "@types/react-transition-group": "npm:^4.4.11"
     clsx: "npm:^2.1.1"
@@ -3683,7 +3683,7 @@ __metadata:
   peerDependencies:
     "@emotion/react": ^11.5.0
     "@emotion/styled": ^11.3.0
-    "@mui/material-pigment-css": ^6.1.6
+    "@mui/material-pigment-css": ^6.1.8
     "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3696,7 +3696,7 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 10/3a805c86fd3bc475ccd185904fb68e46358a67a9f72b88987d497d65ec982f78a5ebf6c6a3c5b52383b0208a25f1a6ead8955dec7b054f854c9f77701cafc7b9
+  checksum: 10/1904719f5e6427b150aabee0e93ac89bd78b669f3d2834f0f06914d57e5dbf09c02ba4253eea3cfb0fcf58e0387de5d16ee7eb14c461e695b119d057725b7f9a
   languageName: node
   linkType: hard
 
@@ -3731,6 +3731,23 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/81bd11bdca8284065279ca587e5c1c7dbc05201c6ae1f3760dfb4d720a9e49d428f677939a24a5b34580bb05436ababd9a6b4fb2fcb510f6cf8dd91fd3d1e360
+  languageName: node
+  linkType: hard
+
+"@mui/private-theming@npm:^6.1.8":
+  version: 6.1.8
+  resolution: "@mui/private-theming@npm:6.1.8"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/utils": "npm:^6.1.8"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/c8f6b4e0b755f5186683188f70622b33febe77ea14d9fbbe564372d6e5493c026a874229fac26bb365836c5018b2e941cc7248114b9df1a4676e5375b8b572ff
   languageName: node
   linkType: hard
 
@@ -3777,6 +3794,29 @@ __metadata:
     "@emotion/styled":
       optional: true
   checksum: 10/4850c70d23439d49567b82f6431a7e01a16ee8fe54a422e98b6ed129a9884416ff3efbc1900d77122a296fd01a2943fd2682e339a1b6151a1a9fd2c7cfed5fb5
+  languageName: node
+  linkType: hard
+
+"@mui/styled-engine@npm:^6.1.8":
+  version: 6.1.8
+  resolution: "@mui/styled-engine@npm:6.1.8"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@emotion/cache": "npm:^11.13.1"
+    "@emotion/serialize": "npm:^1.3.2"
+    "@emotion/sheet": "npm:^1.4.0"
+    csstype: "npm:^3.1.3"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@emotion/react": ^11.4.1
+    "@emotion/styled": ^11.3.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+  checksum: 10/72afb46000040de3b03bd5cf7a80aefe400dbcf524d16081b77fab38ca2e932f2fe6e18485ef9676677fe4524669675ed7bff3ce7cd37682254aa8958a82ee29
   languageName: node
   linkType: hard
 
@@ -3836,6 +3876,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/system@npm:^6.1.8":
+  version: 6.1.8
+  resolution: "@mui/system@npm:6.1.8"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/private-theming": "npm:^6.1.8"
+    "@mui/styled-engine": "npm:^6.1.8"
+    "@mui/types": "npm:^7.2.19"
+    "@mui/utils": "npm:^6.1.8"
+    clsx: "npm:^2.1.1"
+    csstype: "npm:^3.1.3"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10/24a31b116e3cd748e7448f5c223ca5608da2d47ad3e9bc8dbbb65d8923ab9b1777458bcbf4e3cb0a8743f4a7aef1cf9cec67d61afdc74de1ade21a25f219f5f2
+  languageName: node
+  linkType: hard
+
 "@mui/types@npm:^7.2.19":
   version: 7.2.19
   resolution: "@mui/types@npm:7.2.19"
@@ -3885,6 +3953,26 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/c6dbe7109f38e172a71f3efcdf7e7c38d8fb3dbcdd40b2c78f4a69603f2ebfbde8f375bbba911fca46981d7b6d63ab927961be0c2569b2619aa3f76709e84934
+  languageName: node
+  linkType: hard
+
+"@mui/utils@npm:^6.1.8":
+  version: 6.1.8
+  resolution: "@mui/utils@npm:6.1.8"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/types": "npm:^7.2.19"
+    "@types/prop-types": "npm:^15.7.13"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    react-is: "npm:^18.3.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/093a952ce4834e71911550e7bb17f02fe389b948deefec304c58c1970c5a4c454a44a1ec0a8f426eb294cace410356d2ac0ee4bb5f4628c23cf044399d4258be
   languageName: node
   linkType: hard
 
@@ -16116,7 +16204,7 @@ __metadata:
     "@faker-js/faker": "npm:^9.0.0"
     "@mui/base": "npm:5.0.0-beta.61"
     "@mui/lab": "npm:6.0.0-beta.15"
-    "@mui/material": "npm:^6.1.6"
+    "@mui/material": "npm:^6.1.8"
     "@mui/material-nextjs": "npm:^6.1.6"
     "@mui/system": "npm:^6.1.6"
     "@remixicon/react": "npm:^4.2.0"
@@ -16214,6 +16302,7 @@ __metadata:
   resolution: "ol-widgets@workspace:frontends/ol-widgets"
   dependencies:
     "@faker-js/faker": "npm:^9.0.0"
+    "@mui/material": "npm:^6.1.8"
     "@remixicon/react": "npm:^4.2.0"
     "@testing-library/react": "npm:16.0.1"
     "@testing-library/user-event": "npm:14.5.2"


### PR DESCRIPTION
### What are the relevant tickets?
For https://github.com/mitodl/hq/issues/6039

### Description (What does it do?)
This cleans up `ol-components` mui re-exports a bit:
- Removes some exports we simply were not using
- Removes a few exports that were very rarely used and whose usage was easily replaced (example: Box)
- Removes `MuiCard` and friends. This is still used in `ol-widgets`, where it's just imported from mui directly.

### How can this be tested?
1. Visit `/c/unit/ocw` or any other channel page. The subscribe button should be in same spot.
2. Visit `/search?q=gdjslkghafkaghafdklhdafsbk` the "Not found" card should look the same
3. Visit `/kjgoidsh` the "Not Found" error page should look the same.

