### PR TITLE
drawer v2 - use only vector based recommendation carousel

### DIFF
--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.test.tsx
@@ -173,21 +173,14 @@ describe("LearningResourceDrawerV2", () => {
     const similarResources = factories.learningResources.resources({
       count,
     }).results
-    const vectorSimilarResources = factories.learningResources.resources({
-      count,
-    }).results
     setMockResponse.get(urls.userMe.get(), null, { code: 403 })
     setMockResponse.get(
       urls.learningResources.details({ id: resource.id }),
       resource,
     )
     setMockResponse.get(
-      urls.learningResources.similar({ id: resource.id }),
-      similarResources,
-    )
-    setMockResponse.get(
       urls.learningResources.vectorSimilar({ id: resource.id }),
-      vectorSimilarResources,
+      similarResources,
     )
     renderWithProviders(<LearningResourceDrawerV2 />, {
       url: `?resource=${resource.id}`,
@@ -195,10 +188,6 @@ describe("LearningResourceDrawerV2", () => {
     await screen.findByText("Similar Learning Resources")
     for (const similarResource of similarResources) {
       await screen.findByText(similarResource.title)
-    }
-    await screen.findByText("Similar Learning Resources (Vector Based)")
-    for (const vectorSimilarResource of vectorSimilarResources) {
-      await screen.findByText(vectorSimilarResource.title)
     }
   })
 })

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -103,23 +103,6 @@ const DrawerContent: React.FC<{
           label: "Similar Learning Resources",
           cardProps: { size: "small" },
           data: {
-            type: "lr_similar",
-            params: { id: resourceId },
-          },
-        },
-      ]}
-    />
-  )
-  const vectorSimilarResourcesCarousel = (
-    <ResourceCarousel
-      titleComponent="p"
-      titleVariant="subtitle1"
-      title="Similar Learning Resources (Vector Based)"
-      config={[
-        {
-          label: "Similar Learning Resources (Vector Based)",
-          cardProps: { size: "small" },
-          data: {
             type: "lr_vector_similar",
             params: { id: resourceId },
           },
@@ -133,7 +116,7 @@ const DrawerContent: React.FC<{
       <LearningResourceExpandedV2
         imgConfig={imgConfigs.large}
         resource={resource.data}
-        carousels={[similarResourcesCarousel, vectorSimilarResourcesCarousel]}
+        carousels={[similarResourcesCarousel]}
         user={user}
         shareUrl={`${window.location.origin}/search?${RESOURCE_DRAWER_QUERY_PARAM}=${resourceId}`}
         inLearningPath={inLearningPath}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6263

### Description (What does it do?)
This PR removes the OpenSearch based recommendation carousel from the learning resource drawer. The vector (AI) based recommendation carousel is the default now, simply titled "Similar Learning Resources"

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/a43f7b9d-dc37-4c4d-a0cb-fc3e7d3480f5)
![image](https://github.com/user-attachments/assets/85fe067f-2073-4ac8-bd4e-b122e0bc15ff)

### How can this be tested?
 - If you have Posthog set up locally, enable the `lr_drawer_v2` flag
 - If you don't have Posthog set up locally, you can force `drawerV2` to be `true` in `LearningResourceDrawer.tsx`
 - Spin up this branch of `mit-learn`
 - Generate vector embeddings by running `docker compose exec web python manage.py generate_embeddings --skip-contentfiles --recreate-collections --all`
 - Visit the search page at http://localhost:8062/search
 - View a variety of learning resources and ensure that the related resources carousel appears