### PR TITLE
Remove latest change to uwsgi.ini

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -30,5 +30,3 @@ stats = /tmp/uwsgi-stats.sock
 reload-on-rss = 300
 # for sentry
 py-call-uwsgi-fork-hooks = true
-# for streaming response
-http-auto-chunked = true


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Potential fix for across-the-board response slowdown on RC



### How can this be tested?
I did not notice any performance improvement locally, but maybe this will still make a difference on heroku/RC.  All functionality should still work, including http://open.odl.local:8062/chat

### Additional Context
N/A
