### PR TITLE
Track chatbot activity in posthog

### DIFF
--- a/frontends/main/src/app-pages/ChatPage/ChatPage.tsx
+++ b/frontends/main/src/app-pages/ChatPage/ChatPage.tsx
@@ -24,11 +24,7 @@ const CONVERSATION_OPTIONS = {
     {
       prompt:
         "I would like to learn about linear regression, preferably at no cost.",
-<<<<<<< HEAD
-    }
-=======
     },
->>>>>>> f61d54cf3 (Remove prompt about albedo, answers seem erratic)
   ],
 }
 

--- a/frontends/main/src/app-pages/ChatPage/ChatPage.tsx
+++ b/frontends/main/src/app-pages/ChatPage/ChatPage.tsx
@@ -24,7 +24,7 @@ const CONVERSATION_OPTIONS = {
     {
       prompt:
         "I would like to learn about linear regression, preferably at no cost.",
-    },
+    }
   ],
 }
 

--- a/frontends/main/src/app-pages/ChatPage/ChatPage.tsx
+++ b/frontends/main/src/app-pages/ChatPage/ChatPage.tsx
@@ -24,7 +24,11 @@ const CONVERSATION_OPTIONS = {
     {
       prompt:
         "I would like to learn about linear regression, preferably at no cost.",
+<<<<<<< HEAD
     }
+=======
+    },
+>>>>>>> f61d54cf3 (Remove prompt about albedo, answers seem erratic)
   ],
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds posthog event tracking for chatbot questions and answers



### How can this be tested?
- Set `POSTHOG+*` and `OPENAI_API_KEY` env settings to the same as RC
- Go to `http://open.odl.local:8062/chat`, ask some questions.  Logged in or anonymous.
- You will need a posthog account for this: Go to https://us.posthog.com/project/86325/activity/explore and look for `recommendation_agent` events.  Expand on the most recent ones, they should hold info on your questions and the answers you got, and be associated with your user email if logged in, "anonymous" if not.  It may take a few minutes before they show up.

