### PR TITLE
Fix Posthog multiple inits

### DIFF
--- a/frontends/main/src/app/providers.tsx
+++ b/frontends/main/src/app/providers.tsx
@@ -9,20 +9,12 @@ import {
   theme,
 } from "ol-components"
 import { Provider as NiceModalProvider } from "@ebay/nice-modal-react"
+import ConfiguredPostHogProvider from "@/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider"
 import { usePrefetchWarnings } from "api/ssr/usePrefetchWarnings"
 import { AppProgressBar as ProgressBar } from "next-nprogress-bar"
 import type { NProgressOptions } from "next-nprogress-bar"
-import dynamic from "next/dynamic"
 
 const PROGRESS_BAR_OPTS: NProgressOptions = { showSpinner: false }
-
-const ConfiguredPostHogProvider = dynamic(
-  () =>
-    import(
-      "@/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider"
-    ),
-  { ssr: false },
-)
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const queryClient = getQueryClient()

--- a/frontends/main/src/app/providers.tsx
+++ b/frontends/main/src/app/providers.tsx
@@ -9,12 +9,20 @@ import {
   theme,
 } from "ol-components"
 import { Provider as NiceModalProvider } from "@ebay/nice-modal-react"
-import ConfiguredPostHogProvider from "@/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider"
 import { usePrefetchWarnings } from "api/ssr/usePrefetchWarnings"
 import { AppProgressBar as ProgressBar } from "next-nprogress-bar"
 import type { NProgressOptions } from "next-nprogress-bar"
+import dynamic from "next/dynamic"
 
 const PROGRESS_BAR_OPTS: NProgressOptions = { showSpinner: false }
+
+const ConfiguredPostHogProvider = dynamic(
+  () =>
+    import(
+      "@/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider"
+    ),
+  { ssr: false },
+)
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const queryClient = getQueryClient()

--- a/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.test.tsx
+++ b/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 
 import { render, waitFor } from "@testing-library/react"
-import { PosthogIdenifier } from "./ConfiguredPostHogProvider"
+import { PosthogIdentifier } from "./ConfiguredPostHogProvider"
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query"
 
 // mock stuff
@@ -26,7 +26,7 @@ const posthog: Pick<PostHog, "identify" | "reset" | "get_property"> = {
 mockUsePostHog.mockReturnValue(posthog as PostHog)
 const mockPosthog = jest.mocked(posthog)
 
-describe("PosthogIdenifier", () => {
+describe("PosthogIdentifier", () => {
   const setup = (user: Partial<User>) => {
     const queryClient = new QueryClient()
     const userData = makeUserSettings(user)
@@ -34,7 +34,7 @@ describe("PosthogIdenifier", () => {
     setMockResponse.get(urls.userMe.get(), userData)
     render(
       <QueryClientProvider client={queryClient}>
-        <PosthogIdenifier />
+        <PosthogIdentifier />
       </QueryClientProvider>,
     )
     return userData

--- a/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
+++ b/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
@@ -38,7 +38,6 @@ const ConfiguredPostHogProvider: React.FC<{ children: React.ReactNode }> = ({
     const featureFlags = JSON.parse(process.env.FEATURE_FLAGS || "")
 
     if (POSTHOG_API_KEY) {
-      console.info("Initializing PostHog")
       posthog.init(POSTHOG_API_KEY, {
         api_host: POSTHOG_API_HOST,
         bootstrap: {

--- a/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
+++ b/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
@@ -3,6 +3,19 @@ import posthog from "posthog-js"
 import { PostHogProvider, usePostHog } from "posthog-js/react"
 import { useUserMe } from "api/hooks/user"
 
+const POSTHOG_API_KEY = process.env.NEXT_PUBLIC_POSTHOG_API_KEY
+const POSTHOG_API_HOST = process.env.NEXT_PUBLIC_POSTHOG_API_HOST
+const FEATURE_FLAGS = process.env.FEATURE_FLAGS
+
+if (POSTHOG_API_KEY) {
+  posthog.init(POSTHOG_API_KEY, {
+    api_host: POSTHOG_API_HOST,
+    bootstrap: {
+      featureFlags: FEATURE_FLAGS ? JSON.parse(FEATURE_FLAGS) : null,
+    },
+  })
+}
+
 const PosthogIdentifier = () => {
   const { data: user } = useUserMe()
   const posthog = usePostHog()
@@ -28,25 +41,9 @@ const PosthogIdentifier = () => {
   return null
 }
 
-const POSTHOG_API_KEY = process.env.NEXT_PUBLIC_POSTHOG_API_KEY
-const POSTHOG_API_HOST = process.env.NEXT_PUBLIC_POSTHOG_API_HOST
-
 const ConfiguredPostHogProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  useEffect(() => {
-    const featureFlags = JSON.parse(process.env.FEATURE_FLAGS || "")
-
-    if (POSTHOG_API_KEY) {
-      posthog.init(POSTHOG_API_KEY, {
-        api_host: POSTHOG_API_HOST,
-        bootstrap: {
-          featureFlags,
-        },
-      })
-    }
-  }, [])
-
   if (!POSTHOG_API_KEY) {
     return children
   }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Relates to https://github.com/mitodl/hq/issues/6290

### Description (What does it do?)
<!--- Describe your changes in detail -->

Whilst looking into initial page load performance and script blocking, Posthog showed up as significantly adding to the Total Blocking Time.

During build, we see:

```
[PostHog.js] was already loaded elsewhere. This may cause issues.
[PostHog.js] was already loaded elsewhere. This may cause issues.
[PostHog.js] was already loaded elsewhere. This may cause issues.
[PostHog.js] was already loaded elsewhere. This may cause issues.
[PostHog.js] was already loaded elsewhere. This may cause issues.
[PostHog.js] was already loaded elsewhere. This may cause issues.
[PostHog.js] was already loaded elsewhere. This may cause issues.
[PostHog.js] was already loaded elsewhere. This may cause issues.
[PostHog.js] was already loaded elsewhere. This may cause issues.
[PostHog.js] was already loaded elsewhere. This may cause issues.
[PostHog.js] was already loaded elsewhere. This may cause issues.
[PostHog.js] was already loaded elsewhere. This may cause issues.
```

Again we see the log line at runtime on each page load. It is indeed causing issues - running the profiler in Chrome Dev Tools, the flame chart shows this long blocking task with many calls into [rrweb](https://github.com/rrweb-io/rrweb), a library used by PostHog for session replay, here serializing the DOM: https://github.com/rrweb-io/rrweb/blob/52842ba09a975436c7748161887fde0efd875068/packages/rrweb-snapshot/src/snapshot.ts#L900. This profile was run at 20x CPU slowdown:

<br /><br />

<img width="1427" alt="image" src="https://github.com/user-attachments/assets/0386e62c-d0bb-4f8f-8ee9-9bf74cbce759" />


<br /><br />

With this change to initialize Posthog once, which is in line with [Posthog's documentation for Next.js](https://posthog.com/docs/libraries/next-js), the long blocking task that shows up between the DOMContentLoaded and Onload events is gone entirely:

<br /><br />

<img width="1427" alt="image" src="https://github.com/user-attachments/assets/560a4f8e-6d89-4b24-834e-bf9491bb2b06" />



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Posthog should function as previously with feature flags applied and events reported.

- The long blocking task should not appear in the profiler flame chart (Performance tab in Chrome Dev Tools) - this shows up prominently on the main branch when the profile is set to 20x CPU slowdown. Next.js must be run in production mode (`yarn build; yarn start;`) and the site should be profiled in a private window to eliminate any browser extensions.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/497a6bda-5737-4828-aab4-2fd318c516a5" />

<br /><br />

This also shaves a second or two off the Onload timing (running at 20x CPU slowdown). Be mindful though of the initial server response time when testing as this is a significant factor in marker timings (here we can measure between First Paint and Onload).

