### PR TITLE
fix card line clamping

### DIFF
--- a/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
+++ b/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
@@ -192,7 +192,7 @@ const Story: React.FC<{ item: NewsFeedItem; mobile: boolean }> = ({
       {item.image.url ? (
         <Card.Image src={item.image.url} alt={item.image.alt || ""} />
       ) : null}
-      <Card.Title href={item.url} style={{ marginBottom: -13 }}>
+      <Card.Title href={item.url} lines={2} style={{ marginBottom: -13 }}>
         {item.title}
       </Card.Title>
       <Card.Footer>

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -125,8 +125,9 @@ const Title = styled(Linkable, titleOpts)<{ size?: Size }>`
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 3;
 
-    > * {
-      -webkit-line-clamp: 3;
+    /* Any and all children of the card need to be clamped */
+    * {
+      -webkit-line-clamp: 3 !important;
     }
   }
 `

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -12,6 +12,7 @@ import { theme } from "../ThemeProvider/ThemeProvider"
 import { pxToRem } from "../ThemeProvider/typography"
 import Link from "next/link"
 import { default as NextImage, ImageProps as NextImageProps } from "next/image"
+import { TruncateText } from "../TruncateText/TruncateText"
 
 export type Size = "small" | "medium"
 
@@ -103,13 +104,14 @@ const Info = styled.div<{ size?: Size }>`
 `
 
 const titleOpts = {
-  shouldForwardProp: (prop: string) => prop !== "size",
+  shouldForwardProp: (prop: string) => prop !== "lines" && prop !== "size",
 }
-const Title = styled(Linkable, titleOpts)<{ size?: Size }>`
+const Title = styled(Linkable, titleOpts)<{ size?: Size; lines?: number }>`
+  display: flex;
   text-overflow: ellipsis;
-  height: ${({ size }) => {
+  height: ${({ size, lines }) => {
     const lineHeightPx = size === "small" ? 18 : 20
-    return theme.typography.pxToRem(3 * lineHeightPx)
+    return theme.typography.pxToRem((lines || 3) * lineHeightPx)
   }};
   overflow: hidden;
   margin: 0;
@@ -118,18 +120,6 @@ const Title = styled(Linkable, titleOpts)<{ size?: Size }>`
     size === "small"
       ? { ...theme.typography.subtitle2 }
       : { ...theme.typography.subtitle1 }}
-
-  @supports (-webkit-line-clamp: 3) {
-    white-space: initial;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 3;
-
-    /* Any and all children of the card need to be clamped */
-    * {
-      -webkit-line-clamp: 3 !important;
-    }
-  }
 `
 
 const Footer = styled.span`
@@ -225,6 +215,7 @@ export type ImageProps = NextImageProps & {
 type TitleProps = {
   children?: ReactNode
   href?: string
+  lines?: number
   style?: CSSProperties
 }
 
@@ -301,6 +292,7 @@ const Card: Card = ({
   const handleClick = forwardClicksToLink ? handleHrefClick : onClick
 
   const allClassNames = ["MitCard-root", className ?? ""].join(" ")
+  const lines = title.lines || 3
 
   if (content) {
     return (
@@ -343,9 +335,10 @@ const Card: Card = ({
           data-card-link={!!title.href}
           className="MitCard-title"
           size={size}
+          lines={lines}
           {...title}
         >
-          {title.children}
+          <TruncateText lineClamp={lines}>{title.children}</TruncateText>
         </Title>
       </Body>
       <Bottom>

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -12,7 +12,7 @@ import { theme } from "../ThemeProvider/ThemeProvider"
 import { pxToRem } from "../ThemeProvider/typography"
 import Link from "next/link"
 import { default as NextImage, ImageProps as NextImageProps } from "next/image"
-import { TruncateText } from "../TruncateText/TruncateText"
+import { truncateText } from "../TruncateText/TruncateText"
 
 export type Size = "small" | "medium"
 
@@ -106,21 +106,29 @@ const Info = styled.div<{ size?: Size }>`
 const titleOpts = {
   shouldForwardProp: (prop: string) => prop !== "lines" && prop !== "size",
 }
-const Title = styled(Linkable, titleOpts)<{ size?: Size; lines?: number }>`
-  display: flex;
-  text-overflow: ellipsis;
-  height: ${({ size, lines }) => {
-    const lineHeightPx = size === "small" ? 18 : 20
-    return theme.typography.pxToRem((lines || 3) * lineHeightPx)
-  }};
-  overflow: hidden;
-  margin: 0;
-
-  ${({ size }) =>
+const Title = styled(
+  Linkable,
+  titleOpts,
+)<{ size?: Size; lines?: number }>(({ theme, size, lines = 3 }) => {
+  return [
+    {
+      display: "flex",
+      textOverflow: "ellipsis",
+      overflow: "hidden",
+      margin: 0,
+      ...truncateText(lines),
+    },
     size === "small"
-      ? { ...theme.typography.subtitle2 }
-      : { ...theme.typography.subtitle1 }}
-`
+      ? {
+          ...theme.typography.subtitle2,
+          height: theme.typography.pxToRem(18 * lines),
+        }
+      : {
+          ...theme.typography.subtitle1,
+          height: theme.typography.pxToRem(20 * lines),
+        },
+  ]
+})
 
 const Footer = styled.span`
   display: block;
@@ -292,7 +300,6 @@ const Card: Card = ({
   const handleClick = forwardClicksToLink ? handleHrefClick : onClick
 
   const allClassNames = ["MitCard-root", className ?? ""].join(" ")
-  const lines = title.lines || 3
 
   if (content) {
     return (
@@ -335,11 +342,8 @@ const Card: Card = ({
           data-card-link={!!title.href}
           className="MitCard-title"
           size={size}
-          lines={lines}
           {...title}
-        >
-          <TruncateText lineClamp={lines}>{title.children}</TruncateText>
-        </Title>
+        />
       </Body>
       <Bottom>
         <Footer className="MitCard-footer" {...footer}>

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -121,11 +121,11 @@ const Title = styled(
     size === "small"
       ? {
           ...theme.typography.subtitle2,
-          height: theme.typography.pxToRem(18 * lines),
+          height: `calc(${lines} * ${theme.typography.subtitle2.lineHeight})`,
         }
       : {
           ...theme.typography.subtitle1,
-          height: theme.typography.pxToRem(20 * lines),
+          height: `calc(${lines} * ${theme.typography.subtitle1.lineHeight})`,
         },
   ]
 })

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -18,15 +18,10 @@ import {
 } from "ol-utilities"
 import { Card } from "../Card/Card"
 import type { Size } from "../Card/Card"
-import { TruncateText } from "../TruncateText/TruncateText"
 import { ActionButton, ActionButtonProps } from "../Button/Button"
 import { imgConfigs } from "../../constants/imgConfigs"
 import { theme } from "../ThemeProvider/ThemeProvider"
 import Tooltip from "@mui/material/Tooltip"
-
-const EllipsisTitle = styled(TruncateText)({
-  margin: 0,
-})
 
 const SkeletonImage = styled(Skeleton)<{ aspect: number }>`
   padding-bottom: ${({ aspect }) => 100 / aspect}%;
@@ -247,11 +242,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
       <Card.Info>
         <Info resource={resource} size={size} />
       </Card.Info>
-      <Card.Title href={href}>
-        <EllipsisTitle lineClamp={size === "small" ? 2 : 3}>
-          {resource.title}
-        </EllipsisTitle>
-      </Card.Title>
+      <Card.Title href={href}>{resource.title}</Card.Title>
       <Card.Actions>
         {onAddToLearningPathClick && (
           <CardActionButton


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up for https://github.com/mitodl/mit-learn/pull/1850

### Description (What does it do?)
In the above PR, we adjusted the line clamping rules in the `Card` component. Unfortunately, it didn't work in every scenario and this adjustment is needed to ensure that all children of the `Title` within `Card` have the line clamp rule applied.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/a7ab24fa-ad2e-46be-806f-bf36c519080c)
![image](https://github.com/user-attachments/assets/fbaeade7-1d11-4742-92c0-b12f99791ddc)
![image](https://github.com/user-attachments/assets/055ea3d8-34ab-4b89-890e-6171c5dd84bd)
![image](https://github.com/user-attachments/assets/2e188b6b-e2e7-4395-9410-3d39a7a191cc)

### How can this be tested?
 - If you have Posthog set up locally, enable the `lr_drawer_v2` flag
 - If you don't have Posthog set up locally, you can force `drawerV2` to be `true` in `LearningResourceDrawer.tsx`
 - Spin up this branch of `mit-learn`
 - Ensure you have sufficient data backpopulated into your local instance, including some OCW and Sloan courses
 - Visit the home page at http://localhost:8062/
 - Scroll down to the news section and verify that 3 lines of the title are revealed, with an ellipsis included if line clamping is happening
 - Visit the search page at http://localhost:8062/search
 - Click on some results until you get one with a recommended course card with a long title, and verify that it is being clamped at 3 lines
