### PR TITLE
specify non-free course for differing prices test

### DIFF
--- a/frontends/ol-utilities/src/learning-resources/learning-resources.test.ts
+++ b/frontends/ol-utilities/src/learning-resources/learning-resources.test.ts
@@ -123,7 +123,10 @@ describe("allRunsAreIdentical", () => {
   })
 
   test("returns false if prices differ", () => {
-    const resource = factories.learningResources.resource()
+    const resource = factories.learningResources.resource({
+      free: false,
+      certification: false,
+    })
     const prices = [{ amount: "100", currency: "USD" }]
     const delivery = [
       { code: CourseResourceDeliveryInnerCodeEnum.InPerson, name: "In person" },


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up for https://github.com/mitodl/mit-learn/pull/1876

### Description (What does it do?)
This PR fixes a flaky test introduced in the above PR

### How can this be tested?
 - In `frontends/ol-utilities/src/learning-resources/learning-resources.test.ts`, on line 125, modify it to be `test.each(new Array(1000).fill(null))("returns false if prices differ", () => {` to repeat the test 1000 times
 - Spin up `mit-learn`
 - Run `docker compose exec watch yarn test learning-resources`
 - Verify that the tests pass every time
