### PR TITLE
Enable use of ollama (GPU powered) embeddings

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -794,8 +794,6 @@ QDRANT_HOST = get_string(name="QDRANT_HOST", default="http://qdrant:6333")
 QDRANT_BASE_COLLECTION_NAME = get_string(
     name="QDRANT_COLLECTION_NAME", default="resource_embeddings"
 )
-
-
 QDRANT_DENSE_MODEL = get_string(name="QDRANT_DENSE_MODEL", default=None)
 QDRANT_SPARSE_MODEL = get_string(
     name="QDRANT_SPARSE_MODEL", default="prithivida/Splade_PP_en_v1"
@@ -803,6 +801,13 @@ QDRANT_SPARSE_MODEL = get_string(
 QDRANT_ENCODER = get_string(
     name="QDRANT_ENCODER", default="vector_search.encoders.fastembed.FastEmbedEncoder"
 )
+
+LITELLM_TOKEN_ENCODING_NAME = get_string(
+    name="LITELLM_TOKEN_ENCODING_NAME", default=None
+)
+LITELLM_CUSTOM_PROVIDER = get_string(name="LITELLM_CUSTOM_PROVIDER", default="ollama")
+LITELLM_API_BASE = get_string(name="LITELLM_API_BASE", default=None)
+
 
 OPENAI_API_KEY = get_string(
     name="OPENAI_API_KEY",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/6323

### Description (What does it do?)
Currently fastembed is the used in local development which embeds directly on cpu and is quite slow and limited especially when embedding lots of resources and content. Fastembed is still a good default since it works without any external dependecies and is well supported across environments .This PR allows developers to use ollama which takes advantage of the GPU for embeddings and results in a massive speedup. 

### How can this be tested?
1. checkout this branch
2. [install ollama](https://ollama.com/download) if you do not already have it 
3. once installed, open up a terminal and pull down the embedding model you would like to use via `ollama pull <model name>`. ollama currently supports the following models:
    - [nomic-embed-text](https://ollama.com/library/nomic-embed-text)
    - [mxbai-embed-large](https://ollama.com/library/mxbai-embed-large)
    - [all-minilm](https://ollama.com/library/all-minilm)
4. bring down your celery and web container `docker compose down celery web`
5. in your .env file configure litellm to use ollama:
```
QDRANT_ENCODER=vector_search.encoders.litellm.LiteLLMEncoder
LITELLM_API_BASE=http://docker.for.mac.host.internal:11434
QDRANT_DENSE_MODEL=<ollama model name>
```
LITELLM_API_BASE is specific to mac - if you are using something else you will need to figure out what the host machine's address is in docker 
QDRANT_DENSE_MODEL should be the name of the ollama model
my env looks like this:
```
QDRANT_ENCODER=vector_search.encoders.litellm.LiteLLMEncoder
LITELLM_API_BASE=http://docker.for.mac.host.internal:11434
QDRANT_DENSE_MODEL=all-minilm
```
6. bring the web and celery containers back up via ```docker compose up -d```
7. try running embeddings via ```python manage.py generate_embeddings --all --recreate-collections --skip-contentfiles```

It should be noticeably much faster

### Additional Context
If you use the largest model on ollama (mxbai-embed-large) you should also set LITELLM_TOKEN_ENCODING_NAME=cl100k_base to take advantage of the larger input token limit of the model