### PR TITLE
remove unncessary wrapper

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -79,9 +79,7 @@ const Info = ({
           <Certificate>
             {size === "small" ? (
               <Tooltip title="Certificate">
-                <CertificateIconContainer>
-                  <RiAwardFill />
-                </CertificateIconContainer>
+                <RiAwardFill />
               </Tooltip>
             ) : (
               <RiAwardFill />
@@ -97,11 +95,6 @@ const Info = ({
     </>
   )
 }
-
-const CertificateIconContainer = styled.div`
-  display: flex;
-  align-items: center;
-`
 
 const PriceContainer = styled.div`
   display: flex;


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6325

### Description (What does it do?)
This PR removes an unnecessary wrapper around an icon. Previously the wrapping div had an aria-label; this is technically disalllowed and causes some accessibility checkers to issue a warning.

Now the aria-label is on an svg, which is 👍 .

### Screenshots
Small cards with a certificate are "affected", but there is no visual change:

<img width="183" alt="Screenshot 2024-12-18 at 3 28 52 PM" src="https://github.com/user-attachments/assets/58003ec6-883e-4760-bd76-b05dc93c831d" />


### How can this be tested?
1. View a small card with a certificate on RC. These can be found (possibly) in your dashboard, or in the "Similar Resources" carousels inside the learning resource drawer. Check the certificate icon dimensions:
    - svg is 12px by 12px
    - so is the div wrapping it
2. Do same locally; svg should still be 12px by 12px. The div wrapping it is gone. The SVG itself now has aria-label.
3. Additionally / Optionally, you could check that an accessibility checker like [axe devtools ](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd) no longer flags the aria-label as invalid. (Run it with the drawer open).
