### PR TITLE
Fix certification parameter, update prompts, catch json parsing error…

### DIFF
--- a/ai_chat/agents.py
+++ b/ai_chat/agents.py
@@ -218,9 +218,9 @@ offered_by: If a user asks for resources "offered by" or "from" an institution,
 you should include this parameter based on the following
 dictionary: {OfferedBy.as_dict()}  DO NOT USE THE offered_by FILTER OTHERWISE.
 
-certificate: true if the user is interested in resources that offer certificates, false
-if the user does not want resources with a certificate offered.  Do not used this filter
-if the user does not indicate a preference.
+certification: true if the user is interested in resources that offer certificates,
+false if the user does not want resources with a certificate offered.  Do not use
+this filter if the user does not indicate a preference.
 
 free: true if the user is interested in free resources, false if the user is only
 interested in paid resources. Do not used this filter if the user does not indicate
@@ -282,7 +282,7 @@ Search parameters: {{"q": "mathematics"}}
             q: The search query string
             resource_type: Filter by type of resource (course, program, etc)
             free: Filter for free resources only
-            certificate: Filter for resources offering certificates
+            certification: Filter for resources offering certificates
             offered_by: Filter by institution offering the resource
         """
 
@@ -301,7 +301,7 @@ Search parameters: {{"q": "mathematics"}}
             default=None,
             description="Whether the resource is free to access, true|false",
         )
-        certificate: Optional[bool] = Field(
+        certification: Optional[bool] = Field(
             default=None,
             description=(
                 "Whether the resource offers a certificate upon completion, true|false"
@@ -319,7 +319,7 @@ Search parameters: {{"q": "mathematics"}}
                     "q": "machine learning",
                     "resource_type": ["course"],
                     "free": True,
-                    "certificate": False,
+                    "certification": False,
                     "offered_by": "MIT",
                 }
             ]
@@ -366,7 +366,7 @@ Search parameters: {{"q": "mathematics"}}
             "resource_type": kwargs.get("resource_type"),
             "free": kwargs.get("free"),
             "offered_by": kwargs.get("offered_by"),
-            "certificate": kwargs.get("certificate"),
+            "certification": kwargs.get("certification"),
         }
         params.update({k: v for k, v in valid_params.items() if v is not None})
         self.search_parameters.append(params)
@@ -461,7 +461,6 @@ Search parameters: {{"q": "mathematics"}}
             "metadata": {
                 "search_parameters": self.search_parameters,
                 "search_results": self.search_results,
-                "system_prompt": self.instructions,
             }
         }
         return json.dumps(metadata)

--- a/ai_chat/agents_test.py
+++ b/ai_chat/agents_test.py
@@ -208,7 +208,7 @@ def test_search_agent_tool(settings, mocker):
         "q": "physics",
         "resource_type": ["course", "program"],
         "free": False,
-        "certificate": True,
+        "certification": True,
         "offered_by": "xpro",
         "limit": 5,
     }

--- a/frontends/main/src/app-pages/ChatPage/ChatPage.tsx
+++ b/frontends/main/src/app-pages/ChatPage/ChatPage.tsx
@@ -25,7 +25,6 @@ const CONVERSATION_OPTIONS = {
       prompt:
         "I would like to learn about linear regression, preferably at no cost.",
     },
-    { prompt: "What is the relationship between albedo and climate?" },
   ],
 }
 

--- a/frontends/main/src/app-pages/ChatPage/ChatPage.tsx
+++ b/frontends/main/src/app-pages/ChatPage/ChatPage.tsx
@@ -9,9 +9,23 @@ import { useFeatureFlagEnabled } from "posthog-js/react"
 
 const CONVERSATION_OPTTIONS = {
   conversationStarters: [
-    { prompt: "I'm interested in quantum computing." },
-    { prompt: "I want to learn about global warming." },
-    { prompt: "I am curious about AI applications for business." },
+    {
+      prompt:
+        "I'm interested in courses on quantum computing that offer certificates.",
+    },
+    {
+      prompt:
+        "I want to learn about global warming, can you recommend any videos?",
+    },
+    {
+      prompt:
+        "I am curious about AI applications for business.  Do you have any free courses about that?",
+    },
+    {
+      prompt:
+        "I would like to learn about linear regression, preferably at no cost.",
+    },
+    { prompt: "What is the relationship between albedo and climate?" },
   ],
 }
 

--- a/frontends/main/src/app-pages/ChatPage/ChatPage.tsx
+++ b/frontends/main/src/app-pages/ChatPage/ChatPage.tsx
@@ -7,7 +7,7 @@ import { NluxAiChat } from "@/page-components/Nlux-AiChat/AiChat"
 import { FeatureFlags } from "@/common/feature_flags"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 
-const CONVERSATION_OPTTIONS = {
+const CONVERSATION_OPTIONS = {
   conversationStarters: [
     {
       prompt:
@@ -55,7 +55,7 @@ const ChatPage = () => {
           <StyledChat
             key={"agent"}
             send={sends["agent"]}
-            conversationOptions={CONVERSATION_OPTTIONS}
+            conversationOptions={CONVERSATION_OPTIONS}
           />
         ) : (
           <></>

--- a/frontends/ol-utilities/src/lib/utils.ts
+++ b/frontends/ol-utilities/src/lib/utils.ts
@@ -71,5 +71,10 @@ export const pluralize = (singular: string, count: number, plural?: string) => {
  */
 export const extractJSONFromComment = (comment: string) => {
   const jsonStr = comment.toString().match(/<!-{2}(.*)-{2}>/)?.[1] || "{}"
-  return JSON.parse(jsonStr)
+  try {
+    return JSON.parse(jsonStr)
+  } catch (e) {
+    console.error("error parsing JSON from comment", comment, e)
+    return {}
+  }
 }


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
- Fixes the `certification` search parameter
- Updates example prompts
- Catches any debug info json parsing errors

### Screenshots (if appropriate):
![Screenshot 2024-12-20 at 11 29 45 AM](https://github.com/user-attachments/assets/0a0f28c3-b36e-43e8-9c64-8c5ed3e0ab25)


### How can this be tested?
- Set `OPENAI_API_KEY` and `POSTHOG_*` env settings to the same as RC
- Go to `http://open.odl.local:8062/chat/`
- Try out the example prompts, they should return reasonable responses
- Try asking your own questions, asking for courses with certificates.  You should get results assuming there are any courses on your subject of interest that offer certificates.


