### PR TITLE
fix drawer v2 programs flaky test

### DIFF
--- a/frontends/api/src/test-utils/urls.ts
+++ b/frontends/api/src/test-utils/urls.ts
@@ -78,6 +78,8 @@ const learningResources = {
     `${API_BASE_URL}/api/v1/learning_resources/${query(params)}`,
   details: (params: Params<LRApi, "learningResourcesRetrieve">) =>
     `${API_BASE_URL}/api/v1/learning_resources/${params.id}/`,
+  items: (params: Params<LRApi, "learningResourcesRetrieve">) =>
+    `${API_BASE_URL}/api/v1/learning_resources/${params.id}/items/`,
   featured: (params?: Params<FeaturedApi, "featuredList">) =>
     `${API_BASE_URL}/api/v1/featured/${query(params)}`,
   similar: (params: Params<LRApi, "learningResourcesSimilarList">) =>

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.test.tsx
@@ -62,6 +62,25 @@ describe("LearningResourceDrawerV2", () => {
       [],
     )
 
+    if (resource.resource_type === ResourceTypeEnum.Program) {
+      const coursesInProgram = factories.learningResources.resources({
+        count: 10,
+      })
+      coursesInProgram.results.forEach((course) => {
+        setMockResponse.get(
+          urls.learningResources.details({ id: course.id }),
+          course,
+        )
+      })
+
+      setMockResponse.get(
+        urls.learningResources.items({ id: resource.id }),
+        coursesInProgram,
+      )
+
+      return { resource, user, coursesInProgram }
+    }
+
     return { resource, user }
   }
 


### PR DESCRIPTION
### What are the relevant tickets?
Follow up to https://github.com/mitodl/mit-learn/pull/1964

### Description (What does it do?)
This PR fixes an issue with a flaky test caused by merging the above PR

### How can this be tested?
 - Spin up this branch of `mit-learn`
 - Run `docker compose exec watch yarn test LearningResourceDrawerV2` several times
 - Ensure that the tests pass every time
