### PR TITLE
subscription email language update

### DIFF
--- a/learning_resources_search/tasks.py
+++ b/learning_resources_search/tasks.py
@@ -923,7 +923,11 @@ def _generate_subscription_digest_subject(
 
     """
     prefix = "" if shortform else "MIT Learn: "
-    resource_type = unique_resource_types.pop()
+    if len(unique_resource_types) == 1:
+        resource_type = unique_resource_types.pop()
+    else:
+        resource_type = "Learning Resource"
+
     if sample_course["source_channel_type"] == "saved_search":
         if shortform:
             return f"New {resource_type}{pluralize(total_count)} from MIT Learn"

--- a/learning_resources_search/tasks.py
+++ b/learning_resources_search/tasks.py
@@ -960,8 +960,8 @@ def attempt_send_digest_email_batch(user_template_items):
             continue
         user = User.objects.get(id=user_id)
 
-        unique_resource_types = set()
         for group in template_data:
+            unique_resource_types = set()
             total_count = len(template_data[group])
             unique_resource_types.update(
                 [resource["resource_type"] for resource in template_data[group]]

--- a/learning_resources_search/tasks_test.py
+++ b/learning_resources_search/tasks_test.py
@@ -994,6 +994,36 @@ def test_subscription_digest_subject():
     assert subject_line == "New courses from management"
 
 
+def test_subscription_digest_subject_multiple_types():
+    """
+    Test that when there are multiple unique resource types
+    we use Leaning Resource in the header
+    """
+    resource_types = {"program"}
+    sample_course = {"source_channel_type": "topic", "resource_title": "robotics"}
+
+    subject_line = _generate_subscription_digest_subject(
+        sample_course,
+        "electronics",
+        resource_types,
+        total_count=1,
+        shortform=False,
+    )
+    assert subject_line == "MIT Learn: New program in electronics: robotics"
+
+    sample_course = {"source_channel_type": "podcast", "resource_title": "robotics"}
+    resource_types = {"program", "video", "podcast"}
+
+    subject_line = _generate_subscription_digest_subject(
+        sample_course,
+        "xpro",
+        resource_types,
+        total_count=9,
+        shortform=False,
+    )
+    assert subject_line == "MIT Learn: New Learning Resources from xpro: robotics"
+
+
 def test_update_featured_rank(mocker, offeror_featured_lists):
     """The updated_featured_rank task should make the expected calls"""
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/5888

### Description (What does it do?)
This PR changes the subscription email so that when there is more than one resource type in the email (videos + courses + podcasts) it labels it as "learning resources" in the subject line (currently it just arbitrarily picks one resource type from the list)


### How can this be tested?
To test this:
1. checkout this branch
2. set the required settings in settings.py for email to work (MAILGUN_SENDER_DOMAIN, MAILGUN_KEY,MAILGUN_FROM_EMAIL) from the heroku rc settings. 
3. set NOTIFICATION_EMAIL_BACKEND to "anymail.backends.mailgun.EmailBackend"
4. restart celery
6. login locally, make sure your user's email is set to an inbox you have access to. 
7. "subscribe" to all the available provider channels ocw, mitx etc
8. set some number of learning resources to have a created_on date to today. convenience script: 
```
from learning_resource.models import LearningResource
from main.utils import now_in_utc
resources = LearningResource.objects.all()[:30]
for resource in resources:
	resource.created_on = now_in_utc()
	resource.save()
```
9. manually send the daily subscription email via:
```
from learning_resources_search.tasks import send_subscription_emails
send_subscription_emails("channel_subscription_type") 
```
10.  you should receive more than one subscription email. The emails that contain only one unique resource type should say the name of the resource type in the header, the emails with mixed resource types should refer to them as "learning resources"
