### PR TITLE
restore main tag in root layout

### DIFF
--- a/frontends/main/src/app/styled.tsx
+++ b/frontends/main/src/app/styled.tsx
@@ -19,6 +19,6 @@ export const PageWrapper = styled.div(({ theme }) => ({
   },
 }))
 
-export const PageWrapperInner = styled.div({
+export const PageWrapperInner = styled.main({
   flex: "1",
 })


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6291

### Description (What does it do?)
Restores `main` tag in root layout.

### How can this be tested?
- There should be no visual change to any page
- All pages should now have their content inside a `main` tag. 
- If you have an accessibility checker (e.g., axe devtools for chrome, https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd) you could check that we no longer trigger "Document should have one main landmark".

### Additional Context
In our old (pre-nextjs) app, we had the `main` tag, and lost it during the migration. Unfortunately, I'm not sure of a good way to test this / prevent against regressions without e2e tests.
