### PR TITLE
constraining resources for celery service

### DIFF
--- a/docker-compose.apps.yml
+++ b/docker-compose.apps.yml
@@ -53,8 +53,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    mem_limit: 2gb
-    cpus: 2
+    mem_limit: ${MITOL_CELERY_MEM_LIMIT:-2gb}
+    cpus: ${MITOL_CELERY_CPU_LIMIT:-2}
     command: >
       /bin/bash -c '
       sleep 3;

--- a/docker-compose.apps.yml
+++ b/docker-compose.apps.yml
@@ -53,6 +53,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    mem_limit: 2gb
+    cpus: 2
     command: >
       /bin/bash -c '
       sleep 3;


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
 Closes https://github.com/mitodl/hq/issues/6420

### Description (What does it do?)
This pr sets cpu and memory limits on the celery container to avoid high resource usage when running fastembed

# How to test
1. checkout this branch. 
2. recreate the celery container so the new resource constraints are in place via `docker compose down celery` and `docker compose up celery`
3. in order to get many instances of fastembed running at once to try and run up the resource usage, i used the following shell script which sets the created_on date for all learning resources to today and then manually runs the "embed_new_learning_resources" several times:
```
from vector_search.tasks import embed_new_learning_resources
from learning_resources.models import LearningResource

for lr in LearningResource.objects.all():
	lr.create_on = datetime.datetime.now()
	lr.save()

embed_new_learning_resources.delay()
embed_new_learning_resources.delay()
embed_new_learning_resources.delay()
```
4. in the docker desktop app, see that the celery container is not hugging resources
5. see that the celery task is not erroring as its embedding

### Additional Context
I tried creating many instances of the embed tasks and played with cpu and memory allocations for docker but I wasn't able to replicate the initial issue locally. 

The limits are configurable via the following environment variables:
- MITOL_CELERY_MEM_LIMIT
- MITOL_CELERY_CPU_LIMIT