### PR TITLE
consistent image sizes in subscription emails

### DIFF
--- a/main/templates/email/subscribed_channel_digest.html
+++ b/main/templates/email/subscribed_channel_digest.html
@@ -73,6 +73,7 @@
               width="113"
               alt="{{item.resource_title}}"
               style="
+                object-fit: cover;
                 width: 113px;
                 background: #ffffff;
                 font-family: sans-serif;

--- a/main/templates/email/subscribed_channel_digest.html
+++ b/main/templates/email/subscribed_channel_digest.html
@@ -67,19 +67,21 @@
     >
       <tr>
         <td style="padding: 10px 20px; width: 113px; height: 60px">
-          <img
-            src="{{item.resource_image_url}}"
-            width="113"
-            alt="{{item.resource_title}}"
-            style="
-              width: 113px;
-              background: #ffffff;
-              font-family: sans-serif;
-              font-size: 15px;
-              line-height: 15px;
-              color: #a31f34;
-            "
-          />
+          <div style="height: 60px !important; overflow: hidden !important">
+            <img
+              src="{{item.resource_image_url}}"
+              width="113"
+              alt="{{item.resource_title}}"
+              style="
+                width: 113px;
+                background: #ffffff;
+                font-family: sans-serif;
+                font-size: 15px;
+                line-height: 15px;
+                color: #a31f34;
+              "
+            />
+          </div>
         </td>
         <td
           style="

--- a/main/templates/email/subscribed_channel_digest.html
+++ b/main/templates/email/subscribed_channel_digest.html
@@ -67,20 +67,18 @@
     >
       <tr>
         <td style="padding: 10px 20px; width: 113px; height: 60px">
-          <div style="height: 60px !important; overflow: hidden !important">
+          <div
+            style="
+              height: 60px !important;
+              width: 113px !important;
+              display: block;
+              overflow: hidden !important;
+            "
+          >
             <img
               src="{{item.resource_image_url}}"
-              width="113"
               alt="{{item.resource_title}}"
-              style="
-                object-fit: cover;
-                width: 113px;
-                background: #ffffff;
-                font-family: sans-serif;
-                font-size: 15px;
-                line-height: 15px;
-                color: #a31f34;
-              "
+              style="background: #ffffff; max-width: 140%"
             />
           </div>
         </td>

--- a/main/templates/email/subscribed_channel_digest.html
+++ b/main/templates/email/subscribed_channel_digest.html
@@ -69,16 +69,23 @@
         <td style="padding: 10px 20px; width: 113px; height: 60px">
           <div
             style="
-              height: 60px !important;
-              width: 113px !important;
-              display: block;
               overflow: hidden !important;
+              height: 60px;
+              width: 113px;
+              max-height: 60px !important;
+              max-width: 113px !important;
+              display: block;
             "
           >
             <img
               src="{{item.resource_image_url}}"
               alt="{{item.resource_title}}"
-              style="background: #ffffff; max-width: 140%"
+              style="
+                display: block;
+                max-width: 200% !important;
+                background: #ffffff;
+                object-fit: contain;
+              "
             />
           </div>
         </td>


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/6390


### Description (What does it do?)
This PR adds a fix for irregular/inconsistent image sizes in subscription emails 


### Screenshots (if appropriate):

## Outlook
<img width="383" alt="Screenshot 2025-01-08 at 2 26 07 PM" src="https://github.com/user-attachments/assets/14c6820b-3d2a-4748-af74-83ad97e6f519" />

## Chrome
<img width="383" src="https://github.com/user-attachments/assets/3657c5a8-5bf5-4c0e-955b-13beda2094d4" />


### How can this be tested?
1. Checkout this branch.
2. Copy the following  settings from the heroku RC stack:
  - MITOL_NOTIFICATION_EMAIL_BACKEND
  - MAILGUN_API_KEY
  - MAILGUN_SENDER_DOMAIN
  - MAILGUN_FROM_EMAIL
  - MAILGUN_SENDER_DOMAIN
3. restart celery
4. login as your super user (make sure you can access email address for this user). subscribe to all the provider channels mitx, ocw etc 
5. run the following script to mark a few resources as "new" in addition to randomly setting images to a variety of sizes:
```
import datetime
from learning_resources.models import LearningResource, LearningResourceImage
import random
lrimage = LearningResourceImage.objects.create(url='https://professional.mit.edu/sites/default/files/2021-03/Applied%20Data%20Science%20Programs.jpg')
lrimagewide = LearningResourceImage.objects.create(url='https://learn.mit.edu/_next/image?url=https%3A%2F%2Fprofessional.mit.edu%2Fsites%2Fdefault%2Ffiles%2F2020-02%2FAdvanced%2520Machine%2520Learning%2520Website%2520Banner.jpg&w=3840&q=75')
i = 0
for lr in LearningResource.objects.all()[:100]:
	i+=1
	lr.created_on = datetime.datetime.now()
	lr.save()
	if i%3 == 0:
		lr.image = lrimage
	elif i%3 == 1:
		lr.image = lrimagewide
	else:
		lr.image = LearningResourceImage.objects.create(url=random.choice(["https://professional.mit.edu/sites/default/files/2021-03/Applied%20Data%20Science%20Programs.jpg", "https://professional.mit.edu/sites/default/files/2020-11/RL-1.JPG",'https://professional.mit.edu/sites/default/files/2022-04/1200x550%20-%20New.jpg',"https://professional.mit.edu/sites/default/files/2022-09/1200x550%20-%20New.jpg"]))
	lr.save()
	print(lr.published)
```
6. Run the celery task to send out subscription emails via:
```
from learning_resources_search.tasks import send_subscription_emails
send_subscription_emails("channel_subscription_type")
```
7. view the emails - also try sending to various clients to see how they render gmail, outlook