### PR TITLE
v2 drawer qa adjustments

### DIFF
--- a/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
+++ b/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
@@ -192,7 +192,7 @@ const Story: React.FC<{ item: NewsFeedItem; mobile: boolean }> = ({
       {item.image.url ? (
         <Card.Image src={item.image.url} alt={item.image.alt || ""} />
       ) : null}
-      <Card.Title href={item.url} lines={2} style={{ marginBottom: -13 }}>
+      <Card.Title href={item.url} style={{ marginBottom: -13 }}>
         {item.title}
       </Card.Title>
       <Card.Footer>

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -103,14 +103,13 @@ const Info = styled.div<{ size?: Size }>`
 `
 
 const titleOpts = {
-  shouldForwardProp: (prop: string) => prop !== "lines" && prop !== "size",
+  shouldForwardProp: (prop: string) => prop !== "size",
 }
-const Title = styled(Linkable, titleOpts)<{ lines?: number; size?: Size }>`
+const Title = styled(Linkable, titleOpts)<{ size?: Size }>`
   text-overflow: ellipsis;
-  height: ${({ lines, size }) => {
+  height: ${({ size }) => {
     const lineHeightPx = size === "small" ? 18 : 20
-    lines = 3
-    return theme.typography.pxToRem(lines * lineHeightPx)
+    return theme.typography.pxToRem(3 * lineHeightPx)
   }};
   overflow: hidden;
   margin: 0;
@@ -120,18 +119,14 @@ const Title = styled(Linkable, titleOpts)<{ lines?: number; size?: Size }>`
       ? { ...theme.typography.subtitle2 }
       : { ...theme.typography.subtitle1 }}
 
-  ${({ lines }) => {
-    lines = 3
-    return `
-      @supports (-webkit-line-clamp: ${lines}) {
-        white-space: initial;
-        display: -webkit-box;
-        -webkit-box-orient: vertical;
-        div {
-          -webkit-line-clamp: ${lines};
-        }
-      }`
-  }}
+  @supports (-webkit-line-clamp: 3) {
+    white-space: initial;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    div {
+      -webkit-line-clamp: 3;
+    }
+  }
 `
 
 const Footer = styled.span`
@@ -227,7 +222,6 @@ export type ImageProps = NextImageProps & {
 type TitleProps = {
   children?: ReactNode
   href?: string
-  lines?: number
   style?: CSSProperties
 }
 

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -123,7 +123,8 @@ const Title = styled(Linkable, titleOpts)<{ size?: Size }>`
     white-space: initial;
     display: -webkit-box;
     -webkit-box-orient: vertical;
-    div {
+    -webkit-line-clamp: 3;
+    > * {
       -webkit-line-clamp: 3;
     }
   }

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -109,7 +109,7 @@ const Title = styled(Linkable, titleOpts)<{ lines?: number; size?: Size }>`
   text-overflow: ellipsis;
   height: ${({ lines, size }) => {
     const lineHeightPx = size === "small" ? 18 : 20
-    lines = lines ?? (size === "small" ? 2 : 3)
+    lines = 3
     return theme.typography.pxToRem(lines * lineHeightPx)
   }};
   overflow: hidden;
@@ -120,14 +120,16 @@ const Title = styled(Linkable, titleOpts)<{ lines?: number; size?: Size }>`
       ? { ...theme.typography.subtitle2 }
       : { ...theme.typography.subtitle1 }}
 
-  ${({ lines, size }) => {
-    lines = lines ?? (size === "small" ? 2 : 3)
+  ${({ lines }) => {
+    lines = 3
     return `
       @supports (-webkit-line-clamp: ${lines}) {
         white-space: initial;
         display: -webkit-box;
-        -webkit-line-clamp: ${lines};
         -webkit-box-orient: vertical;
+        div {
+          -webkit-line-clamp: ${lines};
+        }
       }`
   }}
 `

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -124,6 +124,7 @@ const Title = styled(Linkable, titleOpts)<{ size?: Size }>`
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 3;
+
     > * {
       -webkit-line-clamp: 3;
     }

--- a/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
@@ -25,7 +25,7 @@ const DifferingRun = styled.div({
   display: "flex",
   flexWrap: "wrap",
   alignItems: "center",
-  gap: "16px",
+  gap: "8px",
   padding: "12px",
   alignSelf: "stretch",
   borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,

--- a/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
@@ -120,7 +120,7 @@ const DifferingRunsTable: React.FC<{ resource: LearningResource }> = ({
             {run.delivery.filter((d) => d.code === "in_person").length > 0 &&
               run.location && (
                 <DifferingRunLocation>
-                  <strong>Location</strong>
+                  <strong>Location:</strong>
                   <span>{run.location}</span>
                 </DifferingRunLocation>
               )}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/DifferingRunsTable.tsx
@@ -35,7 +35,7 @@ const DifferingRunHeader = styled.div({
   display: "flex",
   alignSelf: "stretch",
   alignItems: "center",
-  gap: "16px",
+  gap: "8px",
   padding: "12px",
   color: theme.custom.colors.darkGray2,
   backgroundColor: theme.custom.colors.lightGray1,

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -173,8 +173,11 @@ const Description = styled.p({
 const DescriptionCollapsed = styled(Description)({
   display: "-webkit-box",
   overflow: "hidden",
-  WebkitLineClamp: 5,
-  WebkitBoxOrient: "vertical",
+  height: `calc(${theme.typography.body2.lineHeight} * 5)`,
+  "@supports (-webkit-line-clamp: 5)": {
+    WebkitLineClamp: 5,
+    WebkitBoxOrient: "vertical",
+  },
 })
 
 const DescriptionExpanded = styled(Description)({

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -154,6 +154,12 @@ const Description = styled.p({
   margin: 0,
   whiteSpace: "pre-wrap",
   wordBreak: "break-word",
+  "p:first-child": {
+    marginTop: 0,
+  },
+  "p:last-child": {
+    marginBottom: 0,
+  },
 })
 
 const StyledPlatformLogo = styled(PlatformLogo)({


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6168

### Description (What does it do?)
This PR addresses some minor design concerns to the new v2 learning resource drawer, mostly adjusting text formatting and line clamping.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/c2da64bb-6741-4a81-b181-7169160415a5)
![image](https://github.com/user-attachments/assets/1ffe692d-a146-4552-b070-b52c089aa720)
![image](https://github.com/user-attachments/assets/07b29ef0-2e0d-431a-8382-6dca614873c1)
![image](https://github.com/user-attachments/assets/e7ba279e-5006-4f75-b859-91d72043fbe5)

### How can this be tested?
 - If you have Posthog set up locally, enable the `lr_drawer_v2` flag
 - If you don't have Posthog set up locally, you can force `drawerV2` to be `true` in `LearningResourceDrawer.tsx`
 - Spin up this branch of `mit-learn`
 - Ensure you have sufficient data backpopulated into your local instance, including some OCW and Sloan courses
 - Visit the search page at http://localhost:8062/search
 - Search for "Communication and Persuasion in the Digital Age" and click it to bring up the drawer
 - Verify that the location "differing runs table" now displays with proper spacing in the "location" section, a colon after "Location" and the spacing of the columns aligns with the designs
 - Search for "Introduction to Solid State Chemistry" and click it to bring up the drawer
 - Verify that there is no extra space above and below the description like there is here: https://rc.learn.mit.edu/search?q=introduction+to+solid+state+chemistry&resource=5358
 - Search for "Integrated Chemical Engineering II" and click it to bring up the drawer
 - Verify that you can click "Show more" under the description to reveal the rest of it, at then click "Show less" to collapse it
 - Verify that the small cards in the search results that have long titles are clamped at 3 lines (as opposed to 2)
