### PR TITLE
set min cpu and memory. also add qdrant container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,5 +25,5 @@
   },
   "features": {},
   "postStartCommand": "while [ \"$(python manage.py showmigrations | grep \"\\[ \\]\" | wc -l)\" -ne \"0\" ]; do echo \"waiting for migrations\"; sleep 2; done && python manage.py update_offered_by && python manage.py update_platforms && python manage.py update_departments_schools && python manage.py update_course_number_departments && python manage.py backpopulate_mitxonline_data && python manage.py backpopulate_micromasters_data && python manage.py backpopulate_resource_channels --overwrite --all && python manage.py recreate_index --all",
-  "forwardPorts": [8062, 8063]
+  "forwardPorts": [8062, 8063, 6333]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,8 +9,10 @@
     "tika",
     "celery",
     "nginx",
-    "redis"
+    "redis",
+    "qdrant"
   ],
+  "hostRequirements": { "cpus": 4, "memory": "8gb" },
   "secrets": {
     "EDX_API_CLIENT_ID": {},
     "EDX_API_CLIENT_SECRET": {},


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/mit-learn/issues/1843

### Description (What does it do?)
updates the default configuration so that codespaces will launch a 4cpu and 16gb memory instance by default. This Pr also updates runServices in devcontainer.json to include the qdrant service.
### How can this be tested?
1. Click this button to open the default options for the **main branch** 
  [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mitodl/mit-learn/tree/main)
2. observe that "2-code" is pre-selected as the machine type
3. Open the launch page for this branch
  [![Open Main branch in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mitodl/mit-learn/tree/shanbady%2Fcodespace-set-host-config)
4. see that the "4-core" option is now the default
4. use the link above and actually launch the codespace for this branch.
5. once it finishes building and you can access the terminal, confirm the qdrant container is running by curling the qdrant dashboard page `curl http://qdrant:6333/dashboard`