### PR TITLE
Filter out content type on similar resources endpoint

### DIFF
--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -1040,9 +1040,13 @@ def test_similar_resources_endpoint_only_returns_published(mocker, client):
     for lr in response_resources:
         serialized_resource = serialize_learning_resource_for_update(lr)
         serialized_resource["published"] = False
+        lr.published = False
+        lr.save()
         response_hits.append(serialized_resource)
     # set one item to published
-    response_hits[-1]["published"] = True
+    published_resource = response_resources[0]
+    published_resource.published = True
+    published_resource.save()
     Search.execute.return_value = response.Response(
         Search().query(),
         {
@@ -1061,6 +1065,45 @@ def test_similar_resources_endpoint_only_returns_published(mocker, client):
     )
     response_ids = [hit["id"] for hit in resp.json()]
     assert len(response_ids) == 1
+
+
+def test_similar_resources_endpoint_ignores_opensearch_published(mocker, client):
+    """Test similar learning_resources ignores the published attribute from opensearch"""
+    from learning_resources.models import LearningResource
+
+    resources = LearningResourceFactory.create_batch(5)
+
+    resource_ids = [learning_resource.id for learning_resource in resources]
+    similar_for = resource_ids.pop()
+    mocker.patch.object(Search, "execute")
+    response_resources = LearningResource.objects.for_search_serialization().filter(
+        id__in=resource_ids
+    )
+    response_hits = []
+    for lr in response_resources:
+        serialized_resource = serialize_learning_resource_for_update(lr)
+        serialized_resource["published"] = False
+        response_hits.append(serialized_resource)
+    # remove the published attribute on one hit
+    del response_hits[-1]["published"]
+    Search.execute.return_value = response.Response(
+        Search().query(),
+        {
+            "_shards": {"failed": 0, "successful": 10, "total": 10},
+            "hits": {
+                "hits": response_hits,
+                "max_score": 12.0,
+                "total": 123,
+            },
+            "timed_out": False,
+            "took": 123,
+        },
+    ).hits
+    resp = client.get(
+        reverse("lr:v1:learning_resources_api-similar", args=[similar_for])
+    )
+    response_ids = [hit["id"] for hit in resp.json()]
+    assert len(response_ids) == 4
 
 
 def test_vector_similar_resources_endpoint_does_not_return_self(mocker, client):

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -1062,8 +1062,7 @@ def get_similar_resources_opensearch(
     response = search.execute()
     return LearningResource.objects.for_search_serialization().filter(
         id__in=[
-            resource.id
-            for resource in response.hits
-            if resource.id != value_doc["id"] and resource.published
-        ]
+            resource.id for resource in response.hits if resource.id != value_doc["id"]
+        ],
+        published=True,
     )

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -1046,18 +1046,20 @@ def get_similar_resources_opensearch(
     if num_resources:
         # adding +1 to num_resources since we filter out existing resource.id
         search = search.extra(size=num_resources + 1)
+    mlt_query = MoreLikeThis(
+        like=[{"doc": value_doc, "fields": list(value_doc.keys())}],
+        fields=[
+            "course.course_numbers.value",
+            "title",
+            "description",
+            "full_description",
+        ],
+        min_term_freq=min_term_freq,
+        min_doc_freq=min_doc_freq,
+    )
+    # return only learning_resources
     search = search.query(
-        MoreLikeThis(
-            like=[{"doc": value_doc, "fields": list(value_doc.keys())}],
-            fields=[
-                "course.course_numbers.value",
-                "title",
-                "description",
-                "full_description",
-            ],
-            min_term_freq=min_term_freq,
-            min_doc_freq=min_doc_freq,
-        )
+        "bool", must=[mlt_query], filter={"exists": {"field": "resource_type"}}
     )
     response = search.execute()
     return LearningResource.objects.for_search_serialization().filter(


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/mit-learn/issues/1862
### Description (What does it do?)
This PR fixes a bug with the similar resources endpoint that happens when a opensearch result is missing the published attribute (happens on unpublished contentfiles).


### How can this be tested?
I have included a test that will fail on main and pass on this branch. 
You can also visit the similar resources endpoint `http://open.odl.local:8063/api/v1/learning_resources/181/similar/` and validate that only learning resources are returned.

### Additional Context
Restricting this to just learning resources should fix the issue but I have also moved the check for "published" to the django filter instead of the opensearch response for added measure since we cant rely on that attribute in the index.
