### PR TITLE
fix price comparison in differing runs table

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/testUtils.ts
@@ -193,6 +193,7 @@ const courses = {
     sameData: makeResource({
       resource_type: ResourceTypeEnum.Course,
       free: true,
+      certification: true,
       runs: [
         factories.learningResources.run({
           delivery: sameDataRun.delivery,

--- a/frontends/ol-utilities/src/learning-resources/learning-resources.test.ts
+++ b/frontends/ol-utilities/src/learning-resources/learning-resources.test.ts
@@ -149,6 +149,28 @@ describe("allRunsAreIdentical", () => {
     expect(allRunsAreIdentical(resource)).toBe(false)
   })
 
+  test("returns true if prices differ but have same numerical value", () => {
+    const resource = factories.learningResources.resource()
+    const delivery = [
+      { code: CourseResourceDeliveryInnerCodeEnum.InPerson, name: "In person" },
+    ]
+    const location = "New York"
+    resource.free = true
+    resource.runs = [
+      makeRun({
+        resource_prices: [{ amount: "0", currency: "USD" }],
+        delivery: delivery,
+        location: location,
+      }),
+      makeRun({
+        resource_prices: [{ amount: "0.00", currency: "USD" }],
+        delivery: delivery,
+        location: location,
+      }),
+    ]
+    expect(allRunsAreIdentical(resource)).toBe(true)
+  })
+
   test("returns false if delivery methods differ", () => {
     const resource = factories.learningResources.resource()
     const prices = [{ amount: "100", currency: "USD" }]

--- a/frontends/ol-utilities/src/learning-resources/learning-resources.ts
+++ b/frontends/ol-utilities/src/learning-resources/learning-resources.ts
@@ -136,7 +136,7 @@ const allRunsAreIdentical = (resource: LearningResource) => {
   for (const run of resource.runs) {
     if (run.resource_prices) {
       run.resource_prices.forEach((price) => {
-        if (!(resource.free && price.amount === "0")) {
+        if (!(resource.free && Number(price.amount) === 0)) {
           amounts.add(price.amount)
           currencies.add(price.currency)
         }

--- a/frontends/ol-utilities/src/learning-resources/learning-resources.ts
+++ b/frontends/ol-utilities/src/learning-resources/learning-resources.ts
@@ -129,17 +129,15 @@ const allRunsAreIdentical = (resource: LearningResource) => {
   if (resource.runs.length <= 1) {
     return true
   }
-  const amounts = new Set<string>()
+  const amounts = new Set<number>()
   const currencies = new Set<string>()
   const deliveryMethods = new Set<string>()
   const locations = new Set<string>()
   for (const run of resource.runs) {
     if (run.resource_prices) {
       run.resource_prices.forEach((price) => {
-        if (!(resource.free && Number(price.amount) === 0)) {
-          amounts.add(price.amount)
-          currencies.add(price.currency)
-        }
+        amounts.add(Number(price.amount))
+        currencies.add(price.currency)
       })
     }
     if (run.delivery) {
@@ -151,11 +149,12 @@ const allRunsAreIdentical = (resource: LearningResource) => {
       locations.add(run.location)
     }
   }
+  const expectedPrices = resource.free && resource.certification ? 2 : 1
   const hasInPerson = [...deliveryMethods].some(
     (dm) => dm === DeliveryEnum.InPerson,
   )
   return (
-    amounts.size === 1 &&
+    amounts.size === expectedPrices &&
     currencies.size === 1 &&
     deliveryMethods.size === 1 &&
     (hasInPerson ? locations.size === 1 : locations.size === 0)


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6169

### Description (What does it do?)
This PR fixes an issue with the function `allRunsAreIdentical`, which determines if all of the runs of a given course are identical or not for the purposes of displaying the "differing runs table" in the new learning resource drawer. Previously, a string comparison was being made against `price.amount` and a string of `"0"`. Some runs have their price stored as `"0.00"` which was making the comparison fail. To be sure it won't fail in the future, this value is being converted to a `number` before comparison, which should negate any issues with string comparison.

### How can this be tested?
 - If you have Posthog set up locally, enable the `lr_drawer_v2` flag
 - If you don't have Posthog set up locally, you can force `drawerV2` to be `true` in `LearningResourceDrawer.tsx`
 - Spin up this branch of `mit-learn`
 - Ensure you have Sloan courses backpopulated in your database
 - Visit the search page at http://localhost:8062/search
 - Search for the course "Supply Chain Fundamentals"
 - Click the top search result and verify that the differing runs table does not appear
 - Search for "Communication and Persuasion in the Digital Age"
 - Click the top search result and verify that the differing runs table still appears for this course
