### PR TITLE
add nprogress loading bar

### DIFF
--- a/frontends/.eslintrc.js
+++ b/frontends/.eslintrc.js
@@ -36,6 +36,11 @@ module.exports = {
     ...restrictedImports({
       patterns: [
         {
+          group: ["next/navigation"],
+          importNames: ["useRouter"],
+          message: "Please use `useRouter` from `next-nprogress-bar` instead.",
+        },
+        {
           group: ["@mui/material*", "@mui/lab/*"],
           message:
             "Please use 'ol-components' isInterfaceDeclaration; Direct use of @mui/material is limited to ol-components.",

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -21,6 +21,7 @@
     "formik": "^2.4.6",
     "lodash": "^4.17.21",
     "next": "^15.0.2",
+    "next-nprogress-bar": "^2.4.2",
     "ol-ckeditor": "0.0.0",
     "ol-components": "0.0.0",
     "ol-utilities": "0.0.0",

--- a/frontends/main/src/app-pages/DashboardPage/UserListDetailsTab.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/UserListDetailsTab.tsx
@@ -3,7 +3,7 @@ import {
   useInfiniteUserListItems,
   useUserListsDetail,
 } from "api/hooks/userLists"
-import { useRouter } from "next/navigation"
+import { useRouter } from "next-nprogress-bar"
 import { ListType } from "api/constants"
 import { useUserMe } from "api/hooks/user"
 import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"

--- a/frontends/main/src/app-pages/OnboardingPage/OnboardingPage.tsx
+++ b/frontends/main/src/app-pages/OnboardingPage/OnboardingPage.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useId, useMemo } from "react"
-import { useRouter } from "next/navigation"
+import { useRouter } from "next-nprogress-bar"
 import range from "lodash/range"
 import {
   styled,

--- a/frontends/main/src/app/providers.tsx
+++ b/frontends/main/src/app/providers.tsx
@@ -3,10 +3,18 @@
 import React from "react"
 import { getQueryClient } from "./getQueryClient"
 import { QueryClientProvider } from "@tanstack/react-query"
-import { ThemeProvider, NextJsAppRouterCacheProvider } from "ol-components"
+import {
+  ThemeProvider,
+  NextJsAppRouterCacheProvider,
+  theme,
+} from "ol-components"
 import { Provider as NiceModalProvider } from "@ebay/nice-modal-react"
 import ConfiguredPostHogProvider from "@/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider"
 import { usePrefetchWarnings } from "api/ssr/usePrefetchWarnings"
+import { AppProgressBar as ProgressBar } from "next-nprogress-bar"
+import type { NProgressOptions } from "next-nprogress-bar"
+
+const PROGRESS_BAR_OPTS: NProgressOptions = { showSpinner: false }
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const queryClient = getQueryClient()
@@ -14,14 +22,22 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   usePrefetchWarnings({ queryClient })
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <ConfiguredPostHogProvider>
-        <NextJsAppRouterCacheProvider>
-          <ThemeProvider>
-            <NiceModalProvider>{children}</NiceModalProvider>
-          </ThemeProvider>
-        </NextJsAppRouterCacheProvider>
-      </ConfiguredPostHogProvider>
-    </QueryClientProvider>
+    <>
+      <ProgressBar
+        height="3px"
+        color={theme.custom.colors.brightRed}
+        options={PROGRESS_BAR_OPTS}
+        shallowRouting
+      />
+      <QueryClientProvider client={queryClient}>
+        <ConfiguredPostHogProvider>
+          <NextJsAppRouterCacheProvider>
+            <ThemeProvider>
+              <NiceModalProvider>{children}</NiceModalProvider>
+            </ThemeProvider>
+          </NextJsAppRouterCacheProvider>
+        </ConfiguredPostHogProvider>
+      </QueryClientProvider>
+    </>
   )
 }

--- a/frontends/main/src/page-components/HeroSearch/HeroSearch.tsx
+++ b/frontends/main/src/page-components/HeroSearch/HeroSearch.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useState, useCallback } from "react"
-import { useRouter } from "next/navigation"
+import { useRouter } from "next-nprogress-bar"
 import {
   Typography,
   styled,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14334,6 +14334,7 @@ __metadata:
     jest-extended: "npm:^4.0.2"
     lodash: "npm:^4.17.21"
     next: "npm:^15.0.2"
+    next-nprogress-bar: "npm:^2.4.2"
     ol-ckeditor: "npm:0.0.0"
     ol-components: "npm:0.0.0"
     ol-test-utilities: "npm:0.0.0"
@@ -15783,6 +15784,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"next-nprogress-bar@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "next-nprogress-bar@npm:2.4.2"
+  dependencies:
+    nprogress-v2: "npm:^1.0.4"
+  checksum: 10/a338840accd7b34edd428b9be4554afbff77d1ff6bdf45dd39b57484631734b1a87f616eaf64b93fbcf65c83662527f74ee94dba71228ad03831432e6c75d917
+  languageName: node
+  linkType: hard
+
 "next-router-mock@npm:^0.9.13":
   version: 0.9.13
   resolution: "next-router-mock@npm:0.9.13"
@@ -16041,6 +16051,13 @@ __metadata:
   dependencies:
     path-key: "npm:^3.0.0"
   checksum: 10/5374c0cea4b0bbfdfae62da7bbdf1e1558d338335f4cacf2515c282ff358ff27b2ecb91ffa5330a8b14390ac66a1e146e10700440c1ab868208430f56b5f4d23
+  languageName: node
+  linkType: hard
+
+"nprogress-v2@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "nprogress-v2@npm:1.0.4"
+  checksum: 10/0c9f3e79990440e9f5c6f8484aaf67285a87ec91a11d8d97df2ab3940d6d9dd52ebafc69363b2ed61d99ba3b5415a732ce9204f104ac71671dba22e40ba96b32
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6267

### Description (What does it do?)
Adds a loading bar for internal navigations. 

This only triggers between different nextjs routes—not for client-side stuff, which we generally handle via skeleton uis.

### Screenshots (if appropriate):

Me navigating from homepage to `/departments`

<img width="1594" alt="Screenshot 2024-12-11 at 6 26 03 PM" src="https://github.com/user-attachments/assets/5a695354-4978-45f2-a741-04df1e49cd6b" />


### How can this be tested?
1. Try navigating between paths via links (e.g., in the left-hand nav drawer)
2. Try navigating between paths via `useRouter` (e.g., the homepage search box)
3. Try adding a new `useRouter` import from `next/navigation`; it should error.
