### PR TITLE
fix v2 drawer scrolling issues

### DIFF
--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -115,6 +115,7 @@ const DrawerContent: React.FC<{
     <>
       <LearningResourceExpandedV2
         imgConfig={imgConfigs.large}
+        resourceId={resourceId}
         resource={resource.data}
         carousels={[similarResourcesCarousel]}
         user={user}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSectionV2.tsx
@@ -196,6 +196,7 @@ const RunDates: React.FC<{ resource: LearningResource }> = ({ resource }) => {
     const showMoreLink = (
       <NoWrap>
         <ShowHideLink
+          scroll={false}
           color="red"
           size="small"
           onClick={() => setShowingMore(!showingMore)}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.test.tsx
@@ -35,6 +35,7 @@ const setup = (resource: LearningResource, isLearningPathEditor?: boolean) => {
   return render(
     <BrowserRouter>
       <LearningResourceExpandedV2
+        resourceId={resource.id}
         resource={resource}
         user={user}
         shareUrl={`https://learn.mit.edu/search?resource=${resource.id}`}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react"
+import React, { useCallback, useEffect, useRef, useState } from "react"
 import styled from "@emotion/styled"
 import Skeleton from "@mui/material/Skeleton"
 import { default as NextImage } from "next/image"
@@ -28,6 +28,7 @@ import VideoFrame from "./VideoFrame"
 import { Link } from "../Link/Link"
 import { Input } from "../Input/Input"
 import Typography from "@mui/material/Typography"
+import { useSearchParams } from "next/navigation"
 
 const DRAWER_WIDTH = "900px"
 
@@ -689,8 +690,20 @@ const LearningResourceExpandedV2: React.FC<LearningResourceExpandedV2Props> = ({
   onAddToUserListClick,
   closeDrawer,
 }) => {
+  const outerContainerRef = useRef<HTMLDivElement>(null)
+  const searchParams = useSearchParams()
+  const searchParamsRef = useRef(searchParams)
+  useEffect(() => {
+    if (
+      outerContainerRef.current &&
+      searchParamsRef.current.get("resource") !== searchParams.get("resource")
+    ) {
+      outerContainerRef.current.scrollTo(0, 0)
+      searchParamsRef.current = searchParams
+    }
+  })
   return (
-    <OuterContainer>
+    <OuterContainer ref={outerContainerRef}>
       <TitleSection
         resource={resource}
         closeDrawer={closeDrawer ?? (() => {})}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -659,7 +659,7 @@ const ResourceDescription = ({ resource }: { resource?: LearningResource }) => {
         data-testid="drawer-description-text"
         ref={descriptionRendered}
         /**
-         * Resource descriptions can contain HTML. They are santiized on the
+         * Resource descriptions can contain HTML. They are sanitized on the
          * backend during ETL. This is safe to render.
          */
         dangerouslySetInnerHTML={{ __html: resource.description || "" }}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -28,7 +28,6 @@ import VideoFrame from "./VideoFrame"
 import { Link } from "../Link/Link"
 import { Input } from "../Input/Input"
 import Typography from "@mui/material/Typography"
-import { useSearchParams } from "next/navigation"
 
 const DRAWER_WIDTH = "900px"
 
@@ -293,6 +292,7 @@ const CarouselContainer = styled.div({
 })
 
 type LearningResourceExpandedV2Props = {
+  resourceId: number
   resource?: LearningResource
   user?: User
   shareUrl?: string
@@ -679,6 +679,7 @@ const ResourceDescription = ({ resource }: { resource?: LearningResource }) => {
 }
 
 const LearningResourceExpandedV2: React.FC<LearningResourceExpandedV2Props> = ({
+  resourceId,
   resource,
   imgConfig,
   user,
@@ -691,17 +692,11 @@ const LearningResourceExpandedV2: React.FC<LearningResourceExpandedV2Props> = ({
   closeDrawer,
 }) => {
   const outerContainerRef = useRef<HTMLDivElement>(null)
-  const searchParams = useSearchParams()
-  const searchParamsRef = useRef(searchParams)
   useEffect(() => {
-    if (
-      outerContainerRef.current &&
-      searchParamsRef.current.get("resource") !== searchParams.get("resource")
-    ) {
+    if (outerContainerRef.current && outerContainerRef.current.scrollTo) {
       outerContainerRef.current.scrollTo(0, 0)
-      searchParamsRef.current = searchParams
     }
-  })
+  }, [resourceId])
   return (
     <OuterContainer ref={outerContainerRef}>
       <TitleSection

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -664,7 +664,12 @@ const ResourceDescription = ({ resource }: { resource?: LearningResource }) => {
         dangerouslySetInnerHTML={{ __html: resource.description || "" }}
       />
       {(isClamped || clampedOnFirstRender.current) && (
-        <Link color="red" size="small" onClick={() => setExpanded(!isExpanded)}>
+        <Link
+          scroll={false}
+          color="red"
+          size="small"
+          onClick={() => setExpanded(!isExpanded)}
+        >
           {isExpanded ? "Show less" : "Show more"}
         </Link>
       )}

--- a/frontends/ol-components/src/components/Link/Link.tsx
+++ b/frontends/ol-components/src/components/Link/Link.tsx
@@ -71,9 +71,17 @@ type LinkProps = LinkStyleProps &
      * re-fetch API data.
      */
     shallow?: boolean
+    scroll?: boolean
   }
 
-const BaseLink = ({ href, shallow, nohover, onClick, ...rest }: LinkProps) => {
+const BaseLink = ({
+  href,
+  shallow,
+  nohover,
+  scroll,
+  onClick,
+  ...rest
+}: LinkProps) => {
   if (process.env.NODE_ENV === "development") {
     invariant(
       !shallow || href?.startsWith("?"),
@@ -82,6 +90,7 @@ const BaseLink = ({ href, shallow, nohover, onClick, ...rest }: LinkProps) => {
   }
   return (
     <NextLink
+      scroll={scroll}
       href={href || ""}
       {...rest}
       onClick={


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6293

### Description (What does it do?)
This PR fixes various scrolling related to the new learning resource drawer. Firstly, clicking the "Show more" link on the description or the start dates were causing the main window to scroll to the top. This is caused by the `scroll` property on `NextLink`: https://nextjs.org/docs/pages/api-reference/components/link#scroll. It defaults to `true`, so whenever you click a `NextLink`, `nextjs` scrolls the window to the top. `scroll` can now be passed as a boolean argument to our `Link` component, which passes it on to the `NextLink` component. For the links inside the drawer, we pass `false` which prevents the scroll to the top from happening.

The second scrolling option here has to do with the cards in the recommendation carousel. Currently clicking them reloads the drawer, but does not scroll the drawer to the top. In order to fix this, code was added to `LearningResourceExpandedV2` to reset the scroll position if the resource ID in the query string has changed.

### How can this be tested?
 - If you have Posthog set up locally, enable the `lr_drawer_v2` flag
 - If you don't have Posthog set up locally, you can force `drawerV2` to be `true` in `LearningResourceDrawer.tsx`
 - Ensure that you have backpopulated some courses into your local database for testing
 - On line 119 of `LearningResourceDrawerV2`, temporarily set `carousels={[similarResourcesCarousel, similarResourcesCarousel, similarResourcesCarousel]}` to create enough scrollable content to demonstrate the second issue detailed above
 - Spin up this branch of `mit-learn`
 - Visit the search page at http://localhost:8062/search
 - Search for a course with a long description and many start dates, such as "Global Manufacturing Leadership Program"
 - When the search result is returned, scroll to the bottom of the page and then click the card to bring up the drawer
 - Click "Show more" both below the description and near the start dates, verifying that the page behind the drawer does not scroll to the top
 - Scroll down within the drawer and click one of the cards in the recommendation carousels, verifying that the drawer is scrolled to the top