### PR TITLE
drawer v2 other videos in series / videos in playlist

### DIFF
--- a/frontends/api/src/hooks/learningResources/keyFactory.ts
+++ b/frontends/api/src/hooks/learningResources/keyFactory.ts
@@ -87,7 +87,7 @@ const learningResources = createQueryKeys("learningResources", {
           const { data } = await request
           return {
             ...data,
-            results: data.results.map((relation) => ({
+            results: data.results?.map((relation) => ({
               ...clearListMemberships(relation.resource),
             })),
           }

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.test.tsx
@@ -62,23 +62,26 @@ describe("LearningResourceDrawerV2", () => {
       [],
     )
 
-    if (resource.resource_type === ResourceTypeEnum.Program) {
-      const coursesInProgram = factories.learningResources.resources({
+    if (
+      resource.resource_type === ResourceTypeEnum.Program ||
+      resource.resource_type === ResourceTypeEnum.VideoPlaylist
+    ) {
+      const items = factories.learningResources.resources({
         count: 10,
       })
-      coursesInProgram.results.forEach((course) => {
+      items.results.forEach((item) => {
         setMockResponse.get(
-          urls.learningResources.details({ id: course.id }),
-          course,
+          urls.learningResources.details({ id: item.id }),
+          item,
         )
       })
 
       setMockResponse.get(
-        urls.learningResources.items({ id: resource.id }),
-        coursesInProgram,
+        `${urls.learningResources.items({ id: resource.id })}?limit=12`,
+        items,
       )
 
-      return { resource, user, coursesInProgram }
+      return { resource, user, items }
     }
 
     return { resource, user }

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.test.tsx
@@ -78,7 +78,7 @@ describe("LearningResourceDrawerV2", () => {
 
       setMockResponse.get(
         `${urls.learningResources.items({ id: resource.id })}?limit=12`,
-        items,
+        items.results,
       )
 
       return { resource, user, items }

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -128,7 +128,7 @@ const DrawerContent: React.FC<{
     : undefined
   const otherVideosInThisSeries =
     resource.data?.resource_type === ResourceTypeEnum.Video ? (
-      resource.data?.playlists.length > 0 ? (
+      resource.data?.playlists?.length > 0 ? (
         <ResourceCarousel
           titleComponent="p"
           titleVariant="subtitle1"

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -124,6 +124,24 @@ const DrawerContent: React.FC<{
   const topCarousels = coursesInProgramCarousel
     ? [coursesInProgramCarousel]
     : undefined
+  const videosInSeriesCarousel =
+    resource.data?.resource_type === ResourceTypeEnum.VideoPlaylist ? (
+      <ResourceCarousel
+        titleComponent="p"
+        titleVariant="subtitle1"
+        title="Videos in this Series"
+        config={[
+          {
+            label: "Videos in this Series",
+            cardProps: { size: "small" },
+            data: {
+              type: "resource_items",
+              params: { learning_resource_id: resourceId },
+            },
+          },
+        ]}
+      />
+    ) : null
   const similarResourcesCarousel = (
     <ResourceCarousel
       titleComponent="p"
@@ -156,6 +174,12 @@ const DrawerContent: React.FC<{
       excludeResourceId={resourceId}
     />
   ))
+  const bottomCarousels = []
+  if (videosInSeriesCarousel) {
+    bottomCarousels.push(videosInSeriesCarousel)
+  }
+  bottomCarousels.push(similarResourcesCarousel)
+  bottomCarousels.push(...(topicCarousels || []))
 
   return (
     <>
@@ -165,7 +189,7 @@ const DrawerContent: React.FC<{
         resourceId={resourceId}
         resource={resource.data}
         topCarousels={topCarousels}
-        bottomCarousels={[similarResourcesCarousel, ...(topicCarousels || [])]}
+        bottomCarousels={bottomCarousels}
         user={user}
         shareUrl={`${window.location.origin}/search?${RESOURCE_DRAWER_QUERY_PARAM}=${resourceId}`}
         inLearningPath={inLearningPath}

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -124,7 +124,29 @@ const DrawerContent: React.FC<{
   const topCarousels = coursesInProgramCarousel
     ? [coursesInProgramCarousel]
     : undefined
-  const videosInSeriesCarousel =
+  const otherVideosInThisSeries =
+    resource.data?.resource_type === ResourceTypeEnum.Video ? (
+      resource.data?.playlists.length > 0 ? (
+        <ResourceCarousel
+          titleComponent="p"
+          titleVariant="subtitle1"
+          title="Other Videos in this Series"
+          config={[
+            {
+              label: "Other Videos in this Series",
+              cardProps: { size: "small" },
+              data: {
+                type: "resource_items",
+                params: {
+                  learning_resource_id: parseInt(resource.data.playlists[0]),
+                },
+              },
+            },
+          ]}
+        />
+      ) : null
+    ) : null
+  const videosInThisPlaylist =
     resource.data?.resource_type === ResourceTypeEnum.VideoPlaylist ? (
       <ResourceCarousel
         titleComponent="p"
@@ -175,8 +197,11 @@ const DrawerContent: React.FC<{
     />
   ))
   const bottomCarousels = []
-  if (videosInSeriesCarousel) {
-    bottomCarousels.push(videosInSeriesCarousel)
+  if (otherVideosInThisSeries) {
+    bottomCarousels.push(otherVideosInThisSeries)
+  }
+  if (videosInThisPlaylist) {
+    bottomCarousels.push(videosInThisPlaylist)
   }
   bottomCarousels.push(similarResourcesCarousel)
   bottomCarousels.push(...(topicCarousels || []))

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -82,7 +82,7 @@ const DrawerContent: React.FC<{
   const { data: user } = useUserMe()
   const { data: inLearningPath } = useIsLearningPathMember(resourceId)
   const { data: inUserList } = useIsUserListMember(resourceId)
-  const limit = 12
+  const carouselResultsLimit = 12
 
   const handleAddToLearningPathClick: LearningResourceCardProps["onAddToLearningPathClick"] =
     useMemo(() => {
@@ -116,7 +116,10 @@ const DrawerContent: React.FC<{
             cardProps: { size: "small" },
             data: {
               type: "resource_items",
-              params: { learning_resource_id: resourceId, limit: limit },
+              params: {
+                learning_resource_id: resourceId,
+                limit: carouselResultsLimit,
+              },
             },
           },
         ]}
@@ -141,7 +144,7 @@ const DrawerContent: React.FC<{
                 type: "resource_items",
                 params: {
                   learning_resource_id: parseInt(resource.data.playlists[0]),
-                  limit: limit,
+                  limit: carouselResultsLimit,
                 },
               },
             },
@@ -162,7 +165,10 @@ const DrawerContent: React.FC<{
             cardProps: { size: "small" },
             data: {
               type: "resource_items",
-              params: { learning_resource_id: resourceId, limit: limit },
+              params: {
+                learning_resource_id: resourceId,
+                limit: carouselResultsLimit,
+              },
             },
           },
         ]}
@@ -180,7 +186,7 @@ const DrawerContent: React.FC<{
           cardProps: { size: "small" },
           data: {
             type: "lr_vector_similar",
-            params: { id: resourceId, limit: limit },
+            params: { id: resourceId, limit: carouselResultsLimit },
           },
         },
       ]}

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -120,6 +120,7 @@ const DrawerContent: React.FC<{
             },
           },
         ]}
+        excludeResourceId={resourceId}
       />
     ) : null
   const topCarousels = coursesInProgramCarousel
@@ -145,6 +146,7 @@ const DrawerContent: React.FC<{
               },
             },
           ]}
+          excludeResourceId={resourceId}
         />
       ) : null
     ) : null
@@ -164,6 +166,7 @@ const DrawerContent: React.FC<{
             },
           },
         ]}
+        excludeResourceId={resourceId}
       />
     ) : null
   const similarResourcesCarousel = (

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -82,6 +82,7 @@ const DrawerContent: React.FC<{
   const { data: user } = useUserMe()
   const { data: inLearningPath } = useIsLearningPathMember(resourceId)
   const { data: inUserList } = useIsUserListMember(resourceId)
+  const limit = 12
 
   const handleAddToLearningPathClick: LearningResourceCardProps["onAddToLearningPathClick"] =
     useMemo(() => {
@@ -115,7 +116,7 @@ const DrawerContent: React.FC<{
             cardProps: { size: "small" },
             data: {
               type: "resource_items",
-              params: { learning_resource_id: resourceId },
+              params: { learning_resource_id: resourceId, limit: limit },
             },
           },
         ]}
@@ -139,6 +140,7 @@ const DrawerContent: React.FC<{
                 type: "resource_items",
                 params: {
                   learning_resource_id: parseInt(resource.data.playlists[0]),
+                  limit: limit,
                 },
               },
             },
@@ -158,7 +160,7 @@ const DrawerContent: React.FC<{
             cardProps: { size: "small" },
             data: {
               type: "resource_items",
-              params: { learning_resource_id: resourceId },
+              params: { learning_resource_id: resourceId, limit: limit },
             },
           },
         ]}
@@ -175,7 +177,7 @@ const DrawerContent: React.FC<{
           cardProps: { size: "small" },
           data: {
             type: "lr_vector_similar",
-            params: { id: resourceId },
+            params: { id: resourceId, limit: limit },
           },
         },
       ]}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5882
Closes https://github.com/mitodl/hq/issues/5884

### Description (What does it do?)
This PR adds two new carousels to the learning resource drawer:
- Videos in a playlist while viewing a video playlist
- Other videos in the same series while viewing a video

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/348d7cb1-d2d0-490f-99b8-976d34fbc018)
![image](https://github.com/user-attachments/assets/a5dae2e3-d46d-4b59-95b2-ed5b83a1b379)
![image](https://github.com/user-attachments/assets/e7db68ba-9ac5-4b99-904a-d9f3dc1a51c5)
![image](https://github.com/user-attachments/assets/198166f5-cc09-420d-a7bc-97564f0ea199)

### How can this be tested?
 - If you have Posthog set up locally, enable the `lr_drawer_v2` flag
 - If you don't have Posthog set up locally, you can force `drawerV2` to be `true` in `LearningResourceDrawer.tsx`
 - Ensure that you have backpopulated some videos and video playlists into your database
 - Spin up `mit-learn` on this branch
 - VIsit the search page at http://localhost:8062/search
 - Click the "Learning Materials" tab
 - In the facets on the left, select "Video"
 - Select one of the videos to bring up the drawer
 - Verify that you see "Other Videos in this Series" before the "Similar Learning Resources" carousel and that the videos displayed in the carousel belong to the same series as the one you clicked
 - Unselect the "Video" facet and select "Video Playlist"
 - Select one of the video playlists to bring up the drawer
 - Verify that you see "Videos in this Series" before the "Similar Learning Resources" carousel and that the videos are part of the playlist you clicked
