### PR TITLE
create default collections on local dev initialization

### DIFF
--- a/docker-compose.apps.yml
+++ b/docker-compose.apps.yml
@@ -20,6 +20,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      qdrant:
+        condition: service_healthy
     volumes:
       - .:/src
       - django_media:/var/media

--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -38,6 +38,11 @@ services:
       - "6333:6333"
     volumes:
       - qdrant-data:/qdrant/storage
+    healthcheck:
+      test: ["CMD", "cat", ".qdrant-initialized"]
+      interval: 1s
+      timeout: 3s
+      retries: 10
   nginx:
     profiles:
       - backend

--- a/scripts/run-django-dev.sh
+++ b/scripts/run-django-dev.sh
@@ -17,7 +17,10 @@ RUN_DATA_MIGRATIONS=true python3 manage.py migrate --noinput
 echo "Loading fixtures!"
 python3 manage.py loaddata platforms schools departments offered_by
 
+# create initial qdrant collections
+python manage.py create_qdrant_collections
+
 # consolidate user subscriptions and remove duplicate percolate instances
-python $MANAGE_FILE prune_subscription_queries 2>&1 | indent
+python manage.py prune_subscription_queries 2>&1
 
 uwsgi uwsgi.ini --honour-stdin

--- a/vector_search/management/commands/create_qdrant_collections.py
+++ b/vector_search/management/commands/create_qdrant_collections.py
@@ -1,0 +1,33 @@
+"""Management command to create Qdrant collections"""
+
+from django.core.management.base import BaseCommand
+
+from vector_search.utils import (
+    create_qdrand_collections,
+)
+
+
+class Command(BaseCommand):
+    """Creates Qdrant collections"""
+
+    help = "Create Qdrant collections"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--force",
+            dest="force",
+            action="store_true",
+            help="delete existing collections and force recreate",
+        )
+
+        super().add_arguments(parser)
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        """Create Qdrant collections"""
+
+        if options["force"]:
+            create_qdrand_collections(force_recreate=True)
+        else:
+            create_qdrand_collections(force_recreate=False)
+
+        self.stdout.write("Created Qdrant collections")


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
Fixes https://github.com/mitodl/mit-learn/issues/1910
<!--- N/A --->

### Description (What does it do?)
This PR introduces a new management command that gets called when initializing local environments to create qdrant collections if they dont exist.

### How can this be tested?
1. checkout this branch
2. run ```docker compose down web qdrant```
3. remove the existing qdrant volume (which removes all qdrant data) ```docker volume rm $(docker volume ls | grep qdrant )```
4. rebuild the web container so the changes in the init script are there ```docker compose build web```
5. bring up just the qdrant container ```docker compose up -d qdrant``` - visit [the dashboard](http://localhost:6333/dashboard#/collections) and confirm there are no  collections
6. bring up the web container and let it finish initializing ```docker compose up -d``` - visit the qdrant dashboard again and confirm collections exist

### Additional Context
I also fixed an issue with the prune subscription command in the init script
