### PR TITLE
add topics carousels to v2 drawer

### DIFF
--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -22,6 +22,7 @@ import { usePostHog } from "posthog-js/react"
 import ResourceCarousel from "../ResourceCarousel/ResourceCarousel"
 import { useIsLearningPathMember } from "api/hooks/learningPaths"
 import { useIsUserListMember } from "api/hooks/userLists"
+import { TopicCarouselConfig } from "@/app-pages/DashboardPage/carousels"
 
 const RESOURCE_DRAWER_PARAMS = [RESOURCE_DRAWER_QUERY_PARAM] as const
 
@@ -108,15 +109,27 @@ const DrawerContent: React.FC<{
           },
         },
       ]}
+      excludeResourceId={resourceId}
     />
   )
+  const topicCarousels = resource.data?.topics?.map((topic) => (
+    <ResourceCarousel
+      key={topic.id}
+      titleComponent="p"
+      titleVariant="subtitle1"
+      title={`Popular courses in ${topic.name}`}
+      config={TopicCarouselConfig(topic.name)}
+      data-testid={`topic-carousel-${topic}`}
+      excludeResourceId={resourceId}
+    />
+  ))
 
   return (
     <>
       <LearningResourceExpandedV2
         imgConfig={imgConfigs.large}
         resource={resource.data}
-        carousels={[similarResourcesCarousel]}
+        carousels={[similarResourcesCarousel, ...(topicCarousels || [])]}
         user={user}
         shareUrl={`${window.location.origin}/search?${RESOURCE_DRAWER_QUERY_PARAM}=${resourceId}`}
         inLearningPath={inLearningPath}

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -117,7 +117,7 @@ const DrawerContent: React.FC<{
       key={topic.id}
       titleComponent="p"
       titleVariant="subtitle1"
-      title={`Popular courses in ${topic.name}`}
+      title={`Learning Resources in "${topic.name}"`}
       config={TopicCarouselConfig(topic.name)}
       data-testid={`topic-carousel-${topic}`}
       excludeResourceId={resourceId}

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -112,7 +112,10 @@ const DrawerContent: React.FC<{
       excludeResourceId={resourceId}
     />
   )
-  const topicCarousels = resource.data?.topics?.map((topic) => (
+  const topics = resource.data?.topics
+    ?.filter((topic) => topic.parent)
+    .slice(0, 2)
+  const topicCarousels = topics?.map((topic) => (
     <ResourceCarousel
       key={topic.id}
       titleComponent="p"

--- a/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
+++ b/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
@@ -220,4 +220,28 @@ describe("ResourceCarousel", () => {
       expect(title.tagName).toBe(expectedTag)
     },
   )
+
+  it("Excludes a resource if excludeResourceId is provided", async () => {
+    const config: ResourceCarouselProps["config"] = [
+      {
+        label: "Resources",
+        data: {
+          type: "resources",
+          params: { resource_type: ["course", "program"], professional: true },
+        },
+      },
+    ]
+    const { resources } = setupApis()
+    renderWithProviders(
+      <ResourceCarousel
+        titleComponent="h1"
+        title="My Carousel"
+        config={config}
+        excludeResourceId={resources.list.results[1].id}
+      />,
+    )
+    await screen.findByText(resources.list.results[0].title)
+    await screen.findByText(resources.list.results[2].title)
+    expect(screen.queryByText(resources.list.results[1].title)).toBeNull()
+  })
 })

--- a/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.tsx
+++ b/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.tsx
@@ -177,6 +177,7 @@ type ResourceCarouselProps = {
    */
   titleComponent?: React.ElementType
   titleVariant?: TypographyProps["variant"]
+  excludeResourceId?: number
 }
 /**
  * A tabbed carousel that fetches resources based on the configuration provided.
@@ -197,6 +198,7 @@ const ResourceCarousel: React.FC<ResourceCarouselProps> = ({
   "data-testid": dataTestId,
   titleComponent = "h4",
   titleVariant = "h4",
+  excludeResourceId,
 }) => {
   const [tab, setTab] = React.useState("0")
   const [ref, setRef] = React.useState<HTMLDivElement | null>(null)
@@ -306,13 +308,15 @@ const ResourceCarousel: React.FC<ResourceCarouselProps> = ({
                       {...tabConfig.cardProps}
                     />
                   ))
-                : resources.map((resource) => (
-                    <ResourceCard
-                      key={resource.id}
-                      resource={resource}
-                      {...tabConfig.cardProps}
-                    />
-                  ))}
+                : resources.map((resource) =>
+                    resource.id !== excludeResourceId ? (
+                      <ResourceCard
+                        key={resource.id}
+                        resource={resource}
+                        {...tabConfig.cardProps}
+                      />
+                    ) : null,
+                  )}
             </StyledCarousel>
           )}
         </PanelChildren>


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5879

### Description (What does it do?)
This PR adds a carousel to the new learning resource drawer for every `topic` related to the given resource being displayed, excluding the resource itself.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/3c21be86-a41b-4b7e-b3cf-68e95e513b68)
![image](https://github.com/user-attachments/assets/4476d570-4bbe-43f0-8be3-e9d443e7ee5c)

### How can this be tested?
 - If you have Posthog set up locally, enable the `lr_drawer_v2` flag
 - If you don't have Posthog set up locally, you can force `drawerV2` to be `true` in `LearningResourceDrawer.tsx`
 - Ensure that you have backpopulated some courses into your local database for testing
 - Visit the search page at http://localhost:8062/search
 - Click different types of courses and other resources, bringing up the new learning resource drawer
 - Verify that a carousel is displayed for each topic relevant to the resource below the similar resources carousel
