### PR TITLE
drawer v2 - share resource

### DIFF
--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.test.tsx
@@ -150,11 +150,11 @@ describe("LearningResourceDrawerV2", () => {
       const section = screen.getByTestId("drawer-cta")
 
       const buttons = within(section).getAllByRole("button")
-      const expectedButtons = expectAddToLearningPathButton ? 2 : 1
+      const expectedButtons = expectAddToLearningPathButton ? 3 : 2
       expect(buttons).toHaveLength(expectedButtons)
       expect(
         !!within(section).queryByRole("button", {
-          name: "Add to Learning Path",
+          name: "Add to list",
         }),
       ).toBe(expectAddToLearningPathButton)
     },

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -22,6 +22,7 @@ import { usePostHog } from "posthog-js/react"
 import ResourceCarousel from "../ResourceCarousel/ResourceCarousel"
 import { useIsLearningPathMember } from "api/hooks/learningPaths"
 import { useIsUserListMember } from "api/hooks/userLists"
+import { usePathname, useSearchParams } from "next/navigation"
 
 const RESOURCE_DRAWER_PARAMS = [RESOURCE_DRAWER_QUERY_PARAM] as const
 
@@ -67,6 +68,8 @@ const DrawerContent: React.FC<{
   resourceId: number
   closeDrawer: () => void
 }> = ({ resourceId, closeDrawer }) => {
+  const currentPath = usePathname()
+  const searchParams = useSearchParams()
   const resource = useLearningResourcesDetail(Number(resourceId))
   const [signupEl, setSignupEl] = React.useState<HTMLElement | null>(null)
   const { data: user } = useUserMe()
@@ -135,6 +138,7 @@ const DrawerContent: React.FC<{
         resource={resource.data}
         carousels={[similarResourcesCarousel, vectorSimilarResourcesCarousel]}
         user={user}
+        location={`${window.location.origin}${currentPath}?${searchParams}`}
         inLearningPath={inLearningPath}
         inUserList={inUserList}
         onAddToLearningPathClick={handleAddToLearningPathClick}

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -22,7 +22,6 @@ import { usePostHog } from "posthog-js/react"
 import ResourceCarousel from "../ResourceCarousel/ResourceCarousel"
 import { useIsLearningPathMember } from "api/hooks/learningPaths"
 import { useIsUserListMember } from "api/hooks/userLists"
-import { usePathname, useSearchParams } from "next/navigation"
 
 const RESOURCE_DRAWER_PARAMS = [RESOURCE_DRAWER_QUERY_PARAM] as const
 
@@ -68,8 +67,6 @@ const DrawerContent: React.FC<{
   resourceId: number
   closeDrawer: () => void
 }> = ({ resourceId, closeDrawer }) => {
-  const currentPath = usePathname()
-  const searchParams = useSearchParams()
   const resource = useLearningResourcesDetail(Number(resourceId))
   const [signupEl, setSignupEl] = React.useState<HTMLElement | null>(null)
   const { data: user } = useUserMe()
@@ -138,7 +135,7 @@ const DrawerContent: React.FC<{
         resource={resource.data}
         carousels={[similarResourcesCarousel, vectorSimilarResourcesCarousel]}
         user={user}
-        location={`${window.location.origin}${currentPath}?${searchParams}`}
+        shareUrl={`${window.location.origin}/search?${RESOURCE_DRAWER_QUERY_PARAM}=${resourceId}`}
         inLearningPath={inLearningPath}
         inUserList={inUserList}
         onAddToLearningPathClick={handleAddToLearningPathClick}

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -262,12 +262,17 @@ const IconContainer = styled.span<{ side: "start" | "end"; size: ButtonSize }>(
       alignItems: "center",
     },
     side === "start" && {
-      marginLeft: "0",
-      marginRight: "4px",
+      /**
+       * The negative margin is to counteract the padding on the button itself.
+       * Without icons, the left space is 24/16/12 px.
+       * With icons, the left space is 20/12/8 px.
+       */
+      marginLeft: "-4px",
+      marginRight: "8px",
     },
     side === "end" && {
-      marginLeft: "4px",
-      marginRight: "0",
+      marginLeft: "8px",
+      marginRight: "-4px",
     },
     {
       "& svg, & .MuiSvgIcon-root": {

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -262,17 +262,12 @@ const IconContainer = styled.span<{ side: "start" | "end"; size: ButtonSize }>(
       alignItems: "center",
     },
     side === "start" && {
-      /**
-       * The negative margin is to counteract the padding on the button itself.
-       * Without icons, the left space is 24/16/12 px.
-       * With icons, the left space is 20/12/8 px.
-       */
-      marginLeft: "-4px",
-      marginRight: "8px",
+      marginLeft: "0",
+      marginRight: "4px",
     },
     side === "end" && {
-      marginLeft: "8px",
-      marginRight: "-4px",
+      marginLeft: "4px",
+      marginRight: "0",
     },
     {
       "& svg, & .MuiSvgIcon-root": {

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.test.tsx
@@ -340,5 +340,6 @@ describe("Learning Resource Expanded", () => {
     expect(writeText).toHaveBeenCalledWith(
       `https://learn.mit.edu/search?resource=${resource.id}`,
     )
+    expect(copyButton).toHaveTextContent("Copied!")
   })
 })

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.test.tsx
@@ -306,13 +306,12 @@ describe("Learning Resource Expanded", () => {
 
     setup(resource)
 
-    const shareButton = screen.getByRole("button", { name: "Share" })
-    fireEvent.click(shareButton)
+    fireEvent.click(screen.getByRole("button", { name: "Share" }))
 
     const shareSection = screen.getByTestId("drawer-share")
     expect(shareSection).toBeInTheDocument()
 
-    fireEvent.click(shareButton)
+    fireEvent.click(screen.getByRole("button", { name: "Share" }))
     expect(shareSection).not.toBeInTheDocument()
   })
 

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { BrowserRouter } from "react-router-dom"
-import { fireEvent, render, screen, within } from "@testing-library/react"
+import { render, screen, within } from "@testing-library/react"
 
 import {
   getCallToActionText,
@@ -14,6 +14,7 @@ import invariant from "tiny-invariant"
 import type { LearningResource } from "api"
 import { PLATFORM_LOGOS } from "../Logo/Logo"
 import _ from "lodash"
+import user from "@testing-library/user-event"
 
 const IMG_CONFIG: LearningResourceExpandedV2Props["imgConfig"] = {
   width: 385,
@@ -299,19 +300,19 @@ describe("Learning Resource Expanded", () => {
     },
   )
 
-  test("Clicking the share button toggles the share section", () => {
+  test("Clicking the share button toggles the share section", async () => {
     const resource = factories.learningResources.resource({
       resource_type: ResourceTypeEnum.Course,
     })
 
     setup(resource)
 
-    fireEvent.click(screen.getByRole("button", { name: "Share" }))
+    await user.click(screen.getByRole("button", { name: "Share" }))
 
     const shareSection = screen.getByTestId("drawer-share")
     expect(shareSection).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole("button", { name: "Share" }))
+    await user.click(screen.getByRole("button", { name: "Share" }))
     expect(shareSection).not.toBeInTheDocument()
   })
 
@@ -329,14 +330,14 @@ describe("Learning Resource Expanded", () => {
     setup(resource)
 
     const shareButton = screen.getByRole("button", { name: "Share" })
-    fireEvent.click(shareButton)
+    await user.click(shareButton)
 
     const shareSection = screen.getByTestId("drawer-share")
     const copyButton = within(shareSection).getByRole("button", {
       name: "Copy Link",
     })
 
-    fireEvent.click(copyButton)
+    await user.click(copyButton)
     expect(writeText).toHaveBeenCalledWith(
       `https://learn.mit.edu/search?resource=${resource.id}`,
     )

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -276,6 +276,9 @@ const ShareLink = styled(Link)({
 
 const CopyLinkButton = styled(StyledButton)({
   flexGrow: 0,
+  flexBasis: "112px",
+  padding: "12px 16px",
+  whiteSpace: "nowrap",
   "span:first-of-type": {
     color: theme.custom.colors.red,
   },

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -270,7 +270,6 @@ const ShareLink = styled(Link)({
 const CopyLinkButton = styled(NoWrapButton)({
   flexGrow: 0,
   flexBasis: "112px",
-  // padding: "12px 16px",
   "span:first-of-type": {
     color: theme.custom.colors.red,
   },

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useRef, useState } from "react"
 import styled from "@emotion/styled"
 import Skeleton from "@mui/material/Skeleton"
-import Typography from "@mui/material/Typography"
 import { default as NextImage } from "next/image"
 import { ActionButton, Button, ButtonLink, ButtonProps } from "../Button/Button"
 import type { LearningResource } from "api"
@@ -12,8 +11,12 @@ import {
   RiBookmarkLine,
   RiCloseLargeLine,
   RiExternalLinkLine,
+  RiFacebookFill,
+  RiLink,
+  RiLinkedinFill,
   RiMenuAddLine,
   RiShareLine,
+  RiTwitterXLine,
 } from "@remixicon/react"
 import type { ImageConfig } from "../../constants/imgConfigs"
 import { theme } from "../ThemeProvider/ThemeProvider"
@@ -23,6 +26,8 @@ import type { User } from "api/hooks/user"
 import { LearningResourceCardProps } from "../LearningResourceCard/LearningResourceCard"
 import VideoFrame from "./VideoFrame"
 import { Link } from "../Link/Link"
+import { Input } from "../Input/Input"
+import { Typography } from "../.."
 
 const DRAWER_WIDTH = "900px"
 
@@ -225,6 +230,49 @@ const StyledButton = styled(Button)<{ filled?: number }>((props) => {
   }
 })
 
+const ShareContainer = styled.div({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  alignSelf: "stretch",
+  padding: "16px 0 8px 0",
+  gap: "12px",
+})
+
+const ShareLabel = styled(Typography)({
+  ...theme.typography.body3,
+  color: theme.custom.colors.darkGray2,
+})
+
+const ShareInput = styled(Input)({
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  alignItems: "flexStart",
+  alignSelf: "stretch",
+})
+
+const ShareButtonContainer = styled.div({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  alignSelf: "stretch",
+  gap: "16px",
+})
+
+const ShareLink = styled(Link)({
+  color: theme.custom.colors.silverGrayDark,
+})
+
+const CopyLinkButton = styled(StyledButton)({
+  "span:first-of-type": {
+    color: theme.custom.colors.red,
+    "&:hover": {
+      color: theme.custom.colors.white,
+    },
+  },
+})
+
 const CarouselContainer = styled.div({
   display: "flex",
   flexDirection: "column",
@@ -247,6 +295,7 @@ const CarouselContainer = styled.div({
 type LearningResourceExpandedV2Props = {
   resource?: LearningResource
   user?: User
+  location: string
   imgConfig: ImageConfig
   carousels?: React.ReactNode[]
   inLearningPath?: boolean
@@ -407,6 +456,7 @@ const CallToActionSection = ({
   resource,
   hide,
   user,
+  location,
   inUserList,
   inLearningPath,
   onAddToLearningPathClick,
@@ -416,6 +466,7 @@ const CallToActionSection = ({
   resource?: LearningResource
   hide?: boolean
   user?: User
+  location: string
   inUserList?: boolean
   inLearningPath?: boolean
   onAddToLearningPathClick?: LearningResourceCardProps["onAddToLearningPathClick"]
@@ -444,6 +495,7 @@ const CallToActionSection = ({
   const addToLearningPathLabel = "Add to list"
   const bookmarkLabel = "Bookmark"
   const shareLabel = "Share"
+  const copyLinkLabel = "Copy Link"
   return (
     <CallToAction data-testid="drawer-cta">
       <ImageSection resource={resource} config={imgConfig} />
@@ -498,6 +550,29 @@ const CallToActionSection = ({
           {shareLabel}
         </CallToActionButton>
       </ButtonContainer>
+      <ShareContainer>
+        <ShareLabel>Share a link to this Resource</ShareLabel>
+        <ShareInput value={location} />
+        <ShareButtonContainer>
+          <ShareLink>
+            <RiFacebookFill />
+          </ShareLink>
+          <ShareLink>
+            <RiTwitterXLine />
+          </ShareLink>
+          <ShareLink>
+            <RiLinkedinFill />
+          </ShareLink>
+          <CopyLinkButton
+            size="small"
+            edge="circular"
+            startIcon={<RiLink />}
+            aria-label={copyLinkLabel}
+          >
+            {copyLinkLabel}
+          </CopyLinkButton>
+        </ShareButtonContainer>
+      </ShareContainer>
     </CallToAction>
   )
 }
@@ -557,6 +632,7 @@ const LearningResourceExpandedV2: React.FC<LearningResourceExpandedV2Props> = ({
   resource,
   imgConfig,
   user,
+  location,
   carousels,
   inUserList,
   inLearningPath,
@@ -581,6 +657,7 @@ const LearningResourceExpandedV2: React.FC<LearningResourceExpandedV2Props> = ({
               imgConfig={imgConfig}
               resource={resource}
               user={user}
+              location={location}
               inLearningPath={inLearningPath}
               inUserList={inUserList}
               onAddToLearningPathClick={onAddToLearningPathClick}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -131,6 +131,13 @@ const CallToAction = styled.div({
   },
 })
 
+const ActionsContainer = styled.div({
+  display: "flex",
+  flexDirection: "column",
+  gap: "16px",
+  width: "100%",
+})
+
 const PlatformContainer = styled.div({
   display: "flex",
   alignItems: "center",
@@ -503,87 +510,89 @@ const CallToActionSection = ({
   return (
     <CallToAction data-testid="drawer-cta">
       <ImageSection resource={resource} config={imgConfig} />
-      <StyledLink
-        target="_blank"
-        size="medium"
-        data-ph-action="click-cta"
-        data-ph-offered-by={offeredBy?.code}
-        data-ph-resource-type={resource.resource_type}
-        data-ph-resource-id={resource.id}
-        endIcon={<RiExternalLinkLine />}
-        href={getCallToActionUrl(resource) || ""}
-      >
-        {cta}
-      </StyledLink>
-      <PlatformContainer>
-        {platformImage ? (
-          <Platform>
-            <OnPlatform>on</OnPlatform>
-            <StyledPlatformLogo platformCode={platformCode} height={26} />
-          </Platform>
-        ) : null}
-      </PlatformContainer>
-      <ButtonContainer>
-        {user?.is_learning_path_editor && (
+      <ActionsContainer>
+        <StyledLink
+          target="_blank"
+          size="medium"
+          data-ph-action="click-cta"
+          data-ph-offered-by={offeredBy?.code}
+          data-ph-resource-type={resource.resource_type}
+          data-ph-resource-id={resource.id}
+          endIcon={<RiExternalLinkLine />}
+          href={getCallToActionUrl(resource) || ""}
+        >
+          {cta}
+        </StyledLink>
+        <PlatformContainer>
+          {platformImage ? (
+            <Platform>
+              <OnPlatform>on</OnPlatform>
+              <StyledPlatformLogo platformCode={platformCode} height={26} />
+            </Platform>
+          ) : null}
+        </PlatformContainer>
+        <ButtonContainer>
+          {user?.is_learning_path_editor && (
+            <CallToActionButton
+              filled={inLearningPath ? 1 : 0}
+              startIcon={<RiMenuAddLine />}
+              aria-label={addToLearningPathLabel}
+              onClick={(event) =>
+                onAddToLearningPathClick
+                  ? onAddToLearningPathClick(event, resource.id)
+                  : null
+              }
+            >
+              {addToLearningPathLabel}
+            </CallToActionButton>
+          )}
           <CallToActionButton
-            filled={inLearningPath ? 1 : 0}
-            startIcon={<RiMenuAddLine />}
-            aria-label={addToLearningPathLabel}
-            onClick={(event) =>
-              onAddToLearningPathClick
-                ? onAddToLearningPathClick(event, resource.id)
-                : null
+            filled={inUserList ? 1 : 0}
+            startIcon={inUserList ? <RiBookmarkFill /> : <RiBookmarkLine />}
+            aria-label={bookmarkLabel}
+            onClick={
+              onAddToUserListClick
+                ? (event) => onAddToUserListClick?.(event, resource.id)
+                : undefined
             }
           >
-            {addToLearningPathLabel}
+            {bookmarkLabel}
           </CallToActionButton>
+          <CallToActionButton
+            filled={shareExpanded ? 1 : 0}
+            startIcon={<RiShareLine />}
+            aria-label={shareLabel}
+            onClick={() => setShareExpanded(!shareExpanded)}
+          >
+            {shareLabel}
+          </CallToActionButton>
+        </ButtonContainer>
+        {shareExpanded && (
+          <ShareContainer>
+            <ShareLabel>Share a link to this Resource</ShareLabel>
+            <ShareInput value={location} />
+            <ShareButtonContainer>
+              <ShareLink>
+                <RiFacebookFill />
+              </ShareLink>
+              <ShareLink>
+                <RiTwitterXLine />
+              </ShareLink>
+              <ShareLink>
+                <RiLinkedinFill />
+              </ShareLink>
+              <CopyLinkButton
+                size="small"
+                edge="circular"
+                startIcon={<RiLink />}
+                aria-label={copyLinkLabel}
+              >
+                {copyLinkLabel}
+              </CopyLinkButton>
+            </ShareButtonContainer>
+          </ShareContainer>
         )}
-        <CallToActionButton
-          filled={inUserList ? 1 : 0}
-          startIcon={inUserList ? <RiBookmarkFill /> : <RiBookmarkLine />}
-          aria-label={bookmarkLabel}
-          onClick={
-            onAddToUserListClick
-              ? (event) => onAddToUserListClick?.(event, resource.id)
-              : undefined
-          }
-        >
-          {bookmarkLabel}
-        </CallToActionButton>
-        <CallToActionButton
-          filled={shareExpanded ? 1 : 0}
-          startIcon={<RiShareLine />}
-          aria-label={shareLabel}
-          onClick={() => setShareExpanded(!shareExpanded)}
-        >
-          {shareLabel}
-        </CallToActionButton>
-      </ButtonContainer>
-      {shareExpanded && (
-        <ShareContainer>
-          <ShareLabel>Share a link to this Resource</ShareLabel>
-          <ShareInput value={location} />
-          <ShareButtonContainer>
-            <ShareLink>
-              <RiFacebookFill />
-            </ShareLink>
-            <ShareLink>
-              <RiTwitterXLine />
-            </ShareLink>
-            <ShareLink>
-              <RiLinkedinFill />
-            </ShareLink>
-            <CopyLinkButton
-              size="small"
-              edge="circular"
-              startIcon={<RiLink />}
-              aria-label={copyLinkLabel}
-            >
-              {copyLinkLabel}
-            </CopyLinkButton>
-          </ShareButtonContainer>
-        </ShareContainer>
-      )}
+      </ActionsContainer>
     </CallToAction>
   )
 }

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -270,12 +270,13 @@ const ShareLink = styled(Link)({
   color: theme.custom.colors.silverGrayDark,
 })
 
+const RedLinkIcon = styled(RiLink)({
+  color: theme.custom.colors.red,
+})
+
 const CopyLinkButton = styled(Button)({
   flexGrow: 0,
   flexBasis: "112px",
-  "span:first-of-type": {
-    color: theme.custom.colors.red,
-  },
 })
 
 const CarouselContainer = styled.div({
@@ -604,7 +605,7 @@ const CallToActionSection = ({
                 size="small"
                 edge="circular"
                 variant="bordered"
-                startIcon={<RiLink />}
+                startIcon={<RedLinkIcon />}
                 aria-label={copyLinkLabel}
                 ref={copyLinkButtonRef}
                 onClick={() => {

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -538,7 +538,7 @@ const CallToActionSection = ({
         <ButtonContainer>
           {user?.is_learning_path_editor && (
             <CallToActionButton
-              selected={inLearningPath ? 1 : 0}
+              selected={inLearningPath}
               startIcon={<RiMenuAddLine />}
               aria-label={addToLearningPathLabel}
               onClick={(event) =>
@@ -551,7 +551,7 @@ const CallToActionSection = ({
             </CallToActionButton>
           )}
           <CallToActionButton
-            selected={inUserList ? 1 : 0}
+            selected={inUserList}
             startIcon={inUserList ? <RiBookmarkFill /> : <RiBookmarkLine />}
             aria-label={bookmarkLabel}
             onClick={
@@ -563,7 +563,7 @@ const CallToActionSection = ({
             {bookmarkLabel}
           </CallToActionButton>
           <CallToActionButton
-            selected={shareExpanded ? 1 : 0}
+            selected={shareExpanded}
             startIcon={<RiShareLine />}
             aria-label={shareLabel}
             onClick={() => setShareExpanded(!shareExpanded)}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -247,14 +247,6 @@ const ShareLabel = styled(Typography)({
   color: theme.custom.colors.darkGray1,
 })
 
-const ShareInput = styled(Input)({
-  display: "flex",
-  flexDirection: "column",
-  justifyContent: "center",
-  alignItems: "flexStart",
-  alignSelf: "stretch",
-})
-
 const ShareButtonContainer = styled.div({
   display: "flex",
   justifyContent: "center",
@@ -488,6 +480,7 @@ const CallToActionSection = ({
   onAddToUserListClick?: LearningResourceCardProps["onAddToUserListClick"]
 }) => {
   const [shareExpanded, setShareExpanded] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
   const copyLinkButtonRef = useRef<HTMLButtonElement>(null)
   if (hide) {
     return null
@@ -581,7 +574,16 @@ const CallToActionSection = ({
         {shareExpanded && shareUrl && (
           <ShareContainer data-testid="drawer-share">
             <ShareLabel>Share a link to this Resource</ShareLabel>
-            <ShareInput value={shareUrl} />
+            <Input
+              fullWidth
+              ref={inputRef}
+              value={shareUrl}
+              onClick={() => {
+                if (inputRef.current) {
+                  inputRef.current.getElementsByTagName("input")[0].select()
+                }
+              }}
+            />
             <ShareButtonContainer>
               <ShareLink
                 href={`${facebookShareBaseUrl}?u=${encodeURIComponent(shareUrl)}`}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -215,29 +215,19 @@ const ButtonContainer = styled.div({
   justifyContent: "center",
 })
 
-const StyledButton = styled(Button)<{ filled?: number }>((props) => {
-  return {
-    flex: 1,
-    height: "32px",
-    padding: "12px 8px",
-    border: `1px solid ${props.filled ? theme.custom.colors.red : theme.custom.colors.silverGrayLight}`,
-    backgroundColor: props.filled
-      ? theme.custom.colors.red
-      : theme.custom.colors.white,
-    color: props.filled
-      ? theme.custom.colors.white
-      : theme.custom.colors.silverGrayDark,
-    boxShadow: "none",
-    "&:hover": {
-      backgroundColor: theme.custom.colors.red,
-      borderColor: theme.custom.colors.red,
-      color: theme.custom.colors.white,
-    },
-    "span:first-of-type": {
-      marginLeft: "0",
-      marginRight: "4px",
-    },
-  }
+const NoWrapButton = styled(Button)({
+  whiteSpace: "nowrap",
+})
+
+const SelectedButton = styled(NoWrapButton)({
+  backgroundColor: theme.custom.colors.red,
+  border: `1px solid ${theme.custom.colors.red}`,
+  color: theme.custom.colors.white,
+  "&:hover:not(:disabled)": {
+    backgroundColor: theme.custom.colors.red,
+    border: `1px solid ${theme.custom.colors.red}`,
+    color: theme.custom.colors.white,
+  },
 })
 
 const ShareContainer = styled.div({
@@ -268,24 +258,21 @@ const ShareButtonContainer = styled.div({
   alignItems: "center",
   alignSelf: "stretch",
   gap: "16px",
+  a: {
+    height: "18px",
+  },
 })
 
 const ShareLink = styled(Link)({
   color: theme.custom.colors.silverGrayDark,
 })
 
-const CopyLinkButton = styled(StyledButton)({
+const CopyLinkButton = styled(NoWrapButton)({
   flexGrow: 0,
   flexBasis: "112px",
-  padding: "12px 16px",
-  whiteSpace: "nowrap",
+  // padding: "12px 16px",
   "span:first-of-type": {
     color: theme.custom.colors.red,
-  },
-  "&:hover": {
-    "span:first-of-type": {
-      color: theme.custom.colors.white,
-    },
   },
 })
 
@@ -463,9 +450,20 @@ const getCallToActionText = (resource: LearningResource): string => {
   }
 }
 
-const CallToActionButton: React.FC<ButtonProps & { filled?: number }> = (
+const CallToActionButton: React.FC<ButtonProps & { selected?: number }> = (
   props,
-) => <StyledButton size="small" edge="circular" {...props} />
+) => {
+  return props.selected ? (
+    <SelectedButton
+      size="small"
+      edge="circular"
+      variant="bordered"
+      {...props}
+    />
+  ) : (
+    <NoWrapButton size="small" edge="circular" variant="bordered" {...props} />
+  )
+}
 
 const CallToActionSection = ({
   imgConfig,
@@ -544,7 +542,7 @@ const CallToActionSection = ({
         <ButtonContainer>
           {user?.is_learning_path_editor && (
             <CallToActionButton
-              filled={inLearningPath ? 1 : 0}
+              selected={inLearningPath ? 1 : 0}
               startIcon={<RiMenuAddLine />}
               aria-label={addToLearningPathLabel}
               onClick={(event) =>
@@ -557,7 +555,7 @@ const CallToActionSection = ({
             </CallToActionButton>
           )}
           <CallToActionButton
-            filled={inUserList ? 1 : 0}
+            selected={inUserList ? 1 : 0}
             startIcon={inUserList ? <RiBookmarkFill /> : <RiBookmarkLine />}
             aria-label={bookmarkLabel}
             onClick={
@@ -569,7 +567,7 @@ const CallToActionSection = ({
             {bookmarkLabel}
           </CallToActionButton>
           <CallToActionButton
-            filled={shareExpanded ? 1 : 0}
+            selected={shareExpanded ? 1 : 0}
             startIcon={<RiShareLine />}
             aria-label={shareLabel}
             onClick={() => setShareExpanded(!shareExpanded)}
@@ -603,6 +601,7 @@ const CallToActionSection = ({
               <CopyLinkButton
                 size="small"
                 edge="circular"
+                variant="bordered"
                 startIcon={<RiLink />}
                 aria-label={copyLinkLabel}
                 onClick={() => {

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -469,7 +469,7 @@ const CallToActionSection = ({
   resource?: LearningResource
   hide?: boolean
   user?: User
-  location: string
+  location?: string
   inUserList?: boolean
   inLearningPath?: boolean
   onAddToLearningPathClick?: LearningResourceCardProps["onAddToLearningPathClick"]

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -212,7 +212,7 @@ const StyledButton = styled(Button)<{ filled?: number }>((props) => {
   return {
     flex: 1,
     height: "32px",
-    padding: "12px 12px 12px 8px",
+    padding: "12px 8px",
     border: `1px solid ${props.filled ? theme.custom.colors.red : theme.custom.colors.silverGrayLight}`,
     backgroundColor: props.filled
       ? theme.custom.colors.red
@@ -227,6 +227,7 @@ const StyledButton = styled(Button)<{ filled?: number }>((props) => {
       color: theme.custom.colors.white,
     },
     "span:first-of-type": {
+      marginLeft: "0",
       marginRight: "4px",
     },
   }

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -195,7 +195,7 @@ const OnPlatform = styled.span({
   color: theme.custom.colors.black,
 })
 
-const ListButtonContainer = styled.div({
+const ButtonContainer = styled.div({
   display: "flex",
   gap: "8px",
   flexGrow: 1,
@@ -467,7 +467,7 @@ const CallToActionSection = ({
           </Platform>
         ) : null}
       </PlatformContainer>
-      <ListButtonContainer>
+      <ButtonContainer>
         {user?.is_learning_path_editor && (
           <CallToActionButton
             filled={inLearningPath ? 1 : 0}
@@ -497,7 +497,7 @@ const CallToActionSection = ({
         <CallToActionButton startIcon={<RiShareLine />} aria-label={shareLabel}>
           {shareLabel}
         </CallToActionButton>
-      </ListButtonContainer>
+      </ButtonContainer>
     </CallToAction>
   )
 }

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -602,6 +602,9 @@ const CallToActionSection = ({
                 edge="circular"
                 startIcon={<RiLink />}
                 aria-label={copyLinkLabel}
+                onClick={() => {
+                  navigator.clipboard.writeText(location)
+                }}
               >
                 {copyLinkLabel}
               </CopyLinkButton>

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -202,6 +202,7 @@ const OnPlatform = styled.span({
 
 const ButtonContainer = styled.div({
   display: "flex",
+  width: "100%",
   gap: "8px",
   flexGrow: 1,
   justifyContent: "center",
@@ -209,6 +210,7 @@ const ButtonContainer = styled.div({
 
 const StyledButton = styled(Button)<{ filled?: number }>((props) => {
   return {
+    flex: 1,
     height: "32px",
     padding: "12px 12px 12px 8px",
     border: `1px solid ${props.filled ? theme.custom.colors.red : theme.custom.colors.silverGrayLight}`,

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -27,7 +27,7 @@ import { LearningResourceCardProps } from "../LearningResourceCard/LearningResou
 import VideoFrame from "./VideoFrame"
 import { Link } from "../Link/Link"
 import { Input } from "../Input/Input"
-import { Typography } from "../.."
+import Typography from "@mui/material/Typography"
 
 const DRAWER_WIDTH = "900px"
 

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -3,15 +3,17 @@ import styled from "@emotion/styled"
 import Skeleton from "@mui/material/Skeleton"
 import Typography from "@mui/material/Typography"
 import { default as NextImage } from "next/image"
-import { ActionButton, ButtonLink } from "../Button/Button"
+import { ActionButton, Button, ButtonLink, ButtonProps } from "../Button/Button"
 import type { LearningResource } from "api"
 import { ResourceTypeEnum, PlatformEnum } from "api"
 import { DEFAULT_RESOURCE_IMG, getReadableResourceType } from "ol-utilities"
 import {
+  RiBookmarkFill,
   RiBookmarkLine,
   RiCloseLargeLine,
   RiExternalLinkLine,
   RiMenuAddLine,
+  RiShareLine,
 } from "@remixicon/react"
 import type { ImageConfig } from "../../constants/imgConfigs"
 import { theme } from "../ThemeProvider/ThemeProvider"
@@ -19,7 +21,6 @@ import { PlatformLogo, PLATFORM_LOGOS } from "../Logo/Logo"
 import InfoSectionV2 from "./InfoSectionV2"
 import type { User } from "api/hooks/user"
 import { LearningResourceCardProps } from "../LearningResourceCard/LearningResourceCard"
-import { CardActionButton } from "../LearningResourceCard/LearningResourceListCard"
 import VideoFrame from "./VideoFrame"
 import { Link } from "../Link/Link"
 
@@ -128,7 +129,7 @@ const CallToAction = styled.div({
 const PlatformContainer = styled.div({
   display: "flex",
   alignItems: "center",
-  justifyContent: "space-between",
+  justifyContent: "center",
   gap: "16px",
   alignSelf: "stretch",
 })
@@ -198,7 +199,30 @@ const ListButtonContainer = styled.div({
   display: "flex",
   gap: "8px",
   flexGrow: 1,
-  justifyContent: "flex-end",
+  justifyContent: "center",
+})
+
+const StyledButton = styled(Button)<{ filled?: number }>((props) => {
+  return {
+    height: "32px",
+    padding: "12px 12px 12px 8px",
+    border: `1px solid ${props.filled ? theme.custom.colors.red : theme.custom.colors.silverGrayLight}`,
+    backgroundColor: props.filled
+      ? theme.custom.colors.red
+      : theme.custom.colors.white,
+    color: props.filled
+      ? theme.custom.colors.white
+      : theme.custom.colors.silverGrayDark,
+    boxShadow: "none",
+    "&:hover": {
+      backgroundColor: theme.custom.colors.red,
+      borderColor: theme.custom.colors.red,
+      color: theme.custom.colors.white,
+    },
+    "span:first-of-type": {
+      marginRight: "4px",
+    },
+  }
 })
 
 const CarouselContainer = styled.div({
@@ -374,6 +398,10 @@ const getCallToActionText = (resource: LearningResource): string => {
   }
 }
 
+const CallToActionButton: React.FC<ButtonProps & { filled?: number }> = (
+  props,
+) => <StyledButton size="small" edge="circular" {...props} />
+
 const CallToActionSection = ({
   imgConfig,
   resource,
@@ -413,6 +441,9 @@ const CallToActionSection = ({
       : (platform?.code as PlatformEnum)
   const platformImage = PLATFORM_LOGOS[platformCode]?.image
   const cta = getCallToActionText(resource)
+  const addToLearningPathLabel = "Add to list"
+  const bookmarkLabel = "Bookmark"
+  const shareLabel = "Share"
   return (
     <CallToAction data-testid="drawer-cta">
       <ImageSection resource={resource} config={imgConfig} />
@@ -435,33 +466,38 @@ const CallToActionSection = ({
             <StyledPlatformLogo platformCode={platformCode} height={26} />
           </Platform>
         ) : null}
-        <ListButtonContainer>
-          {user?.is_learning_path_editor && (
-            <CardActionButton
-              filled={inLearningPath}
-              aria-label="Add to Learning Path"
-              onClick={(event) =>
-                onAddToLearningPathClick
-                  ? onAddToLearningPathClick(event, resource.id)
-                  : null
-              }
-            >
-              <RiMenuAddLine aria-hidden />
-            </CardActionButton>
-          )}
-          <CardActionButton
-            filled={inUserList}
-            aria-label={`Bookmark ${getReadableResourceType(resource.resource_type)}`}
-            onClick={
-              onAddToUserListClick
-                ? (event) => onAddToUserListClick?.(event, resource.id)
-                : undefined
+      </PlatformContainer>
+      <ListButtonContainer>
+        {user?.is_learning_path_editor && (
+          <CallToActionButton
+            filled={inLearningPath ? 1 : 0}
+            startIcon={<RiMenuAddLine />}
+            aria-label={addToLearningPathLabel}
+            onClick={(event) =>
+              onAddToLearningPathClick
+                ? onAddToLearningPathClick(event, resource.id)
+                : null
             }
           >
-            <RiBookmarkLine aria-hidden />
-          </CardActionButton>
-        </ListButtonContainer>
-      </PlatformContainer>
+            {addToLearningPathLabel}
+          </CallToActionButton>
+        )}
+        <CallToActionButton
+          filled={inUserList ? 1 : 0}
+          startIcon={inUserList ? <RiBookmarkFill /> : <RiBookmarkLine />}
+          aria-label={bookmarkLabel}
+          onClick={
+            onAddToUserListClick
+              ? (event) => onAddToUserListClick?.(event, resource.id)
+              : undefined
+          }
+        >
+          {bookmarkLabel}
+        </CallToActionButton>
+        <CallToActionButton startIcon={<RiShareLine />} aria-label={shareLabel}>
+          {shareLabel}
+        </CallToActionButton>
+      </ListButtonContainer>
     </CallToAction>
   )
 }

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -480,6 +480,7 @@ const CallToActionSection = ({
   onAddToUserListClick?: LearningResourceCardProps["onAddToUserListClick"]
 }) => {
   const [shareExpanded, setShareExpanded] = useState(false)
+  const [copyText, setCopyText] = useState("Copy Link")
   const inputRef = useRef<HTMLInputElement>(null)
   const copyLinkButtonRef = useRef<HTMLButtonElement>(null)
   if (hide) {
@@ -505,8 +506,6 @@ const CallToActionSection = ({
   const addToLearningPathLabel = "Add to list"
   const bookmarkLabel = "Bookmark"
   const shareLabel = "Share"
-  const copyLinkLabel = "Copy Link"
-  const copiedLabel = "Copied!"
   const socialIconSize = 18
   const facebookShareBaseUrl = "https://www.facebook.com/sharer/sharer.php"
   const twitterShareBaseUrl = "https://x.com/share"
@@ -608,21 +607,14 @@ const CallToActionSection = ({
                 edge="circular"
                 variant="bordered"
                 startIcon={<RedLinkIcon />}
-                aria-label={copyLinkLabel}
+                aria-label={copyText}
                 ref={copyLinkButtonRef}
                 onClick={() => {
                   navigator.clipboard.writeText(shareUrl)
-                  if (copyLinkButtonRef.current) {
-                    copyLinkButtonRef.current.ariaLabel = copiedLabel
-                    copyLinkButtonRef.current.innerHTML =
-                      copyLinkButtonRef.current.innerHTML.replace(
-                        copyLinkLabel,
-                        copiedLabel,
-                      )
-                  }
+                  setCopyText("Copied!")
                 }}
               >
-                {copyLinkLabel}
+                {copyText}
               </CopyLinkButton>
             </ShareButtonContainer>
           </ShareContainer>

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -275,9 +275,12 @@ const ShareLink = styled(Link)({
 })
 
 const CopyLinkButton = styled(StyledButton)({
+  flexGrow: 0,
   "span:first-of-type": {
     color: theme.custom.colors.red,
-    "&:hover": {
+  },
+  "&:hover": {
+    "span:first-of-type": {
       color: theme.custom.colors.white,
     },
   },
@@ -507,6 +510,7 @@ const CallToActionSection = ({
   const bookmarkLabel = "Bookmark"
   const shareLabel = "Share"
   const copyLinkLabel = "Copy Link"
+  const socialIconSize = 18
   return (
     <CallToAction data-testid="drawer-cta">
       <ImageSection resource={resource} config={imgConfig} />
@@ -573,13 +577,13 @@ const CallToActionSection = ({
             <ShareInput value={location} />
             <ShareButtonContainer>
               <ShareLink>
-                <RiFacebookFill />
+                <RiFacebookFill size={socialIconSize} />
               </ShareLink>
               <ShareLink>
-                <RiTwitterXLine />
+                <RiTwitterXLine size={socialIconSize} />
               </ShareLink>
               <ShareLink>
-                <RiLinkedinFill />
+                <RiLinkedinFill size={socialIconSize} />
               </ShareLink>
               <CopyLinkButton
                 size="small"

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -217,6 +217,7 @@ const ButtonContainer = styled.div({
 
 const SelectableButton = styled(Button)<{ selected?: boolean }>((props) => [
   {
+    flex: 1,
     whiteSpace: "nowrap",
   },
   props.selected

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -215,7 +215,7 @@ const ButtonContainer = styled.div({
   justifyContent: "center",
 })
 
-const SelectableButton = styled(Button)<{ selected?: number }>((props) => [
+const SelectableButton = styled(Button)<{ selected?: boolean }>((props) => [
   {
     whiteSpace: "nowrap",
   },
@@ -445,7 +445,7 @@ const getCallToActionText = (resource: LearningResource): string => {
   }
 }
 
-const CallToActionButton: React.FC<ButtonProps & { selected?: number }> = (
+const CallToActionButton: React.FC<ButtonProps & { selected?: boolean }> = (
   props,
 ) => {
   return (

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -511,6 +511,9 @@ const CallToActionSection = ({
   const shareLabel = "Share"
   const copyLinkLabel = "Copy Link"
   const socialIconSize = 18
+  const facebookShareBaseUrl = "https://www.facebook.com/sharer/sharer.php"
+  const twitterShareBaseUrl = "https://x.com/share"
+  const linkedInShareBaseUrl = "https://www.linkedin.com/sharing/share-offsite"
   return (
     <CallToAction data-testid="drawer-cta">
       <ImageSection resource={resource} config={imgConfig} />
@@ -571,18 +574,27 @@ const CallToActionSection = ({
             {shareLabel}
           </CallToActionButton>
         </ButtonContainer>
-        {shareExpanded && (
+        {shareExpanded && location && (
           <ShareContainer>
             <ShareLabel>Share a link to this Resource</ShareLabel>
             <ShareInput value={location} />
             <ShareButtonContainer>
-              <ShareLink>
+              <ShareLink
+                href={`${facebookShareBaseUrl}?u=${encodeURIComponent(location)}`}
+                target="_blank"
+              >
                 <RiFacebookFill size={socialIconSize} />
               </ShareLink>
-              <ShareLink>
+              <ShareLink
+                href={`${twitterShareBaseUrl}?text=${encodeURIComponent(resource.title)}&url=${encodeURIComponent(location)}`}
+                target="_blank"
+              >
                 <RiTwitterXLine size={socialIconSize} />
               </ShareLink>
-              <ShareLink>
+              <ShareLink
+                href={`${linkedInShareBaseUrl}?url=${encodeURIComponent(location)}`}
+                target="_blank"
+              >
                 <RiLinkedinFill size={socialIconSize} />
               </ShareLink>
               <CopyLinkButton

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -295,7 +295,7 @@ const CarouselContainer = styled.div({
 type LearningResourceExpandedV2Props = {
   resource?: LearningResource
   user?: User
-  location: string
+  location?: string
   imgConfig: ImageConfig
   carousels?: React.ReactNode[]
   inLearningPath?: boolean

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -578,7 +578,7 @@ const CallToActionSection = ({
           </CallToActionButton>
         </ButtonContainer>
         {shareExpanded && shareUrl && (
-          <ShareContainer>
+          <ShareContainer data-testid="drawer-share">
             <ShareLabel>Share a link to this Resource</ShareLabel>
             <ShareInput value={shareUrl} />
             <ShareButtonContainer>

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -481,8 +481,6 @@ const CallToActionSection = ({
 }) => {
   const [shareExpanded, setShareExpanded] = useState(false)
   const [copyText, setCopyText] = useState("Copy Link")
-  const inputRef = useRef<HTMLInputElement>(null)
-  const copyLinkButtonRef = useRef<HTMLButtonElement>(null)
   if (hide) {
     return null
   }
@@ -575,12 +573,11 @@ const CallToActionSection = ({
             <ShareLabel>Share a link to this Resource</ShareLabel>
             <Input
               fullWidth
-              ref={inputRef}
               value={shareUrl}
-              onClick={() => {
-                if (inputRef.current) {
-                  inputRef.current.getElementsByTagName("input")[0].select()
-                }
+              onClick={(event) => {
+                const input = event.currentTarget.querySelector("input")
+                if (!input) return
+                input.select()
               }}
             />
             <ShareButtonContainer>
@@ -608,7 +605,6 @@ const CallToActionSection = ({
                 variant="bordered"
                 startIcon={<RedLinkIcon />}
                 aria-label={copyText}
-                ref={copyLinkButtonRef}
                 onClick={() => {
                   navigator.clipboard.writeText(shareUrl)
                   setCopyText("Copied!")

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -472,6 +472,7 @@ const CallToActionSection = ({
   onAddToLearningPathClick?: LearningResourceCardProps["onAddToLearningPathClick"]
   onAddToUserListClick?: LearningResourceCardProps["onAddToUserListClick"]
 }) => {
+  const [shareExpanded, setShareExpanded] = useState(false)
   if (hide) {
     return null
   }
@@ -546,33 +547,40 @@ const CallToActionSection = ({
         >
           {bookmarkLabel}
         </CallToActionButton>
-        <CallToActionButton startIcon={<RiShareLine />} aria-label={shareLabel}>
+        <CallToActionButton
+          filled={shareExpanded ? 1 : 0}
+          startIcon={<RiShareLine />}
+          aria-label={shareLabel}
+          onClick={() => setShareExpanded(!shareExpanded)}
+        >
           {shareLabel}
         </CallToActionButton>
       </ButtonContainer>
-      <ShareContainer>
-        <ShareLabel>Share a link to this Resource</ShareLabel>
-        <ShareInput value={location} />
-        <ShareButtonContainer>
-          <ShareLink>
-            <RiFacebookFill />
-          </ShareLink>
-          <ShareLink>
-            <RiTwitterXLine />
-          </ShareLink>
-          <ShareLink>
-            <RiLinkedinFill />
-          </ShareLink>
-          <CopyLinkButton
-            size="small"
-            edge="circular"
-            startIcon={<RiLink />}
-            aria-label={copyLinkLabel}
-          >
-            {copyLinkLabel}
-          </CopyLinkButton>
-        </ShareButtonContainer>
-      </ShareContainer>
+      {shareExpanded && (
+        <ShareContainer>
+          <ShareLabel>Share a link to this Resource</ShareLabel>
+          <ShareInput value={location} />
+          <ShareButtonContainer>
+            <ShareLink>
+              <RiFacebookFill />
+            </ShareLink>
+            <ShareLink>
+              <RiTwitterXLine />
+            </ShareLink>
+            <ShareLink>
+              <RiLinkedinFill />
+            </ShareLink>
+            <CopyLinkButton
+              size="small"
+              edge="circular"
+              startIcon={<RiLink />}
+              aria-label={copyLinkLabel}
+            >
+              {copyLinkLabel}
+            </CopyLinkButton>
+          </ShareButtonContainer>
+        </ShareContainer>
+      )}
     </CallToAction>
   )
 }

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -487,6 +487,7 @@ const CallToActionSection = ({
   onAddToUserListClick?: LearningResourceCardProps["onAddToUserListClick"]
 }) => {
   const [shareExpanded, setShareExpanded] = useState(false)
+  const copyLinkButtonRef = useRef<HTMLButtonElement>(null)
   if (hide) {
     return null
   }
@@ -511,6 +512,7 @@ const CallToActionSection = ({
   const bookmarkLabel = "Bookmark"
   const shareLabel = "Share"
   const copyLinkLabel = "Copy Link"
+  const copiedLabel = "Copied!"
   const socialIconSize = 18
   const facebookShareBaseUrl = "https://www.facebook.com/sharer/sharer.php"
   const twitterShareBaseUrl = "https://x.com/share"
@@ -604,8 +606,17 @@ const CallToActionSection = ({
                 variant="bordered"
                 startIcon={<RiLink />}
                 aria-label={copyLinkLabel}
+                ref={copyLinkButtonRef}
                 onClick={() => {
                   navigator.clipboard.writeText(shareUrl)
+                  if (copyLinkButtonRef.current) {
+                    copyLinkButtonRef.current.ariaLabel = copiedLabel
+                    copyLinkButtonRef.current.innerHTML =
+                      copyLinkButtonRef.current.innerHTML.replace(
+                        copyLinkLabel,
+                        copiedLabel,
+                      )
+                  }
                 }}
               >
                 {copyLinkLabel}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -308,7 +308,7 @@ const CarouselContainer = styled.div({
 type LearningResourceExpandedV2Props = {
   resource?: LearningResource
   user?: User
-  location?: string
+  shareUrl?: string
   imgConfig: ImageConfig
   carousels?: React.ReactNode[]
   inLearningPath?: boolean
@@ -469,7 +469,7 @@ const CallToActionSection = ({
   resource,
   hide,
   user,
-  location,
+  shareUrl,
   inUserList,
   inLearningPath,
   onAddToLearningPathClick,
@@ -479,7 +479,7 @@ const CallToActionSection = ({
   resource?: LearningResource
   hide?: boolean
   user?: User
-  location?: string
+  shareUrl?: string
   inUserList?: boolean
   inLearningPath?: boolean
   onAddToLearningPathClick?: LearningResourceCardProps["onAddToLearningPathClick"]
@@ -574,25 +574,25 @@ const CallToActionSection = ({
             {shareLabel}
           </CallToActionButton>
         </ButtonContainer>
-        {shareExpanded && location && (
+        {shareExpanded && shareUrl && (
           <ShareContainer>
             <ShareLabel>Share a link to this Resource</ShareLabel>
-            <ShareInput value={location} />
+            <ShareInput value={shareUrl} />
             <ShareButtonContainer>
               <ShareLink
-                href={`${facebookShareBaseUrl}?u=${encodeURIComponent(location)}`}
+                href={`${facebookShareBaseUrl}?u=${encodeURIComponent(shareUrl)}`}
                 target="_blank"
               >
                 <RiFacebookFill size={socialIconSize} />
               </ShareLink>
               <ShareLink
-                href={`${twitterShareBaseUrl}?text=${encodeURIComponent(resource.title)}&url=${encodeURIComponent(location)}`}
+                href={`${twitterShareBaseUrl}?text=${encodeURIComponent(resource.title)}&url=${encodeURIComponent(shareUrl)}`}
                 target="_blank"
               >
                 <RiTwitterXLine size={socialIconSize} />
               </ShareLink>
               <ShareLink
-                href={`${linkedInShareBaseUrl}?url=${encodeURIComponent(location)}`}
+                href={`${linkedInShareBaseUrl}?url=${encodeURIComponent(shareUrl)}`}
                 target="_blank"
               >
                 <RiLinkedinFill size={socialIconSize} />
@@ -603,7 +603,7 @@ const CallToActionSection = ({
                 startIcon={<RiLink />}
                 aria-label={copyLinkLabel}
                 onClick={() => {
-                  navigator.clipboard.writeText(location)
+                  navigator.clipboard.writeText(shareUrl)
                 }}
               >
                 {copyLinkLabel}
@@ -671,7 +671,7 @@ const LearningResourceExpandedV2: React.FC<LearningResourceExpandedV2Props> = ({
   resource,
   imgConfig,
   user,
-  location,
+  shareUrl,
   carousels,
   inUserList,
   inLearningPath,
@@ -696,7 +696,7 @@ const LearningResourceExpandedV2: React.FC<LearningResourceExpandedV2Props> = ({
               imgConfig={imgConfig}
               resource={resource}
               user={user}
-              location={location}
+              shareUrl={shareUrl}
               inLearningPath={inLearningPath}
               inUserList={inUserList}
               onAddToLearningPathClick={onAddToLearningPathClick}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -251,7 +251,7 @@ const ShareContainer = styled.div({
 
 const ShareLabel = styled(Typography)({
   ...theme.typography.body3,
-  color: theme.custom.colors.darkGray2,
+  color: theme.custom.colors.darkGray1,
 })
 
 const ShareInput = styled(Input)({

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -215,20 +215,23 @@ const ButtonContainer = styled.div({
   justifyContent: "center",
 })
 
-const NoWrapButton = styled(Button)({
-  whiteSpace: "nowrap",
-})
-
-const SelectedButton = styled(NoWrapButton)({
-  backgroundColor: theme.custom.colors.red,
-  border: `1px solid ${theme.custom.colors.red}`,
-  color: theme.custom.colors.white,
-  "&:hover:not(:disabled)": {
-    backgroundColor: theme.custom.colors.red,
-    border: `1px solid ${theme.custom.colors.red}`,
-    color: theme.custom.colors.white,
+const SelectableButton = styled(Button)<{ selected?: number }>((props) => [
+  {
+    whiteSpace: "nowrap",
   },
-})
+  props.selected
+    ? {
+        backgroundColor: theme.custom.colors.red,
+        border: `1px solid ${theme.custom.colors.red}`,
+        color: theme.custom.colors.white,
+        "&:hover:not(:disabled)": {
+          backgroundColor: theme.custom.colors.red,
+          border: `1px solid ${theme.custom.colors.red}`,
+          color: theme.custom.colors.white,
+        },
+      }
+    : {},
+])
 
 const ShareContainer = styled.div({
   display: "flex",
@@ -267,7 +270,7 @@ const ShareLink = styled(Link)({
   color: theme.custom.colors.silverGrayDark,
 })
 
-const CopyLinkButton = styled(NoWrapButton)({
+const CopyLinkButton = styled(Button)({
   flexGrow: 0,
   flexBasis: "112px",
   "span:first-of-type": {
@@ -452,15 +455,13 @@ const getCallToActionText = (resource: LearningResource): string => {
 const CallToActionButton: React.FC<ButtonProps & { selected?: number }> = (
   props,
 ) => {
-  return props.selected ? (
-    <SelectedButton
+  return (
+    <SelectableButton
       size="small"
       edge="circular"
       variant="bordered"
       {...props}
     />
-  ) : (
-    <NoWrapButton size="small" edge="circular" variant="bordered" {...props} />
   )
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5876

### Description (What does it do?)
This PR adds the "share" section of the new learning resource drawer and adjusts the layout of the call to section. 

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/15bf3a17-0961-40fc-822f-e598122e4b19)
![image](https://github.com/user-attachments/assets/7d6bb561-95d8-4ae2-bd2d-7aa858965f1b)

### How can this be tested?
 - If you have Posthog set up locally, enable the `lr_drawer_v2` flag
 - If you don't have Posthog set up locally, you can force `drawerV2` to be `true` in `LearningResourceDrawer.tsx`
 - Spin up this branch of `mit-learn`
 - Ensure you have sufficient data backpopulated into your local instance to test a variety of resources
 - Visit http://localhost:8062/search
 - Do *not* log in yet
 - Click any of the search results to bring up the learning resource drawer
 - Verify that you see two buttons below the unit logo, Bookmark and Share
 - Click the Share button
 - Verify that the share section appears and that the URL in the textbox looks correct
 - Click the social media share icons and verify that you are taken to each given social media site and their respective interfaces are displayed for sharing a post with a link to the resource
 - Click the Copy Link button and verify that the link is properly copied to your clipboard
 - Log in as a superuser
 - Go back to the search page and click on any learning resource to bring the drawer back up
 - Verify that you now see 3 buttons; Add to list, Bookmark and Share
