### PR TITLE
add bordered button variant

### DIFF
--- a/frontends/ol-components/src/components/Button/Button.mdx
+++ b/frontends/ol-components/src/components/Button/Button.mdx
@@ -6,7 +6,7 @@ import * as ButtonStories from "./Button.stories"
 
 # Button
 
-Use prop `variant="primary" | "secondary" | "tertiary" | "text"` to set the button variant:
+Use prop `variant="primary" | "secondary" | "tertiary" | "bordered" | "noBorder" | "inverted" | "success" | "text"` to set the button variant:
 
 <Canvas of={ButtonStories.VariantStory} />
 

--- a/frontends/ol-components/src/components/Button/Button.stories.tsx
+++ b/frontends/ol-components/src/components/Button/Button.stories.tsx
@@ -34,6 +34,8 @@ const meta: Meta<typeof Button> = {
         "primary",
         "secondary",
         "tertiary",
+        "bordered",
+        "noBorder",
         "text",
         "inverted",
         "text-secondary",

--- a/frontends/ol-components/src/components/Button/Button.stories.tsx
+++ b/frontends/ol-components/src/components/Button/Button.stories.tsx
@@ -93,14 +93,17 @@ export const VariantStory: Story = {
       <Button {...args} variant="bordered">
         Bordered
       </Button>
-      <Button {...args} variant="text">
-        Text
-      </Button>
       <Button {...args} variant="noBorder">
-        Text Secondary
+        No Border
       </Button>
       <Button {...args} variant="inverted">
         Inverted
+      </Button>
+      <Button {...args} variant="success">
+        Success
+      </Button>
+      <Button {...args} variant="text">
+        Text
       </Button>
     </Stack>
   ),
@@ -154,19 +157,19 @@ export const DisabledStory: Story = {
       <Button {...args} disabled variant="secondary">
         Secondary
       </Button>
-      <Button {...args} variant="tertiary">
+      <Button {...args} disabled variant="tertiary">
         Tertiary
       </Button>
-      <Button {...args} variant="bordered">
+      <Button {...args} disabled variant="bordered">
         Bordered
       </Button>
-      <Button {...args} variant="noBorder">
+      <Button {...args} disabled variant="noBorder">
         No Border
       </Button>
-      <Button {...args} variant="inverted">
+      <Button {...args} disabled variant="inverted">
         Inverted
       </Button>
-      <Button {...args} variant="success">
+      <Button {...args} disabled variant="success">
         Success
       </Button>
       <Button {...args} disabled variant="text">

--- a/frontends/ol-components/src/components/Button/Button.stories.tsx
+++ b/frontends/ol-components/src/components/Button/Button.stories.tsx
@@ -36,9 +36,9 @@ const meta: Meta<typeof Button> = {
         "tertiary",
         "bordered",
         "noBorder",
-        "text",
         "inverted",
-        "text-secondary",
+        "success",
+        "text",
       ],
       control: { type: "select" },
     },
@@ -89,6 +89,9 @@ export const VariantStory: Story = {
       </Button>
       <Button {...args} variant="tertiary">
         Tertiary
+      </Button>
+      <Button {...args} variant="bordered">
+        Bordered
       </Button>
       <Button {...args} variant="text">
         Text
@@ -153,6 +156,18 @@ export const DisabledStory: Story = {
       </Button>
       <Button {...args} variant="tertiary">
         Tertiary
+      </Button>
+      <Button {...args} variant="bordered">
+        Bordered
+      </Button>
+      <Button {...args} variant="noBorder">
+        No Border
+      </Button>
+      <Button {...args} variant="inverted">
+        Inverted
+      </Button>
+      <Button {...args} variant="success">
+        Success
       </Button>
       <Button {...args} disabled variant="text">
         Text
@@ -219,7 +234,16 @@ export const IconOnlyStory: Story = {
 
 const EDGES = ["rounded", "circular", "none"] as const
 
-const VARIANTS = ["primary", "secondary", "tertiary", "text"] as const
+const VARIANTS = [
+  "primary",
+  "secondary",
+  "tertiary",
+  "bordered",
+  "noBorder",
+  "success",
+  "inverted",
+  "text",
+] as const
 const EXTRA_PROPS = [
   {},
   /**

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -10,11 +10,11 @@ type ButtonVariant =
   | "primary"
   | "secondary"
   | "tertiary"
-  | "text"
   | "bordered"
   | "noBorder"
   | "inverted"
   | "success"
+  | "text"
 type ButtonSize = "small" | "medium" | "large"
 type ButtonEdge = "circular" | "rounded" | "none"
 
@@ -191,11 +191,6 @@ const buildStyles = (props: ButtonStyleProps & { theme: Theme }) => {
       },
       ":disabled": {
         color: colors.silverGray,
-      },
-      ":active": {
-        backgroundColor: colors.red,
-        borderColor: colors.red,
-        color: colors.white,
       },
     },
     variant === "noBorder" && {

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -190,7 +190,9 @@ const buildStyles = (props: ButtonStyleProps & { theme: Theme }) => {
         backgroundColor: colors.lightGray1,
       },
       ":disabled": {
-        color: colors.silverGray,
+        backgroundColor: colors.lightGray2,
+        border: `1px solid ${colors.silverGrayDark}`,
+        color: colors.silverGrayDark,
       },
     },
     variant === "noBorder" && {

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -11,6 +11,7 @@ type ButtonVariant =
   | "secondary"
   | "tertiary"
   | "text"
+  | "bordered"
   | "noBorder"
   | "inverted"
   | "success"
@@ -98,7 +99,7 @@ const buildStyles = (props: ButtonStyleProps & { theme: Theme }) => {
     ...props,
   }
   const { colors } = theme.custom
-  const hasBorder = variant === "secondary"
+  const hasBorder = variant === "secondary" || variant === "bordered"
   return css([
     {
       color: theme.palette.text.primary,
@@ -142,11 +143,6 @@ const buildStyles = (props: ButtonStyleProps & { theme: Theme }) => {
         boxShadow: "none",
       },
     },
-    hasBorder && {
-      backgroundColor: "transparent",
-      borderColor: "currentcolor",
-      borderStyle: "solid",
-    },
     variant === "success" && {
       backgroundColor: colors.darkGreen,
       color: colors.white,
@@ -163,13 +159,11 @@ const buildStyles = (props: ButtonStyleProps & { theme: Theme }) => {
         boxShadow: "none",
       },
     },
-    hasBorder && {
+    variant === "secondary" && {
+      color: colors.red,
       backgroundColor: "transparent",
       borderColor: "currentcolor",
       borderStyle: "solid",
-    },
-    variant === "secondary" && {
-      color: colors.red,
       ":hover:not(:disabled)": {
         backgroundColor: tinycolor(colors.brightRed).setAlpha(0.06).toString(),
       },
@@ -186,6 +180,22 @@ const buildStyles = (props: ButtonStyleProps & { theme: Theme }) => {
       },
       ":disabled": {
         color: colors.silverGray,
+      },
+    },
+    variant === "bordered" && {
+      backgroundColor: colors.white,
+      color: colors.silverGrayDark,
+      border: `1px solid ${colors.silverGrayLight}`,
+      ":hover:not(:disabled)": {
+        backgroundColor: colors.lightGray1,
+      },
+      ":disabled": {
+        color: colors.silverGray,
+      },
+      ":active": {
+        backgroundColor: colors.red,
+        borderColor: colors.red,
+        color: colors.white,
       },
     },
     variant === "noBorder" && {

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -188,10 +188,11 @@ const buildStyles = (props: ButtonStyleProps & { theme: Theme }) => {
       border: `1px solid ${colors.silverGrayLight}`,
       ":hover:not(:disabled)": {
         backgroundColor: colors.lightGray1,
+        color: colors.darkGray2,
       },
       ":disabled": {
         backgroundColor: colors.lightGray2,
-        border: `1px solid ${colors.silverGrayDark}`,
+        border: `1px solid ${colors.lightGray2}`,
         color: colors.silverGrayDark,
       },
     },


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6277

### Description (What does it do?)
This PR adds the `bordered` variant to the `Button` component and updates the Storybook stories to demonstrate its usage.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/26113431-37c3-432f-8ec8-f560031f05dd)
![image](https://github.com/user-attachments/assets/a4391c75-8662-4147-bd68-6e202f491cd8)

### How can this be tested?
 - Spin up `mit-learn` on this branch
 - Visit Storybook at http://localhost:6006
 - Verify that the `bordered` button variant behaves as expected in normal, hover and disabled states according to the designs linked in the issue
