### PR TITLE
fix line clamping of HTML description

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -174,20 +174,23 @@ const Description = styled.p({
   ...theme.typography.body2,
   color: theme.custom.colors.black,
   margin: 0,
-  whiteSpace: "pre-wrap",
   wordBreak: "break-word",
-  "p:first-child": {
-    marginTop: 0,
-  },
-  "p:last-child": {
-    marginBottom: 0,
+  "> *": {
+    ":first-child": {
+      marginTop: 0,
+    },
+    ":last-child": {
+      marginBottom: 0,
+    },
+    ":empty": {
+      display: "none",
+    },
   },
 })
 
 const DescriptionCollapsed = styled(Description)({
   display: "-webkit-box",
   overflow: "hidden",
-  maxHeight: `calc(${theme.typography.body2.lineHeight} * 5)`,
   "@supports (-webkit-line-clamp: 5)": {
     WebkitLineClamp: 5,
     WebkitBoxOrient: "vertical",

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpandedV2.tsx
@@ -191,7 +191,9 @@ const Description = styled.p({
 const DescriptionCollapsed = styled(Description)({
   display: "-webkit-box",
   overflow: "hidden",
+  maxHeight: `calc(${theme.typography.body2.lineHeight} * 5)`,
   "@supports (-webkit-line-clamp: 5)": {
+    maxHeight: "unset",
     WebkitLineClamp: 5,
     WebkitBoxOrient: "vertical",
   },


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6512

### Description (What does it do?)
This PR fixes some issues with line clamping of the resource description in the V2 learning resource drawer. What's happening here is similar to the issue we had with some descriptions having extraneous padding at the top; nested paragraph elements in the description HTML in the database. Previously, I had simply set the first child top padding and last child bottom padding to zero, but it seems now that we've added the "show more" line clamping functionality we need a bit more sophisticated of a solution. The main issue is that paragraphs (`p` elements) get a default amount of padding applied to them, both top and bottom. When we set up line clamping, we used the `-webkit-line-clamp` rule, which is supported by most browsers, but we have a fallback in there for unsupported browsers that sets:
```
maxHeight: `calc(${theme.typography.body2.lineHeight} * 5)`
```
This rule simply takes the font's line height value and multiplies it by 5 to cap the height of the description container at 5 lines. The `body2` font in use here has a line height of `1.125rem`, which is `18px` at `16px` base font size. Since the `p` elements being inserted inside the description have a padding of 14 pixels, the 5th "line" of text gets pushed down by that much, but only the very top of it is exposed. This is because the `max-height` rule being set only accounts for the literal pixel height of 5 lines of text at `1.125rem` line height.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/7020b0f6-5cfb-4541-84ef-7d366b12c2b8)
![image](https://github.com/user-attachments/assets/dfccaaf6-0545-472d-a22c-ca6e42453c09)

### How can this be tested?
 - If you have Posthog set up locally, enable the `lr_drawer_v2` flag
 - If you don't have Posthog set up locally, you can force `drawerV2` to be `true` in `LearningResourceDrawer.tsx`
 - Ensure that you have backpopulated some courses and resources that have HTML descriptions in your database
 - Spin up `mit-learn` on the `main` branch
 - Search for the Program "Architecture and Systems Engineering: Models and Methods to Manage Complex Systems"
 - Verify that you see the issue as described; a cut off line of text at the bottom of the clamped description
 - Switch to this PR branch
 - Refresh the page and verify that you now do not see the cut off line of text