### PR TITLE
fix search text

### DIFF
--- a/frontends/main/src/app-pages/ChannelPage/ChannelSearch.tsx
+++ b/frontends/main/src/app-pages/ChannelPage/ChannelSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react"
+import React, { useCallback, useMemo, useEffect } from "react"
 import { ChannelTypeEnum } from "api/v0"
 import { useOfferorsList } from "api/hooks/learningResources"
 import { useResourceSearchParams } from "@mitodl/course-search-utils"
@@ -94,6 +94,10 @@ const ChannelSearch: React.FC<ChannelSearchProps> = ({
     onFacetsChange,
   })
   const page = +(searchParams.get("page") ?? "1")
+
+  useEffect(() => {
+    setCurrentText(params.q ?? "")
+  }, [params, setCurrentText])
 
   return (
     <section>

--- a/frontends/main/src/app-pages/SearchPage/SearchPage.tsx
+++ b/frontends/main/src/app-pages/SearchPage/SearchPage.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { keyBy } from "lodash"
-import React, { useCallback, useMemo } from "react"
+import React, { useCallback, useMemo, useEffect } from "react"
 import type { FacetManifest } from "@mitodl/course-search-utils"
 import { useSearchParams } from "@mitodl/course-search-utils/next"
 import { useResourceSearchParams } from "@mitodl/course-search-utils"
@@ -93,6 +93,7 @@ const SearchPage: React.FC = () => {
     },
     [setSearchParams],
   )
+
   const onFacetsChange = useCallback(() => {
     setPage(1)
   }, [setPage])
@@ -114,6 +115,10 @@ const SearchPage: React.FC = () => {
   })
 
   const page = +(searchParams.get("page") ?? "1")
+
+  useEffect(() => {
+    setCurrentText(params.q ?? "")
+  }, [params, setCurrentText])
 
   return (
     <Page>


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/6403

### Description (What does it do?)
Currently hitting the back button changes search text in the url but not the text box. This fixes the issue.

### How can this be tested?
1) Go to http://open.odl.local:8062/search
2) Make a text search
3) Search for some different text
4) Click the back button

Your search page should show the text from step 2 and the appropriate results

Go to a channel page (such as http://open.odl.local:8062/c/unit/mitx) and repeat the above