### PR TITLE
Randomize hero image index on the server

### DIFF
--- a/frontends/main/src/app-pages/HomePage/HomePage.test.tsx
+++ b/frontends/main/src/app-pages/HomePage/HomePage.test.tsx
@@ -83,7 +83,7 @@ const setupAPIs = () => {
 describe("Home Page Hero", () => {
   test("Submitting search goes to search page", async () => {
     setupAPIs()
-    const { location } = renderWithProviders(<HomePage />)
+    const { location } = renderWithProviders(<HomePage heroImageIndex={1} />)
     const searchbox = screen.getByRole("textbox", { name: /search for/i })
     await user.click(searchbox)
     await user.paste("physics")
@@ -101,7 +101,7 @@ describe("Home Page Hero", () => {
       results: [],
     })
     setupAPIs()
-    renderWithProviders(<HomePage />)
+    renderWithProviders(<HomePage heroImageIndex={1} />)
     const expected = [
       { label: "Topic", href: "/topics" },
       { label: "Recently Added", href: "/search?sortby=new" },
@@ -128,7 +128,7 @@ describe("Home Page Browse by Topic", () => {
     const response = learningResources.topics({ count: 3 })
     setMockResponse.get(urls.topics.list({ is_toplevel: true }), response)
 
-    renderWithProviders(<HomePage />)
+    renderWithProviders(<HomePage heroImageIndex={1} />)
 
     await waitFor(() => {
       const section = screen
@@ -258,7 +258,7 @@ describe("Home Page personalize section", () => {
   test("Links to dashboard when authenticated", async () => {
     setupAPIs()
 
-    renderWithProviders(<HomePage />)
+    renderWithProviders(<HomePage heroImageIndex={1} />)
     const personalize = (
       await screen.findByRole("heading", {
         name: "Continue Your Journey",
@@ -273,7 +273,7 @@ describe("Home Page personalize section", () => {
     setupAPIs()
 
     setMockResponse.get(urls.userMe.get(), {}, { code: 403 })
-    renderWithProviders(<HomePage />)
+    renderWithProviders(<HomePage heroImageIndex={1} />)
     const personalize = (
       await screen.findByRole("heading", {
         name: "Personalize Your Journey",
@@ -294,7 +294,7 @@ describe("Home Page Testimonials", () => {
   test("Displays testimonials carousel", async () => {
     setupAPIs()
 
-    renderWithProviders(<HomePage />)
+    renderWithProviders(<HomePage heroImageIndex={1} />)
 
     await waitFor(() => {
       screen.getAllByText(/testable title/i)
@@ -306,7 +306,7 @@ describe("Home Page Carousel", () => {
   test("Tabbed Carousel sanity check", async () => {
     setupAPIs()
 
-    renderWithProviders(<HomePage />)
+    renderWithProviders(<HomePage heroImageIndex={1} />)
 
     await screen.findAllByRole("tablist").then(([featured, media]) => {
       within(featured).getByRole("tab", { name: "All" })
@@ -325,7 +325,7 @@ describe("Home Page Carousel", () => {
 test("Headings", async () => {
   setupAPIs()
 
-  renderWithProviders(<HomePage />)
+  renderWithProviders(<HomePage heroImageIndex={1} />)
   await waitFor(() => {
     assertHeadings([
       { level: 1, name: "Learn with MIT" },

--- a/frontends/main/src/app-pages/HomePage/HomePage.tsx
+++ b/frontends/main/src/app-pages/HomePage/HomePage.tsx
@@ -44,13 +44,13 @@ const StyledContainer = styled(Container)({
   },
 })
 
-const HomePage: React.FC = () => {
+const HomePage: React.FC<{ heroImageIndex: number }> = ({ heroImageIndex }) => {
   return (
     <>
       <LearningResourceDrawer />
       <FullWidthBackground>
         <StyledContainer>
-          <HeroSearch />
+          <HeroSearch imageIndex={heroImageIndex} />
           <section>
             <FeaturedCoursesCarousel
               titleComponent="h2"

--- a/frontends/main/src/app/page.tsx
+++ b/frontends/main/src/app/page.tsx
@@ -81,7 +81,7 @@ const Page: React.FC = async () => {
 
   return (
     <Hydrate state={dehydratedState}>
-      <HomePage />
+      <HomePage heroImageIndex={Math.floor(Math.random() * 5) + 1} />
     </Hydrate>
   )
 }

--- a/frontends/main/src/page-components/HeroSearch/HeroSearch.tsx
+++ b/frontends/main/src/page-components/HeroSearch/HeroSearch.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState, useCallback, useEffect } from "react"
+import React, { useState, useCallback } from "react"
 import { useRouter } from "next/navigation"
 import {
   Typography,
@@ -192,29 +192,7 @@ const BoldLink = styled(Link)(({ theme }) => ({
   ...theme.typography.subtitle1,
 }))
 
-const HeroImage: React.FC = () => {
-  const [imageIndex, setImageIndex] = useState<number>()
-
-  useEffect(() => {
-    /* We need to set the random image index once in useEffece to prevent
-     * hydration mismatch between client and server
-     */
-    const index = Math.floor(Math.random() * 5) + 1
-    setImageIndex(index)
-  }, [])
-
-  if (!imageIndex) {
-    return <ImageContainer />
-  }
-
-  return (
-    <ImageContainer>
-      <Image alt="" src={`/images/hero/hero-${imageIndex}.png`} fill priority />
-    </ImageContainer>
-  )
-}
-
-const HeroSearch: React.FC = () => {
+const HeroSearch: React.FC<{ imageIndex: number }> = ({ imageIndex }) => {
   const [searchText, setSearchText] = useState("")
   const onSearchClear = useCallback(() => setSearchText(""), [])
   const router = useRouter()
@@ -281,7 +259,14 @@ const HeroSearch: React.FC = () => {
           </div>
         </ControlsContainer>
       </TitleAndControls>
-      <HeroImage />
+      <ImageContainer>
+        <Image
+          alt=""
+          src={`/images/hero/hero-${imageIndex}.png`}
+          fill
+          priority
+        />
+      </ImageContainer>
     </HeroWrapper>
   )
 }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Closes: https://github.com/mitodl/hq/issues/5921

### Description (What does it do?)
<!--- Describe your changes in detail -->

Selects the random Hero image index on the server so it can be server rendered.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

In development watch mode, refresh the homepage to see a the a randomized image selection and ensure that it is server rendered (ie. hero-_n_.png) appears in the HTML source.

### Additional context

We're caching for 30 mins on the CDNs - each image selection will be shown for that duration.
