### PR TITLE
fix certification type none display

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -344,7 +344,7 @@ const INFO_ITEMS: InfoItemConfig = [
     label: "Certificate:",
     Icon: RiAwardLine,
     selector: (resource: LearningResource) => {
-      return resource.certification_type && !resource.free ? (
+      return resource.certification_type ? (
         <InfoItemValue
           label={resource.certification_type.name}
           index={1}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -18,7 +18,12 @@ import {
   RiMapPinLine,
   RiCalendarScheduleLine,
 } from "@remixicon/react"
-import { DeliveryEnum, LearningResource, ResourceTypeEnum } from "api"
+import {
+  CertificationTypeEnum,
+  DeliveryEnum,
+  LearningResource,
+  ResourceTypeEnum,
+} from "api"
 import {
   allRunsAreIdentical,
   formatDurationClockTime,
@@ -344,7 +349,9 @@ const INFO_ITEMS: InfoItemConfig = [
     label: "Certificate:",
     Icon: RiAwardLine,
     selector: (resource: LearningResource) => {
-      return resource.certification_type ? (
+      return (resource.certification_type && !resource.free) ||
+        (resource.free &&
+          resource.certification_type?.code === CertificationTypeEnum.None) ? (
         <InfoItemValue
           label={resource.certification_type.name}
           index={1}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6170

### Description (What does it do?)
In https://github.com/mitodl/mit-learn/pull/1823, we tweaked the way certifications are displayed in the v2 learning resource drawer. It was overlooked that if a resource is free and doesn't offer a paid certificate, "none" is an explicit certification type that should be displayed. This PR corrects that.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/b110bcd1-d3ed-4cba-a3a4-9c97d79f36cc)
![image](https://github.com/user-attachments/assets/ffdab436-92ae-4813-9c45-57a42c5a7cb1)

### How can this be tested?
 - If you have Posthog set up locally, enable the `lr_drawer_v2` flag
 - If you don't have Posthog set up locally, you can force `drawerV2` to be `true` in `LearningResourceDrawer.tsx`
 - Spin up this branch of `mit-learn`
 - Ensure you have sufficient data backpopulated into your local instance to cover the following test cases:
   - Free course without certification
   - Free course with certification and no prices
   - Free course with certification and prices
   - Paid course with certification
 - Visit the search page at http://localhost:8062/search
 - In the search facets on the left hand side, select "No Certificate"
 - Click any of the results to bring up the learning resource drawer, and verify that "Certificate: No Certificate" is displayed
 - Close the drawer and check only the "Free" and "Certificate of Completion" search facets
 - Click any of the results to bring up the learning resource drawer, and verify that the "Certificate:" info item is *not* displayed and the certificate info is instead displayed next to the "Price: Free" info item
 - Close the drawer and select only the "Professional Certificate" facet
 - Click on any of the results and verify that you see the "Certificate: Professional Certificate" info item
