### PR TITLE
Basic Syllabus Bot for demo

### DIFF
--- a/ai_chat/agents.py
+++ b/ai_chat/agents.py
@@ -543,7 +543,7 @@ information.
         return results as a JSON string
         """
         url = settings.AI_MIT_SYLLABUS_URL or reverse(
-            "vector_search:v0:content_files_vector_search"
+            "vector_search:v0:vector_content_files_search"
         )
         params = {
             "q": self.user_message,

--- a/ai_chat/serializers.py
+++ b/ai_chat/serializers.py
@@ -35,3 +35,9 @@ class ChatRequestSerializer(serializers.Serializer):
             msg = "You are not allowed to modify the AI system prompt."
             raise serializers.ValidationError(msg)
         return value
+
+
+class SyllabusChatRequestSerializer(ChatRequestSerializer):
+    """DRF serializer for syllabus chatbot requests"""
+
+    readable_id = serializers.CharField(required=True)

--- a/ai_chat/urls.py
+++ b/ai_chat/urls.py
@@ -8,6 +8,11 @@ app_name = "ai_chat"
 
 v0_urls = [
     re_path(r"^chat_agent/", views.SearchAgentView.as_view(), name="chatbot_agent_api"),
+    re_path(
+        r"^syllabus_agent/",
+        views.SyllabusAgentView.as_view(),
+        name="syllabus_agent_api",
+    ),
 ]
 urlpatterns = [
     re_path(r"^api/v0/", include((v0_urls, "v0"))),

--- a/ai_chat/views.py
+++ b/ai_chat/views.py
@@ -8,6 +8,7 @@ from rest_framework import views
 from rest_framework.request import Request
 
 from ai_chat import serializers
+from ai_chat.agents import SyllabusAgent
 from ai_chat.permissions import SearchAgentPermissions
 
 log = logging.getLogger(__name__)
@@ -52,6 +53,60 @@ class SearchAgentView(views.APIView):
         clear_history = serializer.validated_data.pop("clear_history", False)
         agent = SearchAgent(
             "Learning Resource Search AI Assistant",
+            user_id=user_id,
+            cache_key=f"{cache_id}_search_chat_history",
+            save_history=True,
+            **serializer.validated_data,
+        )
+        if clear_history:
+            agent.clear_chat_history()
+        return StreamingHttpResponse(
+            agent.get_completion(message),
+            content_type="text/event-stream",
+            headers={"X-Accel-Buffering": "no"},
+        )
+
+
+class SyllabusAgentView(views.APIView):
+    """
+    DRF view for an AI agent that answers user queries
+    by performing a relevant contentfile search for a
+    specified course.
+    """
+
+    http_method_names = ["post"]
+    serializer_class = serializers.SyllabusChatRequestSerializer
+    permission_classes = (SearchAgentPermissions,)  # Add IsAuthenticated
+
+    @extend_schema(
+        responses={
+            (200, "text/event-stream"): {
+                "description": "Chatbot response",
+                "type": "string",
+            }
+        }
+    )
+    def post(self, request: Request) -> StreamingHttpResponse:
+        """Handle a POST request to the chatbot agent."""
+
+        serializer = serializers.SyllabusChatRequestSerializer(
+            data=request.data, context={"request": request}
+        )
+        serializer.is_valid(raise_exception=True)
+        if not request.session.session_key:
+            request.session.save()
+        cache_id = (
+            request.user.email
+            if request.user.is_authenticated
+            else request.session.session_key
+        )
+        # Make anonymous users share a common LiteLLM budget/rate limit.
+        user_id = request.user.email if request.user.is_authenticated else "anonymous"
+        message = serializer.validated_data.pop("message", "")
+        clear_history = serializer.validated_data.pop("clear_history", False)
+        agent = SyllabusAgent(
+            "Learning Resource Search AI Assistant",
+            serializer.validated_data.pop("readable_id"),
             user_id=user_id,
             cache_key=f"{cache_id}_search_chat_history",
             save_history=True,

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -4986,6 +4986,49 @@ export interface SubChannel {
   position?: number
 }
 /**
+ * DRF serializer for syllabus chatbot requests
+ * @export
+ * @interface SyllabusChatRequestRequest
+ */
+export interface SyllabusChatRequestRequest {
+  /**
+   *
+   * @type {string}
+   * @memberof SyllabusChatRequestRequest
+   */
+  message: string
+  /**
+   *
+   * @type {string}
+   * @memberof SyllabusChatRequestRequest
+   */
+  model?: string
+  /**
+   *
+   * @type {number}
+   * @memberof SyllabusChatRequestRequest
+   */
+  temperature?: number
+  /**
+   *
+   * @type {string}
+   * @memberof SyllabusChatRequestRequest
+   */
+  instructions?: string
+  /**
+   *
+   * @type {boolean}
+   * @memberof SyllabusChatRequestRequest
+   */
+  clear_history?: boolean
+  /**
+   *
+   * @type {string}
+   * @memberof SyllabusChatRequestRequest
+   */
+  readable_id: string
+}
+/**
  * * `0-to-5-hours` - <5 hours/week * `5-to-10-hours` - 5-10 hours/week * `10-to-20-hours` - 10-20 hours/week * `20-to-30-hours` - 20-30 hours/week * `30-plus-hours` - 30+ hours/week
  * @export
  * @enum {string}
@@ -9453,6 +9496,181 @@ export class ProgramCertificatesApi extends BaseAPI {
       .programCertificatesList(
         requestParameters.micromasters_program_id,
         requestParameters.program_title,
+        options,
+      )
+      .then((request) => request(this.axios, this.basePath))
+  }
+}
+
+/**
+ * SyllabusAgentApi - axios parameter creator
+ * @export
+ */
+export const SyllabusAgentApiAxiosParamCreator = function (
+  configuration?: Configuration,
+) {
+  return {
+    /**
+     * Handle a POST request to the chatbot agent.
+     * @param {SyllabusChatRequestRequest} SyllabusChatRequestRequest
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    syllabusAgentCreate: async (
+      SyllabusChatRequestRequest: SyllabusChatRequestRequest,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'SyllabusChatRequestRequest' is not null or undefined
+      assertParamExists(
+        "syllabusAgentCreate",
+        "SyllabusChatRequestRequest",
+        SyllabusChatRequestRequest,
+      )
+      const localVarPath = `/api/v0/syllabus_agent/`
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "POST",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      localVarHeaderParameter["Content-Type"] = "application/json"
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        SyllabusChatRequestRequest,
+        localVarRequestOptions,
+        configuration,
+      )
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+  }
+}
+
+/**
+ * SyllabusAgentApi - functional programming interface
+ * @export
+ */
+export const SyllabusAgentApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator =
+    SyllabusAgentApiAxiosParamCreator(configuration)
+  return {
+    /**
+     * Handle a POST request to the chatbot agent.
+     * @param {SyllabusChatRequestRequest} SyllabusChatRequestRequest
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async syllabusAgentCreate(
+      SyllabusChatRequestRequest: SyllabusChatRequestRequest,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.syllabusAgentCreate(
+          SyllabusChatRequestRequest,
+          options,
+        )
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap["SyllabusAgentApi.syllabusAgentCreate"]?.[index]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+  }
+}
+
+/**
+ * SyllabusAgentApi - factory interface
+ * @export
+ */
+export const SyllabusAgentApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance,
+) {
+  const localVarFp = SyllabusAgentApiFp(configuration)
+  return {
+    /**
+     * Handle a POST request to the chatbot agent.
+     * @param {SyllabusAgentApiSyllabusAgentCreateRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    syllabusAgentCreate(
+      requestParameters: SyllabusAgentApiSyllabusAgentCreateRequest,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<string> {
+      return localVarFp
+        .syllabusAgentCreate(
+          requestParameters.SyllabusChatRequestRequest,
+          options,
+        )
+        .then((request) => request(axios, basePath))
+    },
+  }
+}
+
+/**
+ * Request parameters for syllabusAgentCreate operation in SyllabusAgentApi.
+ * @export
+ * @interface SyllabusAgentApiSyllabusAgentCreateRequest
+ */
+export interface SyllabusAgentApiSyllabusAgentCreateRequest {
+  /**
+   *
+   * @type {SyllabusChatRequestRequest}
+   * @memberof SyllabusAgentApiSyllabusAgentCreate
+   */
+  readonly SyllabusChatRequestRequest: SyllabusChatRequestRequest
+}
+
+/**
+ * SyllabusAgentApi - object-oriented interface
+ * @export
+ * @class SyllabusAgentApi
+ * @extends {BaseAPI}
+ */
+export class SyllabusAgentApi extends BaseAPI {
+  /**
+   * Handle a POST request to the chatbot agent.
+   * @param {SyllabusAgentApiSyllabusAgentCreateRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof SyllabusAgentApi
+   */
+  public syllabusAgentCreate(
+    requestParameters: SyllabusAgentApiSyllabusAgentCreateRequest,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return SyllabusAgentApiFp(this.configuration)
+      .syllabusAgentCreate(
+        requestParameters.SyllabusChatRequestRequest,
         options,
       )
       .then((request) => request(this.axios, this.basePath))

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -14,6 +14,7 @@
     "@emotion/cache": "^11.13.1",
     "@emotion/styled": "^11.11.0",
     "@mitodl/course-search-utils": "3.3.2",
+    "@mitodl/smoot-design": "^0.0.0-preview215f7ae3fa",
     "@next/bundle-analyzer": "^14.2.15",
     "@nlux/react": "^2.17.1",
     "@nlux/themes": "^2.17.1",

--- a/frontends/main/src/app-pages/ChatPage/ChatPage.tsx
+++ b/frontends/main/src/app-pages/ChatPage/ChatPage.tsx
@@ -1,11 +1,17 @@
 "use client"
-import React from "react"
-import { Container, styled } from "ol-components"
-import { sends } from "./send"
-import { NluxAiChat } from "@/page-components/Nlux-AiChat/AiChat"
+import React, { useMemo } from "react"
+import { makeSend } from "./send"
 
 import { FeatureFlags } from "@/common/feature_flags"
 import { useFeatureFlagEnabled } from "posthog-js/react"
+import StyledContainer from "@/page-components/StyledContainer/StyledContainer"
+import { styled } from "ol-components"
+import { NluxAiChat } from "@/page-components/Nlux-AiChat/AiChat"
+
+const StyledChat = styled(NluxAiChat)({
+  maxHeight: "60vh",
+  flex: 1,
+})
 
 const CONVERSATION_OPTIONS = {
   conversationStarters: [
@@ -28,24 +34,13 @@ const CONVERSATION_OPTIONS = {
   ],
 }
 
-const StyledChat = styled(NluxAiChat)({
-  maxHeight: "60vh",
-  flex: 1,
-})
-
-const StyledContainer = styled(Container)({
-  height: "100%",
-  padding: "24px 0",
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "flex-start",
-  gap: "16px",
-})
-
 const ChatPage = () => {
   const recommendationBotEnabled = useFeatureFlagEnabled(
     FeatureFlags.RecommendationBot,
   )
+  const send = useMemo(() => {
+    return makeSend({ url: "/api/v0/chat_agent/" })
+  }, [])
   return (
     <StyledContainer>
       {
@@ -53,7 +48,7 @@ const ChatPage = () => {
         recommendationBotEnabled ? (
           <StyledChat
             key={"agent"}
-            send={sends["agent"]}
+            send={send}
             conversationOptions={CONVERSATION_OPTIONS}
           />
         ) : (

--- a/frontends/main/src/app-pages/ChatSyllabusPage/ChatSyllabusPage.tsx
+++ b/frontends/main/src/app-pages/ChatSyllabusPage/ChatSyllabusPage.tsx
@@ -1,0 +1,160 @@
+"use client"
+import React, { useState } from "react"
+import { styled, MenuItem, Alert } from "ol-components"
+
+import { FeatureFlags } from "@/common/feature_flags"
+import { useFeatureFlagEnabled } from "posthog-js/react"
+import StyledContainer from "@/page-components/StyledContainer/StyledContainer"
+// eslint-disable-next-line
+import { InputLabel, Select } from "@mui/material"
+import { AiChat, AiChatProps } from "@mitodl/smoot-design/ai"
+import { extractJSONFromComment } from "ol-utilities"
+
+function getCookie(name: string) {
+  const value = `; ${document.cookie}`
+  const parts = value.split(`; ${name}=`)
+  if (parts.length === 2) {
+    return parts.pop()?.split(";").shift()
+  }
+}
+
+const STARTERS: AiChatProps["conversationStarters"] = [
+  { content: "What are the prerequisites for this course?" },
+  { content: "Does this course include any written assignments?" },
+]
+
+const INITIAL_MESSAGES: AiChatProps["initialMessages"] = [
+  {
+    content:
+      "Hello! I'm here to help you with any questions you have about this course.",
+    role: "assistant",
+  },
+]
+
+const FormContainer = styled.div(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  paddingTop: "40px",
+  gap: "40px",
+  width: "800px",
+  [theme.breakpoints.down("md")]: {
+    paddingTop: "24px",
+    gap: "32px",
+  },
+}))
+
+const StyledDebugPre = styled.pre({
+  width: "80%",
+  whiteSpace: "pre-wrap",
+})
+
+const ChatSyllabusPage = () => {
+  const botEnabled = useFeatureFlagEnabled(FeatureFlags.RecommendationBot)
+  const [readableId, setReadableId] = useState("18.06SC+fall_2011")
+  const [debugInfo, setDebugInfo] = useState("")
+
+  const parseContent = (content: string | unknown) => {
+    if (typeof content !== "string") {
+      return ""
+    }
+    const contentParts = content.split("<!--")
+    if (contentParts.length > 1) {
+      setDebugInfo(contentParts[1])
+    }
+    return contentParts[0]
+  }
+
+  return (
+    <StyledContainer>
+      {
+        // eslint-disable-next-line no-constant-condition
+        botEnabled ? (
+          <>
+            <form id="chat-form">
+              <FormContainer>
+                <div>
+                  <InputLabel>Course</InputLabel>
+                  <Select
+                    label="Course"
+                    value={readableId}
+                    onChange={(e) => setReadableId(e.target.value)}
+                  >
+                    <MenuItem value="18.06SC+fall_2011">
+                      Linear Algebra (OCW)
+                    </MenuItem>
+                    <MenuItem value="7.01SC+fall_2011">
+                      Fundamentals of Biology (OCW)
+                    </MenuItem>
+                    <MenuItem value="3.091SC+fall_2010">
+                      Intro to Solid State Chemistry (OCW)
+                    </MenuItem>
+                    <MenuItem value="6.01SC+spring_2011">
+                      Intro to Electrical Engineering (OCW)
+                    </MenuItem>
+                    <MenuItem value="MITx+6.00.1x">
+                      Intro to Computer Science & Programming Using Python (EdX)
+                    </MenuItem>
+                    <MenuItem value="MITx+7.00x">
+                      Introduction to Biology - The Secret of Life (EdX)
+                    </MenuItem>
+                    <MenuItem value="course-v1:MITxT+10.50.CH04x">
+                      Analysis of Transport Phenomena: Asymptotics (EdX)
+                    </MenuItem>
+                    <MenuItem value="course-v1:MITxT+18.03.1x">
+                      {" "}
+                      Introduction to Differential Equations(EdX)
+                    </MenuItem>
+                  </Select>
+                </div>
+              </FormContainer>
+            </form>
+            <AiChat
+              initialMessages={INITIAL_MESSAGES}
+              conversationStarters={STARTERS}
+              parseContent={parseContent}
+              requestOpts={{
+                apiUrl: `${process.env.NEXT_PUBLIC_MITOL_API_BASE_URL}/api/v0/syllabus_agent/`,
+                headersOpts: {
+                  "X-CSRFToken":
+                    getCookie(
+                      process.env.NEXT_PUBLIC_CSRF_COOKIE_NAME || "csrftoken",
+                    ) ?? "",
+                },
+                transformBody: (messages) => {
+                  return {
+                    message: messages[messages.length - 1].content,
+                    readable_id: readableId,
+                  }
+                },
+              }}
+            />
+            {debugInfo &&
+              (debugInfo.toString().includes('{"error":') ? (
+                <Alert severity="error">
+                  {extractJSONFromComment(debugInfo)?.error?.message ||
+                    "Sorry, an unexpected error occurred."}
+                </Alert>
+              ) : debugInfo ? (
+                <div>
+                  <p>Debug Info:</p>
+                  <StyledDebugPre>
+                    {debugInfo
+                      ? JSON.stringify(
+                          extractJSONFromComment(`<!--${debugInfo}`),
+                          null,
+                          4,
+                        )
+                      : ""}
+                  </StyledDebugPre>
+                </div>
+              ) : null)}
+          </>
+        ) : (
+          <></>
+        )
+      }
+    </StyledContainer>
+  )
+}
+
+export default ChatSyllabusPage

--- a/frontends/main/src/app/chat_syllabus/page.tsx
+++ b/frontends/main/src/app/chat_syllabus/page.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+import { Metadata } from "next"
+
+import ChatSyllabusPage from "@/app-pages/ChatSyllabusPage/ChatSyllabusPage"
+import { standardizeMetadata } from "@/common/metadata"
+
+export const metadata: Metadata = standardizeMetadata({
+  title: "Chat Syllabus Demo",
+  robots: "noindex",
+})
+
+const Page: React.FC = () => {
+  return <ChatSyllabusPage />
+}
+
+export default Page

--- a/frontends/main/src/page-components/StyledContainer/StyledContainer.tsx
+++ b/frontends/main/src/page-components/StyledContainer/StyledContainer.tsx
@@ -1,0 +1,12 @@
+import { Container, styled } from "ol-components"
+
+const StyledContainer = styled(Container)({
+  height: "100%",
+  padding: "24px 0",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  gap: "16px",
+})
+
+export default StyledContainer

--- a/main/settings.py
+++ b/main/settings.py
@@ -833,6 +833,7 @@ AI_MIT_SEARCH_URL = get_string(
     name="AI_MIT_SEARCH_URL",
     default="https://api.learn.mit.edu/api/v1/learning_resources_search/",
 )
+AI_MIT_SYLLABUS_URL = get_string("AI_MIT_SYLLABUS_URL", "")
 AI_MIT_SEARCH_LIMIT = get_int(name="AI_MIT_SEARCH_LIMIT", default=10)
 AI_MODEL = get_string(name="AI_MODEL", default="gpt-4o")
 AI_MODEL_API = get_string(name="AI_MODEL_API", default="openai")

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -576,6 +576,32 @@ paths:
                 items:
                   $ref: '#/components/schemas/ProgramCertificate'
           description: ''
+  /api/v0/syllabus_agent/:
+    post:
+      operationId: syllabus_agent_create
+      description: Handle a POST request to the chatbot agent.
+      tags:
+      - syllabus_agent
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SyllabusChatRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SyllabusChatRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/SyllabusChatRequestRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            text/event-stream:
+              schema:
+                description: Chatbot response
+                type: string
+          description: ''
   /api/v0/testimonials/:
     get:
       operationId: testimonials_list
@@ -5000,6 +5026,34 @@ components:
       required:
       - channel
       - parent_channel
+    SyllabusChatRequestRequest:
+      type: object
+      description: DRF serializer for syllabus chatbot requests
+      properties:
+        message:
+          type: string
+          minLength: 1
+        model:
+          type: string
+          minLength: 1
+          default: gpt-4o
+        temperature:
+          type: number
+          format: double
+          maximum: 1.0
+          minimum: 0.0
+        instructions:
+          type: string
+          minLength: 1
+        clear_history:
+          type: boolean
+          default: false
+        readable_id:
+          type: string
+          minLength: 1
+      required:
+      - message
+      - readable_id
     TimeCommitmentEnum:
       enum:
       - 0-to-5-hours

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,68 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ai-sdk/provider-utils@npm:2.0.7":
+  version: 2.0.7
+  resolution: "@ai-sdk/provider-utils@npm:2.0.7"
+  dependencies:
+    "@ai-sdk/provider": "npm:1.0.4"
+    eventsource-parser: "npm:^3.0.0"
+    nanoid: "npm:^3.3.8"
+    secure-json-parse: "npm:^2.7.0"
+  peerDependencies:
+    zod: ^3.0.0
+  peerDependenciesMeta:
+    zod:
+      optional: true
+  checksum: 10/b461e2710c55ec6462b44bcd3dede99e89d35bd96cfc8a034a59142ec74d5c88992a3bd6744ad96682980b284cac006a59a08a2ce00730cd6d9c4a56703ae71d
+  languageName: node
+  linkType: hard
+
+"@ai-sdk/provider@npm:1.0.4":
+  version: 1.0.4
+  resolution: "@ai-sdk/provider@npm:1.0.4"
+  dependencies:
+    json-schema: "npm:^0.4.0"
+  checksum: 10/7aa66f19087ee039f76c7ee165e2be83e2bf95baa83496ea34ee9e1540fff857ccf28769efae869951be358715df2935c3d5d5a56d742e64ad11d1a7b1f68407
+  languageName: node
+  linkType: hard
+
+"@ai-sdk/react@npm:1.0.11":
+  version: 1.0.11
+  resolution: "@ai-sdk/react@npm:1.0.11"
+  dependencies:
+    "@ai-sdk/provider-utils": "npm:2.0.7"
+    "@ai-sdk/ui-utils": "npm:1.0.10"
+    swr: "npm:^2.2.5"
+    throttleit: "npm:2.1.0"
+  peerDependencies:
+    react: ^18 || ^19 || ^19.0.0-rc
+    zod: ^3.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    zod:
+      optional: true
+  checksum: 10/1221713f6f1177284507b61ea9b35eb67e87c39395cd895a1b82029844e6597fc3d9403d978f1f1a21f3a9890be0c6dd8a273a243705adf731b2b49d0a4da81c
+  languageName: node
+  linkType: hard
+
+"@ai-sdk/ui-utils@npm:1.0.10":
+  version: 1.0.10
+  resolution: "@ai-sdk/ui-utils@npm:1.0.10"
+  dependencies:
+    "@ai-sdk/provider": "npm:1.0.4"
+    "@ai-sdk/provider-utils": "npm:2.0.7"
+    zod-to-json-schema: "npm:^3.24.1"
+  peerDependencies:
+    zod: ^3.0.0
+  peerDependenciesMeta:
+    zod:
+      optional: true
+  checksum: 10/febe182d5abf196a915651630924e2bc19967d20f698c385e1ab47e053c08adfb17ba74a115f253a42f11de0af67d74523b15cc30db4cfcc71ad0c3090115dbd
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.2.0":
   version: 2.3.0
   resolution: "@ampproject/remapping@npm:2.3.0"
@@ -1647,6 +1709,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/cache@npm:^11.13.5":
+  version: 11.14.0
+  resolution: "@emotion/cache@npm:11.14.0"
+  dependencies:
+    "@emotion/memoize": "npm:^0.9.0"
+    "@emotion/sheet": "npm:^1.4.0"
+    "@emotion/utils": "npm:^1.4.2"
+    "@emotion/weak-memoize": "npm:^0.4.0"
+    stylis: "npm:4.2.0"
+  checksum: 10/52336b28a27b07dde8fcdfd80851cbd1487672bbd4db1e24cca1440c95d8a6a968c57b0453c2b7c88d9b432b717f99554dbecc05b5cdef27933299827e69fd8e
+  languageName: node
+  linkType: hard
+
 "@emotion/hash@npm:^0.9.2":
   version: 0.9.2
   resolution: "@emotion/hash@npm:0.9.2"
@@ -1704,6 +1779,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/serialize@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "@emotion/serialize@npm:1.3.3"
+  dependencies:
+    "@emotion/hash": "npm:^0.9.2"
+    "@emotion/memoize": "npm:^0.9.0"
+    "@emotion/unitless": "npm:^0.10.0"
+    "@emotion/utils": "npm:^1.4.2"
+    csstype: "npm:^3.0.2"
+  checksum: 10/44a2e06fc52dba177d9cf720f7b2c5d45ee4c0d9c09b78302d9a625e758d728ef3ae26f849237fec6f70e9eeb7d87e45a65028e944dc1f877df97c599f1cdaee
+  languageName: node
+  linkType: hard
+
 "@emotion/sheet@npm:^1.4.0":
   version: 1.4.0
   resolution: "@emotion/sheet@npm:1.4.0"
@@ -1751,6 +1839,13 @@ __metadata:
   version: 1.4.1
   resolution: "@emotion/utils@npm:1.4.1"
   checksum: 10/95e56fc0c9e05cf01a96268f0486ce813f1109a8653d2f575c67df9e8765d9c1b2daf09ad1ada67d933efbb08ca7990228e14b210c713daf90156b4869abe6a7
+  languageName: node
+  linkType: hard
+
+"@emotion/utils@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "@emotion/utils@npm:1.4.2"
+  checksum: 10/e5f3b8bca066b3361a7ad9064baeb9d01ed1bf51d98416a67359b62cb3affec6bb0249802c4ed11f4f8030f93cc4b67506909420bdb110adec6983d712897208
   languageName: node
   linkType: hard
 
@@ -2609,6 +2704,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mitodl/smoot-design@npm:^0.0.0-preview215f7ae3fa":
+  version: 0.0.0-preview215f7ae3fa
+  resolution: "@mitodl/smoot-design@npm:0.0.0-preview215f7ae3fa"
+  dependencies:
+    "@emotion/react": "npm:^11.11.1"
+    "@emotion/styled": "npm:^11.11.0"
+    "@mui/base": "npm:5.0.0-beta.67"
+    "@mui/lab": "npm:6.0.0-beta.20"
+    "@mui/material": "npm:^6.1.6"
+    "@mui/material-nextjs": "npm:^6.1.6"
+    "@mui/system": "npm:^6.1.6"
+    "@remixicon/react": "npm:^4.2.0"
+    "@types/jest": "npm:^29.5.14"
+    ai: "npm:^4.0.13"
+    classnames: "npm:^2.5.1"
+    lodash: "npm:^4.17.21"
+    react-markdown: "npm:^9.0.1"
+    tiny-invariant: "npm:^1.3.1"
+    zod: "npm:^3.23.8"
+  peerDependencies:
+    react: ^18 || ^19
+    react-dom: ^18 || ^19
+  checksum: 10/733d2c677e849ebda034c3d60eda445b6487708db00af711ace189b84ff93ba44c3ba54f15983a74ae0a19e0b2e9fa69dab17b0bdcfb0ef306f678b129a2ad83
+  languageName: node
+  linkType: hard
+
 "@mui/base@npm:5.0.0-beta.61":
   version: 5.0.0-beta.61
   resolution: "@mui/base@npm:5.0.0-beta.61"
@@ -2631,10 +2752,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/base@npm:5.0.0-beta.67":
+  version: 5.0.0-beta.67
+  resolution: "@mui/base@npm:5.0.0-beta.67"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@floating-ui/react-dom": "npm:^2.1.1"
+    "@mui/types": "npm:^7.2.20"
+    "@mui/utils": "npm:^6.2.1"
+    "@popperjs/core": "npm:^2.11.8"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/92d2ed1550cd33c8b2c890b98ff67d55677c3fb4871a7e600fc6e973ab2318dc362fd897b60e63d67cd9d8af984dd80ca99075c526ac1df89a740215139f6194
+  languageName: node
+  linkType: hard
+
 "@mui/core-downloads-tracker@npm:^6.1.8":
   version: 6.1.8
   resolution: "@mui/core-downloads-tracker@npm:6.1.8"
   checksum: 10/87e10a09909d32f9a1618fe23d5f7bf8981a942431be3432ae5cb24c31502af93eca38204e46619a3546f13a5c32b1741c80f24657a29a6e7a9e53d4384d042d
+  languageName: node
+  linkType: hard
+
+"@mui/core-downloads-tracker@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "@mui/core-downloads-tracker@npm:6.4.0"
+  checksum: 10/3e8f31c3b461f85448152b99e156f487b146725560d2f60f0b60becf2c37f4fc1ab913ca7496dd038514bddb214a51cb6f6147fa66b4f9d0d7d5a1e7ce0cce97
   languageName: node
   linkType: hard
 
@@ -2670,6 +2820,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/lab@npm:6.0.0-beta.20":
+  version: 6.0.0-beta.20
+  resolution: "@mui/lab@npm:6.0.0-beta.20"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/base": "npm:5.0.0-beta.67"
+    "@mui/system": "npm:^6.2.1"
+    "@mui/types": "npm:^7.2.20"
+    "@mui/utils": "npm:^6.2.1"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@mui/material": ^6.2.1
+    "@mui/material-pigment-css": ^6.2.1
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@mui/material-pigment-css":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10/87575513ecda8ff5c2897cab79e1247d04bc8c4c1983c91b5a22481c55dd454ed93288a8d0d7955c592c72d23ee671fc149b68d03676e93e48e8f97c67bde845
+  languageName: node
+  linkType: hard
+
 "@mui/material-nextjs@npm:^6.1.6":
   version: 6.1.6
   resolution: "@mui/material-nextjs@npm:6.1.6"
@@ -2690,6 +2872,42 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/de3d6fafd60c6fa7450306e0f27d4aaddceca501477ceccce85ca2b0658c84e12c540efed35dcb6a1a43fb5fba8efec9922419e15f73d2da6f2c0c4c2dd4441f
+  languageName: node
+  linkType: hard
+
+"@mui/material@npm:^6.1.6":
+  version: 6.4.0
+  resolution: "@mui/material@npm:6.4.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/core-downloads-tracker": "npm:^6.4.0"
+    "@mui/system": "npm:^6.4.0"
+    "@mui/types": "npm:^7.2.21"
+    "@mui/utils": "npm:^6.4.0"
+    "@popperjs/core": "npm:^2.11.8"
+    "@types/react-transition-group": "npm:^4.4.12"
+    clsx: "npm:^2.1.1"
+    csstype: "npm:^3.1.3"
+    prop-types: "npm:^15.8.1"
+    react-is: "npm:^19.0.0"
+    react-transition-group: "npm:^4.4.5"
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@mui/material-pigment-css": ^6.4.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@mui/material-pigment-css":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10/6b4180c660389adee9c7237348a7d36342aa5021e23d0ce0dd9024a2aa863bbf380ec36e9dce2c5defdc67856652f4033e620fab4129f47405c51eda96bd98d9
   languageName: node
   linkType: hard
 
@@ -2780,6 +2998,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/private-theming@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "@mui/private-theming@npm:6.4.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/utils": "npm:^6.4.0"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/bb54f1666d4f6428fcb069a670dbc087c7edd23b3a56351d69e7a91c7dbf9e37de6f94e56c04156897d6a62303e7e3ba6863991cae372944659b58842cc81fa8
+  languageName: node
+  linkType: hard
+
 "@mui/styled-engine@npm:^6.1.6":
   version: 6.1.6
   resolution: "@mui/styled-engine@npm:6.1.6"
@@ -2846,6 +3081,29 @@ __metadata:
     "@emotion/styled":
       optional: true
   checksum: 10/72afb46000040de3b03bd5cf7a80aefe400dbcf524d16081b77fab38ca2e932f2fe6e18485ef9676677fe4524669675ed7bff3ce7cd37682254aa8958a82ee29
+  languageName: node
+  linkType: hard
+
+"@mui/styled-engine@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "@mui/styled-engine@npm:6.4.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@emotion/cache": "npm:^11.13.5"
+    "@emotion/serialize": "npm:^1.3.3"
+    "@emotion/sheet": "npm:^1.4.0"
+    csstype: "npm:^3.1.3"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@emotion/react": ^11.4.1
+    "@emotion/styled": ^11.3.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+  checksum: 10/dca3f784a53e8b4838f6d468eb6b503eaa55b001bd09de4e99237a4b227f1401d932b7fb306bad9d68fe77549ebe5faf368a1ae6be6f20ff6499101fc0dfb600
   languageName: node
   linkType: hard
 
@@ -2933,6 +3191,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/system@npm:^6.2.1, @mui/system@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "@mui/system@npm:6.4.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/private-theming": "npm:^6.4.0"
+    "@mui/styled-engine": "npm:^6.4.0"
+    "@mui/types": "npm:^7.2.21"
+    "@mui/utils": "npm:^6.4.0"
+    clsx: "npm:^2.1.1"
+    csstype: "npm:^3.1.3"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10/c2a5550898c598b9d8b564f189acaa6858286ff82c103c5ea832b6a769863fd315de1a5841a9a0e6428f078929522e58b418cf16fea12e389bcfcb7fc3f1b912
+  languageName: node
+  linkType: hard
+
 "@mui/types@npm:^7.2.19":
   version: 7.2.19
   resolution: "@mui/types@npm:7.2.19"
@@ -2942,6 +3228,18 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/a23bc280c0722527ce5e264b0dcb44271441e4016eb2285acc1f0d236cf78c73ecc3ec7abba81876c2eadf45b905b55eb26e0e824ea6afc233efce2ef5a34f7d
+  languageName: node
+  linkType: hard
+
+"@mui/types@npm:^7.2.20, @mui/types@npm:^7.2.21":
+  version: 7.2.21
+  resolution: "@mui/types@npm:7.2.21"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/cf604b02ee8a9127fe1cdcd1d2ee5d5aa92b2a3543b465a09c46a8be2452df7c58930ac0d8e55610e7130efe0fb9de9fa0c8522e30a04ca5dadc6640a4c77eda
   languageName: node
   linkType: hard
 
@@ -3002,6 +3300,26 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/093a952ce4834e71911550e7bb17f02fe389b948deefec304c58c1970c5a4c454a44a1ec0a8f426eb294cace410356d2ac0ee4bb5f4628c23cf044399d4258be
+  languageName: node
+  linkType: hard
+
+"@mui/utils@npm:^6.2.1, @mui/utils@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "@mui/utils@npm:6.4.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/types": "npm:^7.2.21"
+    "@types/prop-types": "npm:^15.7.14"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    react-is: "npm:^19.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/fb1e3d0a6e44fe9cd3aae68456084966f4d0f73f7be4cfe4e4998a9cf11f199aced8aedae7192f7da1c7c7814551aa13202e58c8c6531deae43b866a980744ec
   languageName: node
   linkType: hard
 
@@ -3280,7 +3598,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api@npm:^1.0.0, @opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.8, @opentelemetry/api@npm:^1.9.0":
+"@opentelemetry/api@npm:1.9.0, @opentelemetry/api@npm:^1.0.0, @opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.8, @opentelemetry/api@npm:^1.9.0":
   version: 1.9.0
   resolution: "@opentelemetry/api@npm:1.9.0"
   checksum: 10/a607f0eef971893c4f2ee2a4c2069aade6ec3e84e2a1f5c2aac19f65c5d9eeea41aa72db917c1029faafdd71789a1a040bdc18f40d63690e22ccae5d7070f194
@@ -5156,6 +5474,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/diff-match-patch@npm:^1.0.36":
+  version: 1.0.36
+  resolution: "@types/diff-match-patch@npm:1.0.36"
+  checksum: 10/7d7ce03422fcc3e79d0cda26e4748aeb176b75ca4b4e5f38459b112bf24660d628424bdb08d330faefa69039d19a5316e7a102a8ab68b8e294c8346790e55113
+  languageName: node
+  linkType: hard
+
 "@types/doctrine@npm:^0.0.9":
   version: 0.0.9
   resolution: "@types/doctrine@npm:0.0.9"
@@ -5319,6 +5644,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/jest@npm:^29.5.14":
+  version: 29.5.14
+  resolution: "@types/jest@npm:29.5.14"
+  dependencies:
+    expect: "npm:^29.0.0"
+    pretty-format: "npm:^29.0.0"
+  checksum: 10/59ec7a9c4688aae8ee529316c43853468b6034f453d08a2e1064b281af9c81234cec986be796288f1bbb29efe943bc950e70c8fa8faae1e460d50e3cf9760f9b
+  languageName: node
+  linkType: hard
+
 "@types/jquery@npm:*":
   version: 3.5.31
   resolution: "@types/jquery@npm:3.5.31"
@@ -5471,6 +5806,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prop-types@npm:^15.7.14":
+  version: 15.7.14
+  resolution: "@types/prop-types@npm:15.7.14"
+  checksum: 10/d0c5407b9ccc3dd5fae0ccf9b1007e7622ba5e6f1c18399b4f24dff33619d469da4b9fa918a374f19dc0d9fe6a013362aab0b844b606cfc10676efba3f5f736d
+  languageName: node
+  linkType: hard
+
 "@types/qs@npm:*":
   version: 6.9.16
   resolution: "@types/qs@npm:6.9.16"
@@ -5518,6 +5860,15 @@ __metadata:
   dependencies:
     "@types/react": "npm:*"
   checksum: 10/a7f4de6e5f57d9fcdea027e22873c633f96a803c96d422db8b99a45c36a9cceb7882d152136bbc31c7158fc1827e37aea5070d369724bb71dd11b5687332bc4d
+  languageName: node
+  linkType: hard
+
+"@types/react-transition-group@npm:^4.4.12":
+  version: 4.4.12
+  resolution: "@types/react-transition-group@npm:4.4.12"
+  peerDependencies:
+    "@types/react": "*"
+  checksum: 10/ea14bc84f529a3887f9954b753843820ac8a3c49fcdfec7840657ecc6a8800aad98afdbe4b973eb96c7252286bde38476fcf64b1c09527354a9a9366e516d9a2
   languageName: node
   linkType: hard
 
@@ -6375,6 +6726,28 @@ __metadata:
     clean-stack: "npm:^2.0.0"
     indent-string: "npm:^4.0.0"
   checksum: 10/1101a33f21baa27a2fa8e04b698271e64616b886795fd43c31068c07533c7b3facfcaf4e9e0cab3624bd88f729a592f1c901a1a229c9e490eafce411a8644b79
+  languageName: node
+  linkType: hard
+
+"ai@npm:^4.0.13":
+  version: 4.0.36
+  resolution: "ai@npm:4.0.36"
+  dependencies:
+    "@ai-sdk/provider": "npm:1.0.4"
+    "@ai-sdk/provider-utils": "npm:2.0.7"
+    "@ai-sdk/react": "npm:1.0.11"
+    "@ai-sdk/ui-utils": "npm:1.0.10"
+    "@opentelemetry/api": "npm:1.9.0"
+    jsondiffpatch: "npm:0.6.0"
+  peerDependencies:
+    react: ^18 || ^19 || ^19.0.0-rc
+    zod: ^3.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    zod:
+      optional: true
+  checksum: 10/01e0ca0ae86a7ad4dd2bfbb28b482f2478a37d4f8cb0db002968ce4b1756c4edc9450d706e2c8755f8cbcc66015ec30b4bfb7c71e35cb93a9eb4f8e3e6ff3625
   languageName: node
   linkType: hard
 
@@ -7709,6 +8082,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"comma-separated-tokens@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "comma-separated-tokens@npm:2.0.3"
+  checksum: 10/e3bf9e0332a5c45f49b90e79bcdb4a7a85f28d6a6f0876a94f1bb9b2bfbdbbb9292aac50e1e742d8c0db1e62a0229a106f57917e2d067fca951d81737651700d
+  languageName: node
+  linkType: hard
+
 "commander@npm:12.1.0":
   version: 12.1.0
   resolution: "commander@npm:12.1.0"
@@ -8385,6 +8765,13 @@ __metadata:
   dependencies:
     dequal: "npm:^2.0.0"
   checksum: 10/3cc5f903d02d279d6dc4aa71ab6ed9898b9f4d1f861cc5421ce7357893c21b9520de78afb203c92bd650a6977ad0ca98195453a0707a39958cf5fea3b0a8ddd8
+  languageName: node
+  linkType: hard
+
+"diff-match-patch@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "diff-match-patch@npm:1.0.5"
+  checksum: 10/fd1ab417eba9559bda752a4dfc9a8ac73fa2ca8b146d29d153964b437168e301c09d8a688fae0cd81d32dc6508a4918a94614213c85df760793f44e245173bb6
   languageName: node
   linkType: hard
 
@@ -9597,6 +9984,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventsource-parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "eventsource-parser@npm:3.0.0"
+  checksum: 10/8215adf5d8404105ecd0658030b0407e06987ceb9aadcea28a38d69bacf02e5d0fc8bba5fa7c3954552c89509c8ef5e1fa3895e000c061411c055b4bbc26f4b0
+  languageName: node
+  linkType: hard
+
 "evp_bytestokey@npm:^1.0.0, evp_bytestokey@npm:^1.0.3":
   version: 1.0.3
   resolution: "evp_bytestokey@npm:1.0.3"
@@ -10581,12 +10975,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-to-jsx-runtime@npm:^2.0.0":
+  version: 2.3.2
+  resolution: "hast-util-to-jsx-runtime@npm:2.3.2"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+    "@types/hast": "npm:^3.0.0"
+    "@types/unist": "npm:^3.0.0"
+    comma-separated-tokens: "npm:^2.0.0"
+    devlop: "npm:^1.0.0"
+    estree-util-is-identifier-name: "npm:^3.0.0"
+    hast-util-whitespace: "npm:^3.0.0"
+    mdast-util-mdx-expression: "npm:^2.0.0"
+    mdast-util-mdx-jsx: "npm:^3.0.0"
+    mdast-util-mdxjs-esm: "npm:^2.0.0"
+    property-information: "npm:^6.0.0"
+    space-separated-tokens: "npm:^2.0.0"
+    style-to-object: "npm:^1.0.0"
+    unist-util-position: "npm:^5.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10/3d72f83e2d8c29adc6576d2c6b41479902fd51fac8cfb2b67c35fd68fcb9c25c274699442e4dee901a7ab926a0ff6851713ed5d92448ac09ae0f10daf293476c
+  languageName: node
+  linkType: hard
+
 "hast-util-to-string@npm:^3.0.0":
   version: 3.0.1
   resolution: "hast-util-to-string@npm:3.0.1"
   dependencies:
     "@types/hast": "npm:^3.0.0"
   checksum: 10/a569518313a648bc86e712858bc907d1f65137ebba87bc71180dbc2f24f194f6035019ffa8e38b1f7897672d45a337046a4c9964ce6d2593953b5069e10d31c2
+  languageName: node
+  linkType: hard
+
+"hast-util-whitespace@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "hast-util-whitespace@npm:3.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+  checksum: 10/8c7e9eeb8131fc18702f3a42623eb6b0b09d470347aa8badacac70e6d91f79657ab8c6b57c4c6fee3658cff405fac30e816d1cdfb3ed1fbf6045d0a4555cf4d4
   languageName: node
   linkType: hard
 
@@ -10672,6 +11098,13 @@ __metadata:
   version: 3.3.1
   resolution: "html-tags@npm:3.3.1"
   checksum: 10/d0e808544b92d8b999cbcc86d539577255a2f0f2f4f73110d10749d1d36e6fe6ad706a0355a8477afb6e000ecdc93d8455b3602951f9a2b694ac9e28f1b52878
+  languageName: node
+  linkType: hard
+
+"html-url-attributes@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "html-url-attributes@npm:3.0.1"
+  checksum: 10/494074c2f730c5c0e517aa1b10111fb36732534a2d2b70427582c4a615472b47da472cf3a17562cc653826d378d20960f2783e0400f4f7cf0c3c2d91c6188d13
   languageName: node
   linkType: hard
 
@@ -10950,6 +11383,13 @@ __metadata:
   version: 4.1.3
   resolution: "ini@npm:4.1.3"
   checksum: 10/f536b414d1442e5b233429e2b56efcdb354109b2d65ddd489e5939d8f0f5ad23c88aa2b19c92987249d0dd63ba8192e9aeb1a02b0459549c5a9ff31acd729a5d
+  languageName: node
+  linkType: hard
+
+"inline-style-parser@npm:0.2.4":
+  version: 0.2.4
+  resolution: "inline-style-parser@npm:0.2.4"
+  checksum: 10/80814479d1f3c9cbd102f9de4cd6558cf43cc2e48640e81c4371c3634f1e8b6dfeb2f21063cfa31d46cc83e834c20cd59ed9eeed9bfd45ef5bc02187ad941faf
   languageName: node
   linkType: hard
 
@@ -12245,6 +12685,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-schema@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "json-schema@npm:0.4.0"
+  checksum: 10/8b3b64eff4a807dc2a3045b104ed1b9335cd8d57aa74c58718f07f0f48b8baa3293b00af4dcfbdc9144c3aafea1e97982cc27cc8e150fc5d93c540649507a458
+  languageName: node
+  linkType: hard
+
 "json-stable-stringify-without-jsonify@npm:^1.0.1":
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
@@ -12285,6 +12732,19 @@ __metadata:
   version: 3.3.1
   resolution: "jsonc-parser@npm:3.3.1"
   checksum: 10/9b0dc391f20b47378f843ef1e877e73ec652a5bdc3c5fa1f36af0f119a55091d147a86c1ee86a232296f55c929bba174538c2bf0312610e0817a22de131cc3f4
+  languageName: node
+  linkType: hard
+
+"jsondiffpatch@npm:0.6.0":
+  version: 0.6.0
+  resolution: "jsondiffpatch@npm:0.6.0"
+  dependencies:
+    "@types/diff-match-patch": "npm:^1.0.36"
+    chalk: "npm:^5.3.0"
+    diff-match-patch: "npm:^1.0.5"
+  bin:
+    jsondiffpatch: bin/jsondiffpatch.js
+  checksum: 10/124b9797c266c693e69f8d23216e64d5ca4b21a4ec10e3a769a7b8cb19602ba62522f9a3d0c55299c1bfbe5ad955ca9ad2852439ca2c6b6316b8f91a5c218e94
   languageName: node
   linkType: hard
 
@@ -12615,6 +13075,7 @@ __metadata:
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^9.0.0"
     "@mitodl/course-search-utils": "npm:3.3.2"
+    "@mitodl/smoot-design": "npm:^0.0.0-preview215f7ae3fa"
     "@next/bundle-analyzer": "npm:^14.2.15"
     "@nlux/react": "npm:^2.17.1"
     "@nlux/themes": "npm:^2.17.1"
@@ -12957,6 +13418,23 @@ __metadata:
     "@types/mdast": "npm:^4.0.0"
     unist-util-is: "npm:^6.0.0"
   checksum: 10/3a97533e8ad104a422f8bebb34b3dde4f17167b8ed3a721cf9263c7416bd3447d2364e6d012a594aada40cac9e949db28a060bb71a982231693609034ed5324e
+  languageName: node
+  linkType: hard
+
+"mdast-util-to-hast@npm:^13.0.0":
+  version: 13.2.0
+  resolution: "mdast-util-to-hast@npm:13.2.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    "@ungap/structured-clone": "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    micromark-util-sanitize-uri: "npm:^2.0.0"
+    trim-lines: "npm:^3.0.0"
+    unist-util-position: "npm:^5.0.0"
+    unist-util-visit: "npm:^5.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 10/b17ee338f843af31a1c7a2ebf0df6f0b41c9380b7119a63ab521d271df665456578e1234bb7617883e8d860fe878038dcf2b76ab2f21e0f7451215a096d26cce
   languageName: node
   linkType: hard
 
@@ -13807,6 +14285,15 @@ __metadata:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 10/ac1eb60f615b272bccb0e2b9cd933720dad30bf9708424f691b8113826bb91aca7e9d14ef5d9415a6ba15c266b37817256f58d8ce980c82b0ba3185352565679
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.3.8":
+  version: 3.3.8
+  resolution: "nanoid@npm:3.3.8"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10/2d1766606cf0d6f47b6f0fdab91761bb81609b2e3d367027aff45e6ee7006f660fb7e7781f4a34799fe6734f1268eeed2e37a5fdee809ade0c2d4eb11b0f9c40
   languageName: node
   linkType: hard
 
@@ -15199,6 +15686,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"property-information@npm:^6.0.0":
+  version: 6.5.0
+  resolution: "property-information@npm:6.5.0"
+  checksum: 10/fced94f3a09bf651ad1824d1bdc8980428e3e480e6d01e98df6babe2cc9d45a1c52eee9a7736d2006958f9b394eb5964dedd37e23038086ddc143fc2fd5e426c
+  languageName: node
+  linkType: hard
+
 "proxy-addr@npm:~2.0.7":
   version: 2.0.7
   resolution: "proxy-addr@npm:2.0.7"
@@ -15472,6 +15966,34 @@ __metadata:
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: 10/d5f60c87d285af24b1e1e7eaeb123ec256c3c8bdea7061ab3932e3e14685708221bf234ec50b21e10dd07f008f1b966a2730a0ce4ff67905b3872ff2042aec22
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^19.0.0":
+  version: 19.0.0
+  resolution: "react-is@npm:19.0.0"
+  checksum: 10/6cd3695c462ec3f0d4db98583f0c1b9a439248d60214f6c42c2b0e2951a1066339d0eefa74707f03484042e043fca87750282a35b652492c035f5f3da0d6498a
+  languageName: node
+  linkType: hard
+
+"react-markdown@npm:^9.0.1":
+  version: 9.0.3
+  resolution: "react-markdown@npm:9.0.3"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    devlop: "npm:^1.0.0"
+    hast-util-to-jsx-runtime: "npm:^2.0.0"
+    html-url-attributes: "npm:^3.0.0"
+    mdast-util-to-hast: "npm:^13.0.0"
+    remark-parse: "npm:^11.0.0"
+    remark-rehype: "npm:^11.0.0"
+    unified: "npm:^11.0.0"
+    unist-util-visit: "npm:^5.0.0"
+    vfile: "npm:^6.0.0"
+  peerDependencies:
+    "@types/react": ">=18"
+    react: ">=18"
+  checksum: 10/b97eb9a61762762043263286ece030bd878acabe24bbf433767a9518cb18e434e26a75b1b810a7cb966e304ddb4e16bd4a15edcc808113b11b4fb85a68d99e8d
   languageName: node
   linkType: hard
 
@@ -15844,6 +16366,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"remark-rehype@npm:^11.0.0":
+  version: 11.1.1
+  resolution: "remark-rehype@npm:11.1.1"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-to-hast: "npm:^13.0.0"
+    unified: "npm:^11.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 10/39404bd19c57b2b69660be7e3d587ddb2240495845d42fad3bcc506c9c132d07abacb0a20182b73c530857b2da0c463ad5658382b448243ce432152ab49af08d
+  languageName: node
+  linkType: hard
+
 "remark-stringify@npm:^11.0.0":
   version: 11.0.0
   resolution: "remark-stringify@npm:11.0.0"
@@ -16199,6 +16734,13 @@ __metadata:
     ajv-formats: "npm:^2.1.1"
     ajv-keywords: "npm:^5.1.0"
   checksum: 10/808784735eeb153ab7f3f787f840aa3bc63f423d2a5a7e96c9e70a0e53d0bc62d7b37ea396fc598ce19196e4fb86a72f897154b7c6ce2358bbc426166f205e14
+  languageName: node
+  linkType: hard
+
+"secure-json-parse@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "secure-json-parse@npm:2.7.0"
+  checksum: 10/974386587060b6fc5b1ac06481b2f9dbbb0d63c860cc73dc7533f27835fdb67b0ef08762dbfef25625c15bc0a0c366899e00076cb0d556af06b71e22f1dede4c
   languageName: node
   linkType: hard
 
@@ -16983,6 +17525,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"style-to-object@npm:^1.0.0":
+  version: 1.0.8
+  resolution: "style-to-object@npm:1.0.8"
+  dependencies:
+    inline-style-parser: "npm:0.2.4"
+  checksum: 10/530b067325e3119bfaf75bdbe25cc86b02b559db00d881a74b98a2d5bb10ac953d1b455ed90c825963cf3b4bdaa1bda45f406d78d987391434b8d8ab3835df4e
+  languageName: node
+  linkType: hard
+
 "styled-jsx@npm:5.1.6, styled-jsx@npm:^5.1.6":
   version: 5.1.6
   resolution: "styled-jsx@npm:5.1.6"
@@ -17191,6 +17742,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"swr@npm:^2.2.5":
+  version: 2.3.0
+  resolution: "swr@npm:2.3.0"
+  dependencies:
+    dequal: "npm:^2.0.3"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/9f09a68a0dcd354915c7098b000197190aa5faa39c6caec7b91c3b9b682de79173abd5b733cd07cc3e79ee8a1eb294f7d2162716c515d1e4d7c1283d4342fda8
+  languageName: node
+  linkType: hard
+
 "symbol-tree@npm:^3.2.4":
   version: 3.2.4
   resolution: "symbol-tree@npm:3.2.4"
@@ -17341,6 +17904,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"throttleit@npm:2.1.0":
+  version: 2.1.0
+  resolution: "throttleit@npm:2.1.0"
+  checksum: 10/a2003947aafc721c4a17e6f07db72dc88a64fa9bba0f9c659f7997d30f9590b3af22dadd6a41851e0e8497d539c33b2935c2c7919cf4255922509af6913c619b
+  languageName: node
+  linkType: hard
+
 "tightrope@npm:0.2.0":
   version: 0.2.0
   resolution: "tightrope@npm:0.2.0"
@@ -17468,6 +18038,13 @@ __metadata:
   version: 0.0.3
   resolution: "tr46@npm:0.0.3"
   checksum: 10/8f1f5aa6cb232f9e1bdc86f485f916b7aa38caee8a778b378ffec0b70d9307873f253f5cbadbe2955ece2ac5c83d0dc14a77513166ccd0a0c7fe197e21396695
+  languageName: node
+  linkType: hard
+
+"trim-lines@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "trim-lines@npm:3.0.1"
+  checksum: 10/7a1325e4ce8ff7e9e52007600e9c9862a166d0db1f1cf0c9357e359e410acab1278fcd91cc279dfa5123fc37b69f080de02f471e91dbbc61b155b9ca92597929
   languageName: node
   linkType: hard
 
@@ -17934,6 +18511,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unist-util-position@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "unist-util-position@npm:5.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+  checksum: 10/89d4da00e74618d7562ac7ac288961df9bcd4ccca6df3b5a90650f018eceb6b95de6e771e88bdbef46cc9d96861d456abe57b7ad1108921e0feb67c6292aa29d
+  languageName: node
+  linkType: hard
+
 "unist-util-stringify-position@npm:^2.0.0":
   version: 2.0.3
   resolution: "unist-util-stringify-position@npm:2.0.3"
@@ -18082,6 +18668,15 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 10/671e9c190aab9a8374a5d468c6ba17f52c38b6fae970110bc196fc1e2b57204149aea9619be49a1bb5207fb6e51d8afd19c3bcb94afe61813fed039821461dc0
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "use-sync-external-store@npm:1.4.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/08bf581a8a2effaefc355e9d18ed025d436230f4cc973db2f593166df357cf63e47b9097b6e5089b594758bde322e1737754ad64905e030d70f8ff7ee671fd01
   languageName: node
   linkType: hard
 
@@ -18742,6 +19337,22 @@ __metadata:
     toposort: "npm:^2.0.2"
     type-fest: "npm:^2.19.0"
   checksum: 10/3d1277e5e1fff4d8130e525c7361f54874ca848ebd427a0aa66606952e3370b9947d84a1ea0b943f389649e886d26b1349930889727489460d6f2f86c2a26e77
+  languageName: node
+  linkType: hard
+
+"zod-to-json-schema@npm:^3.24.1":
+  version: 3.24.1
+  resolution: "zod-to-json-schema@npm:3.24.1"
+  peerDependencies:
+    zod: ^3.24.1
+  checksum: 10/d31fd05b67b428d8e0d5ecad2c3e80a1c2fc370e4c22f9111ffd11cbe05cfcab00f3228f84295830952649d15ea4494ef42c2ee1cbe723c865b13f4cf2b80c09
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.23.8":
+  version: 3.24.1
+  resolution: "zod@npm:3.24.1"
+  checksum: 10/54e25956495dec22acb9399c168c6ba657ff279801a7fcd0530c414d867f1dcca279335e160af9b138dd70c332e17d548be4bc4d2f7eaf627dead50d914fec27
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6454

### Description (What does it do?)
Adds a rudimentary syllabus chatbot to mit-learn, needed for a demo on RC tomorrow (Wednesday)

![Screenshot 2025-01-14 at 3 42 36 PM](https://github.com/user-attachments/assets/c8c648bc-4ece-4d68-83bf-e00d488cd296)

![Screenshot 2025-01-14 at 3 42 43 PM](https://github.com/user-attachments/assets/98e088e7-f98d-4a04-9abc-aaff917d1a28)

![Screenshot 2025-01-14 at 3 43 04 PM](https://github.com/user-attachments/assets/6b9b55c3-c5c4-4fa3-874e-33f71fb8041f)




### How can this be tested?
Go to http://open.odl.local:8062/chat_syllabus and try it out.

### Additional Context
There are no unit tests for the new functionality, didn't have time.
The system prompt is very basic.
The front end could use improvement (it should probably reinitiate to the default view when another course is selected, for example) and currently throws a non-breaking error when updating debug info.


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
