### PR TITLE
Fix SCIM API error on patch with nested attributes

### DIFF
--- a/profiles/scim/views_test.py
+++ b/profiles/scim/views_test.py
@@ -92,6 +92,10 @@ def test_scim_post_user(staff_client):
                                 "schemas": [constants.SchemaURI.USER],
                                 "emailOptIn": 1,
                                 "fullName": "Billy Bob",
+                                "name": {
+                                    "givenName": "Billy",
+                                    "fmailyName": "Bob",
+                                },
                             }
                         ),
                     }
@@ -107,7 +111,7 @@ def test_scim_post_user(staff_client):
     assert user is not None
     assert user.email == "jsmith@example.com"
     assert user.username == "jsmith"
-    assert user.first_name == "Jimmy"
-    assert user.last_name == "Smith"
+    assert user.first_name == "Billy"
+    assert user.last_name == "Bob"
     assert user.profile.name == "Billy Bob"
     assert user.profile.email_optin is True

--- a/profiles/scim/views_test.py
+++ b/profiles/scim/views_test.py
@@ -94,7 +94,7 @@ def test_scim_post_user(staff_client):
                                 "fullName": "Billy Bob",
                                 "name": {
                                     "givenName": "Billy",
-                                    "fmailyName": "Bob",
+                                    "familyName": "Bob",
                                 },
                             }
                         ),


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/6436

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds in handling for nested field updates which are being sent when a profile is updated in keycloak.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
If you have SCIM setup locally w/ keycloak you can simply update your first or last name in your keycloak profile. You should see an API request to `/scim/v2/Users/[ID]` and that should not error and the update be reflected on your user.

Alternatively if you don't have this setup, the tests cover this scenario with the payload that is sent by keycloak.
