### PR TITLE
Add parent id to podcast api

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -3367,6 +3367,12 @@ export interface PodcastEpisodeResource {
    */
   podcast_episode: PodcastEpisode
   /**
+   * Get the playlist id(s) the video belongs to
+   * @type {Array<string>}
+   * @memberof PodcastEpisodeResource
+   */
+  podcasts: Array<string>
+  /**
    *
    * @type {string}
    * @memberof PodcastEpisodeResource

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -4336,6 +4336,12 @@ export interface PodcastEpisodeResource {
    */
   podcast_episode: PodcastEpisode
   /**
+   * Get the playlist id(s) the video belongs to
+   * @type {Array<string>}
+   * @memberof PodcastEpisodeResource
+   */
+  podcasts: Array<string>
+  /**
    *
    * @type {string}
    * @memberof PodcastEpisodeResource

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -629,6 +629,16 @@ class PodcastEpisodeResourceSerializer(LearningResourceBaseSerializer):
 
     podcast_episode = PodcastEpisodeSerializer(read_only=True)
 
+    podcasts = serializers.SerializerMethodField()
+
+    def get_podcasts(self, instance) -> list[str]:
+        """Get the playlist id(s) the video belongs to"""
+        return list(
+            instance.parents.filter(
+                relation_type=constants.LearningResourceRelationTypes.PODCAST_EPISODES.value
+            ).values_list("parent__id", flat=True)
+        )
+
 
 class VideoResourceSerializer(LearningResourceBaseSerializer):
     """Serializer for video resources"""

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -3272,6 +3272,12 @@ components:
           allOf:
           - $ref: '#/components/schemas/PodcastEpisode'
           readOnly: true
+        podcasts:
+          type: array
+          items:
+            type: string
+          description: Get the playlist id(s) the video belongs to
+          readOnly: true
         readable_id:
           type: string
           maxLength: 512
@@ -3346,6 +3352,7 @@ components:
       - pace
       - platform
       - podcast_episode
+      - podcasts
       - position
       - prices
       - professional

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -11563,6 +11563,12 @@ components:
           allOf:
           - $ref: '#/components/schemas/PodcastEpisode'
           readOnly: true
+        podcasts:
+          type: array
+          items:
+            type: string
+          description: Get the playlist id(s) the video belongs to
+          readOnly: true
         readable_id:
           type: string
           maxLength: 512
@@ -11637,6 +11643,7 @@ components:
       - pace
       - platform
       - podcast_episode
+      - podcasts
       - position
       - prices
       - professional


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/5886

### Description (What does it do?)
This pr adds the parent podcast id to podcast episode api responses

### How can this be tested?
1. checkout this branch. 
2. make sure you have podcasts loaded up locally `python manage.py backpopulate_podcast_data`
3. pick a podcast episode's id and visit the api endpoint http://open.odl.local:8063/api/v1/podcast_episodes/{episode id}/
4. note that there is a "podcasts" attribute that contains the parent podcast id
5. use that id to visit the podcast api http://open.odl.local:8063/api/v1/podcasts/{podcast id}/

