### PR TITLE
Load font with simple link tag

### DIFF
--- a/frontends/main/src/app/layout.tsx
+++ b/frontends/main/src/app/layout.tsx
@@ -24,6 +24,18 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        {/*
+          Font files for Adobe neue haas grotesk.
+          WARNING: This is linked to chudzick@mit.edu's Adobe account.
+          We'd prefer a non-personal MIT account to be used.
+          See https://github.com/mitodl/hq/issues/4237 for more.
+        */}
+        <link
+          rel="stylesheet"
+          href="https://use.typekit.net/lbk1xay.css"
+        ></link>
+      </head>
       <body>
         <Providers>
           <MITLearnGlobalStyles />

--- a/frontends/ol-components/src/components/ThemeProvider/MITLearnGlobalStyles.tsx
+++ b/frontends/ol-components/src/components/ThemeProvider/MITLearnGlobalStyles.tsx
@@ -3,26 +3,8 @@
 import React from "react"
 import { css, Global } from "@emotion/react"
 import { theme } from "./ThemeProvider"
-import { preload } from "react-dom"
-
-/**
-    Font files for Adobe neue haas grotesk.
-    WARNING: This is linked to chudzick@mit.edu's Adobe account.
-    We'd prefer a non-personal MIT account to be used.
-    See https://github.com/mitodl/hq/issues/4237 for more.
-
-    Ideally the font would be loaded via a <link /> tag; see
-      - https://nextjs.org/docs/app/api-reference/functions/generate-metadata#unsupported-metadata
-      - https://github.com/vercel/next.js/discussions/52877
-      - https://github.com/vercel/next.js/discussions/50796
- */
-const ADOBE_FONT_URL = "https://use.typekit.net/lbk1xay.css"
 
 const pageCss = css`
-  @import url("${ADOBE_FONT_URL}"); /**
-    @import must come before other styles, including comments
-  */
-
   html {
     font-family: ${theme.typography.body1.fontFamily};
     color: ${theme.typography.body1.color};
@@ -57,11 +39,6 @@ const pageCss = css`
 `
 
 const MITLearnGlobalStyles: React.FC = () => {
-  /**
-   * Preload the font just in case emotion doesn't put the import near top of
-   * HTML.
-   */
-  preload(ADOBE_FONT_URL, { as: "style", fetchPriority: "high" })
   return <Global styles={[pageCss]}></Global>
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6257

### Description (What does it do?)
Loads our adobe font with a style tag

### Screenshots (if appropriate):
Before:

https://github.com/user-attachments/assets/a759a721-b116-4153-86ed-e4e6660db7c1

Now:

https://github.com/user-attachments/assets/2f902466-c6d9-48c5-92c5-9f1c1dd9b193



### How can this be tested?

I'm unsure why, but in order to see the RC behavior locally I had to use a production build.

So... 
1. `docker compose up --profile backend`
2. On host, or inside a `docker compose run --rm watch bash`:
    - `cd frontends/main` 
    - `NODE_ENV=production yarn build
    - `NODE_ENV=production yarn next start
3. Load the topics page (or any page); it should look like second video above. You may want to throttle network requests.
