### PR TITLE
dedupe edx content files further

### DIFF
--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -330,16 +330,17 @@ def documents_from_olx(
                     filebytes = f.read()
 
                 mimetype = mimetypes.types_map.get(extension_lower)
+                checksum = md5(filebytes).hexdigest()  # noqa: S324
 
                 yield (
                     filebytes,
                     {
-                        "key": f"{path}/{filename}",
+                        "key": checksum,
                         "content_type": CONTENT_TYPE_FILE,
                         "mime_type": mimetype,
-                        "checksum": md5(filebytes).hexdigest(),  # noqa: S324
+                        "checksum": checksum,
                         "file_extension": extension_lower,
-                        "source_path": path,
+                        "source_path": f"{path}/{filename}",
                     },
                 )
 

--- a/learning_resources/etl/utils_test.py
+++ b/learning_resources/etl/utils_test.py
@@ -259,12 +259,15 @@ def test_documents_from_olx():
     assert len(parsed_documents) == 92
 
     formula2do = next(
-        doc for doc in parsed_documents if doc[1]["key"].endswith("formula2do.xml")
+        doc
+        for doc in parsed_documents
+        if doc[1]["source_path"].endswith("formula2do.xml")
     )
     assert formula2do[0] == b'<html filename="formula2do" display_name="To do list"/>\n'
-    assert formula2do[1]["key"].endswith("formula2do.xml")
+    assert formula2do[1]["source_path"].endswith("formula2do.xml")
     assert formula2do[1]["content_type"] == CONTENT_TYPE_FILE
     assert formula2do[1]["mime_type"].endswith("/xml")
+    assert formula2do[1]["key"] == "8852bcb31c0a4dc9d6c5385e09b0e0c4"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/6343

### Description (What does it do?)
The edx course folders contain duplicates of some files. This PR updates the file etl to dedupe files that have the same run and content 

### How can this be tested?
If you don't have xpro files already populated, run 
Run `docker-compose run web ./manage.py backpopulate_xpro_data` , `docker-compose run web ./manage.py backpopulate_xpro_files --overwrite`
in the main branch

From the shell run
```
from learning_resources.models import *
ContentFile.objects.filter(run__learning_resource__platform_id='xpro').count()
ContentFile.objects.filter(checksum='c701f34e5593021eec27db37561c45de').count()
```

You should have about 7187 xpro content files and 33 content files with checksum c701f34e5593021eec27db37561c45de

In this branch run 
 `docker-compose run web ./manage.py backpopulate_xpro_files --overwrite`

From the shell run
```
from learning_resources.models import *
ContentFile.objects.filter(run__learning_resource__platform_id='xpro').count()
ContentFile.objects.filter(checksum='c701f34e5593021eec27db37561c45de').count()
```

You will have about 5555 xpro content files and 1 file with checksum c701f34e5593021eec27db37561c45de



