### PR TITLE
Populate OCW file extensions

### DIFF
--- a/learning_resources/etl/ocw.py
+++ b/learning_resources/etl/ocw.py
@@ -254,10 +254,12 @@ def transform_contentfile(
         content_type = CONTENT_TYPE_VIDEO
         file_s3_path = contentfile_data.get("transcript_file")
         image_src = contentfile_data.get("thumbnail_file")
+        file_extension = Path(contentfile_data.get("file")).suffix
     else:
         content_type = get_content_type(file_type)
         file_s3_path = contentfile_data.get("file")
         image_src = None
+        file_extension = Path(file_s3_path).suffix
 
     title = contentfile_data.get("title")
 
@@ -274,6 +276,7 @@ def transform_contentfile(
         "key": s3_path,
         "content_tags": contentfile_data.get("learning_resource_types"),
         "published": True,
+        "file_extension": file_extension,
     }
 
     if not file_s3_path.startswith("courses"):

--- a/learning_resources/etl/ocw_test.py
+++ b/learning_resources/etl/ocw_test.py
@@ -41,7 +41,7 @@ pytestmark = pytest.mark.django_db
 @pytest.mark.parametrize("base_ocw_url", ["http://test.edu/", "http://test.edu"])
 def test_transform_content_files(settings, mocker, base_ocw_url):
     """
-    Test transform_content_files
+    Test that ocw.transform_content_files returns the expected data
     """
     settings.OCW_BASE_URL = base_ocw_url
     ocw_url = base_ocw_url.rstrip("/")
@@ -94,6 +94,7 @@ def test_transform_content_files(settings, mocker, base_ocw_url):
         "title": "Resource Title",
         "content_title": "Resource Title",
         "url": f"{ocw_url}/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/resource/",
+        "file_extension": ".pdf",
     }
 
     assert content_data[3] == {
@@ -108,13 +109,14 @@ def test_transform_content_files(settings, mocker, base_ocw_url):
         "content_title": None,
         "url": f"{ocw_url}/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video/",
         "image_src": "https://img.youtube.com/vi/vKer2U5W5-s/default.jpg",
+        "file_extension": ".mp4",
     }
 
 
 @mock_aws
 def test_transform_content_files_exceptions(settings, mocker):
     """
-    Test transform_content_files
+    Test that ocw.transform_content_files logs exceptions
     """
 
     setup_s3_ocw(settings)


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6222 - for now this just populates the file extension and does not do additional cleaning pending this discussion https://github.com/mitodl/hq/discussions/6230

### Description (What does it do?)
After  https://github.com/mitodl/mit-learn/pull/1867 we populate file extensions for edx files. This populates them for ocw

### How can this be tested?
run ./manage.py
backpopulate_ocw_data 6-100l-introduction-to-cs-and-programming-using-python-fall-2022 --overwrite

From the shell run
```
from learning_resources.models import *
run = LearningResource.objects.filter(url__contains='6-100l-introduction-to-cs-and-programming-using-python-fall-2022').runs.first()
ContentFile.objects.filter(run=run).filter(content_type='file').filter(file_extension__isnull=True).count() 
```
should return zero

Spot check some content files from `ContentFile.objects.filter(run=run).filter(content_type='file')` to check that that the file extension makes sense


