### PR TITLE
make useSearchParams mock return stable reference

### DIFF
--- a/frontends/ol-test-utilities/package.json
+++ b/frontends/ol-test-utilities/package.json
@@ -14,5 +14,11 @@
     "dom-accessibility-api": "^0.7.0",
     "next-router-mock": "^0.9.13",
     "tiny-invariant": "^1.3.1"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.6"
   }
 }

--- a/frontends/ol-test-utilities/src/mocks/nextNavigation.ts
+++ b/frontends/ol-test-utilities/src/mocks/nextNavigation.ts
@@ -6,6 +6,7 @@
  *
  * See https://github.com/scottrippey/next-router-mock/issues
  */
+import { useRef } from "react"
 import * as mocks from "next-router-mock"
 import { createDynamicRouteParser } from "next-router-mock/dynamic-routes"
 
@@ -73,7 +74,14 @@ export const nextNavigationMocks = {
   useSearchParams: () => {
     const router = nextNavigationMocks.useRouter()
     const url = new URL(router.asPath, "http://localhost")
-    return url.searchParams
+    // Ensure the reference to the URLSearchParams object is stable
+    // across renders.
+    // NextJS guarantees this.
+    const ref = useRef<URLSearchParams>(url.searchParams)
+    if (url.searchParams.toString() !== ref.current.toString()) {
+      ref.current = new URLSearchParams(url.searchParams)
+    }
+    return ref.current
   },
   useParams: () => {
     const router = nextNavigationMocks.useRouter()

--- a/yarn.lock
+++ b/yarn.lock
@@ -14282,10 +14282,13 @@ __metadata:
   dependencies:
     "@faker-js/faker": "npm:^9.0.0"
     "@testing-library/react": "npm:^16.1.0"
+    "@types/react": "npm:^19.0.6"
     css-mediaquery: "npm:^0.1.2"
     dom-accessibility-api: "npm:^0.7.0"
     next-router-mock: "npm:^0.9.13"
     tiny-invariant: "npm:^1.3.1"
+  peerDependencies:
+    react: ^19.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What are the relevant tickets?
Fixes a testing issue in #1951 

### Description (What does it do?)
See comment in code.

### How can this be tested?
Tests should pass.

Tests should also pass on #1951 when rebased against this branch. (They do. See https://github.com/mitodl/mit-learn/pull/1957, which is based off of #1951 instead of main.)

