### PR TITLE
returning all resource types for similar resources endpoint

### DIFF
--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -1043,12 +1043,11 @@ def get_similar_resources_opensearch(
         list of str:
             list of learning resources
     """
-    indexes = relevant_indexes([COURSE_TYPE], [], endpoint=LEARNING_RESOURCE)
+    indexes = relevant_indexes(LEARNING_RESOURCE_TYPES, [], endpoint=LEARNING_RESOURCE)
     search = Search(index=",".join(indexes))
     if num_resources:
         # adding +1 to num_resources since we filter out existing resource.id
         search = search.extra(size=num_resources + 1)
-    search = search.filter("term", resource_type=COURSE_TYPE)
     search = search.query(
         MoreLikeThis(
             like=[{"doc": value_doc, "fields": list(value_doc.keys())}],


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/6132

### Description (What does it do?)
Fixes the similar resources endpoint so that it returns more than just courses


### How can this be tested?
1. checkout this branch
2. load up resources locally. ensure you have a variety of resource types (videos, courses, podcasts etc)
3. go to the search page, find a learning resource and open up the drawer. in the "similar resources" carousel you should see a mixture of resources types and not just courses.

