### PR TITLE
fix drawer sticking

### DIFF
--- a/frontends/ol-components/src/components/RoutedDrawer/RoutedDrawer.test.tsx
+++ b/frontends/ol-components/src/components/RoutedDrawer/RoutedDrawer.test.tsx
@@ -1,6 +1,7 @@
 import { RoutedDrawer } from "./RoutedDrawer"
 import type { RoutedDrawerProps } from "./RoutedDrawer"
 import {
+  ByRoleOptions,
   render,
   screen,
   waitForElementToBeRemoved,
@@ -18,8 +19,8 @@ const TestDrawerContents = ({ closeDrawer }: { closeDrawer: () => void }) => (
     </button>
   </section>
 )
-const getDrawerContent = () =>
-  screen.getByRole("heading", { name: "DrawerContent" })
+const getDrawerContent = (opts: ByRoleOptions = {}) =>
+  screen.getByRole("heading", { name: "DrawerContent", ...opts })
 
 const renderRoutedDrawer = <P extends string, R extends P>(
   props: Omit<RoutedDrawerProps<P, R>, "children">,
@@ -124,6 +125,24 @@ describe("RoutedDrawer", () => {
     await waitForElementToBeRemoved(content)
 
     expect(mockRouter.query).toEqual({})
+  })
+
+  it("Renders previous search params while closing drawer", async () => {
+    const params = ["a"]
+    const requiredParams = ["a"]
+    const initialSearch = "a=1"
+    const { childFn } = renderRoutedDrawer(
+      { params, requiredParams },
+      initialSearch,
+      "",
+    )
+
+    await user.click(screen.getByRole("button", { name: "CloseFn" }))
+    await waitForElementToBeRemoved(getDrawerContent({ hidden: true }))
+    expect(childFn).toHaveBeenLastCalledWith({
+      params: { a: "1" },
+      closeDrawer: expect.any(Function),
+    })
   })
 
   it("Restores any hash params that were in the initial request", async () => {


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/6150

### Description (What does it do?)
Fixes a bug where the drawer was sticking sometimes—getting stuck in an openable state.


### How can this be tested?
1. On `main` homepage: Click a card to open the drawer, then click outside the drawer to close it, and quickly click a different card.
    - you'll be stuck in a state where `?resource=1234` is in the URL, but drawer is not open.
2. Try on this branch. Drawer will not stick.


