### PR TITLE
add "courses in program" carousel

### DIFF
--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -121,6 +121,9 @@ const DrawerContent: React.FC<{
         ]}
       />
     ) : null
+  const topCarousels = coursesInProgramCarousel
+    ? [coursesInProgramCarousel]
+    : null
   const similarResourcesCarousel = (
     <ResourceCarousel
       titleComponent="p"
@@ -161,11 +164,8 @@ const DrawerContent: React.FC<{
         imgConfig={imgConfigs.large}
         resourceId={resourceId}
         resource={resource.data}
-        carousels={[
-          coursesInProgramCarousel,
-          similarResourcesCarousel,
-          ...(topicCarousels || []),
-        ]}
+        topCarousels={topCarousels}
+        bottomCarousels={[similarResourcesCarousel, ...(topicCarousels || [])]}
         user={user}
         shareUrl={`${window.location.origin}/search?${RESOURCE_DRAWER_QUERY_PARAM}=${resourceId}`}
         inLearningPath={inLearningPath}

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -123,7 +123,7 @@ const DrawerContent: React.FC<{
     ) : null
   const topCarousels = coursesInProgramCarousel
     ? [coursesInProgramCarousel]
-    : null
+    : undefined
   const similarResourcesCarousel = (
     <ResourceCarousel
       titleComponent="p"

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -23,6 +23,7 @@ import ResourceCarousel from "../ResourceCarousel/ResourceCarousel"
 import { useIsLearningPathMember } from "api/hooks/learningPaths"
 import { useIsUserListMember } from "api/hooks/userLists"
 import { TopicCarouselConfig } from "@/common/carousels"
+import { ResourceTypeEnum } from "api"
 
 const RESOURCE_DRAWER_PARAMS = [RESOURCE_DRAWER_QUERY_PARAM] as const
 
@@ -102,6 +103,24 @@ const DrawerContent: React.FC<{
       }
     }, [user])
   useCapturePageView(Number(resourceId))
+  const coursesInProgramCarousel =
+    resource.data?.resource_type === ResourceTypeEnum.Program ? (
+      <ResourceCarousel
+        titleComponent="p"
+        titleVariant="subtitle1"
+        title="Courses in this Program"
+        config={[
+          {
+            label: "Courses in this Program",
+            cardProps: { size: "small" },
+            data: {
+              type: "resource_items",
+              params: { learning_resource_id: resourceId },
+            },
+          },
+        ]}
+      />
+    ) : null
   const similarResourcesCarousel = (
     <ResourceCarousel
       titleComponent="p"
@@ -142,7 +161,11 @@ const DrawerContent: React.FC<{
         imgConfig={imgConfigs.large}
         resourceId={resourceId}
         resource={resource.data}
-        carousels={[similarResourcesCarousel, ...(topicCarousels || [])]}
+        carousels={[
+          coursesInProgramCarousel,
+          similarResourcesCarousel,
+          ...(topicCarousels || []),
+        ]}
         user={user}
         shareUrl={`${window.location.origin}/search?${RESOURCE_DRAWER_QUERY_PARAM}=${resourceId}`}
         inLearningPath={inLearningPath}

--- a/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.tsx
+++ b/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.tsx
@@ -220,6 +220,10 @@ const ResourceCarousel: React.FC<ResourceCarouselProps> = ({
         switch (tab.data.type) {
           case "resources":
             return learningResources.list(tab.data.params)
+          case "resource_items":
+            return learningResources
+              .detail(tab.data.params.learning_resource_id)
+              ._ctx.items(tab.data.params)
           case "lr_search":
             return learningResources.search(tab.data.params)
           case "lr_featured":

--- a/frontends/main/src/page-components/ResourceCarousel/types.ts
+++ b/frontends/main/src/page-components/ResourceCarousel/types.ts
@@ -1,5 +1,6 @@
 import type {
   LearningResourcesApiLearningResourcesListRequest as LRListRequest,
+  LearningResourcesApiLearningResourcesItemsListRequest as LRItemsListRequest,
   LearningResourcesSearchApiLearningResourcesSearchRetrieveRequest as SearchRequest,
   FeaturedApiFeaturedListRequest as FeaturedListParams,
   LearningResourcesApiLearningResourcesSimilarListRequest as SimilarListParams,
@@ -10,6 +11,11 @@ import type { LearningResourceCardProps } from "ol-components"
 interface ResourceDataSource {
   type: "resources"
   params: LRListRequest
+}
+
+interface ResourceItemsDataSource {
+  type: "resource_items"
+  params: LRItemsListRequest
 }
 
 interface SearchDataSource {
@@ -34,6 +40,7 @@ interface VectorSimilarDataSource {
 
 type DataSource =
   | ResourceDataSource
+  | ResourceItemsDataSource
   | SearchDataSource
   | FeaturedDataSource
   | SimilarDataSource

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -273,7 +273,13 @@ const CopyLinkButton = styled(Button)({
   flexBasis: "112px",
 })
 
-const CarouselContainer = styled.div({
+const TopCarouselContainer = styled.div({
+  display: "flex",
+  flexDirection: "column",
+  paddingTop: "24px",
+})
+
+const BottomCarouselContainer = styled.div({
   display: "flex",
   flexDirection: "column",
   flexGrow: 1,
@@ -299,7 +305,8 @@ type LearningResourceExpandedV2Props = {
   user?: User
   shareUrl?: string
   imgConfig: ImageConfig
-  carousels?: React.ReactNode[]
+  topCarousels?: React.ReactNode[]
+  bottomCarousels?: React.ReactNode[]
   inLearningPath?: boolean
   inUserList?: boolean
   onAddToLearningPathClick?: LearningResourceCardProps["onAddToLearningPathClick"]
@@ -691,7 +698,8 @@ const LearningResourceExpandedV2: React.FC<LearningResourceExpandedV2Props> = ({
   imgConfig,
   user,
   shareUrl,
-  carousels,
+  topCarousels,
+  bottomCarousels,
   inUserList,
   inLearningPath,
   titleId,
@@ -731,10 +739,19 @@ const LearningResourceExpandedV2: React.FC<LearningResourceExpandedV2Props> = ({
             />
           </RightContainer>
         </ContentContainer>
+        {topCarousels && (
+          <TopCarouselContainer>
+            {topCarousels?.map((carousel, index) => (
+              <div key={index}>{carousel}</div>
+            ))}
+          </TopCarouselContainer>
+        )}
       </Container>
-      <CarouselContainer>
-        {carousels?.map((carousel, index) => <div key={index}>{carousel}</div>)}
-      </CarouselContainer>
+      <BottomCarouselContainer>
+        {bottomCarousels?.map((carousel, index) => (
+          <div key={index}>{carousel}</div>
+        ))}
+      </BottomCarouselContainer>
     </OuterContainer>
   )
 }


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5880

### Description (What does it do?)
This PR adds a carousel under the description for programs in the V2 drawer showing the courses included in said program. A context query was added to the learning resources detail query to fetch the "items" that are children of any learning resource in order to support this.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/1976eff4-44ec-4805-9c68-b718db83b0a6)
![image](https://github.com/user-attachments/assets/c532c687-adee-4492-a43b-713f59a21dc8)

### How can this be tested?
 - If you have Posthog set up locally, enable the `lr_drawer_v2` flag
 - If you don't have Posthog set up locally, you can force `drawerV2` to be `true` in `LearningResourceDrawer.tsx`
 - Ensure that you have backpopulated some programs and their courses into your database, xPro has a number of them
 - Spin up `mit-learn` on this branch
 - Visit the search page at http://localhost:8062/search
 - Click the "Programs" tab
 - Click on any of the programs
 - Verify that the "Courses in this Program" carousel renders and shows the courses in the program
