### PR TITLE
remove two unused entries

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,15 +3,6 @@
   "extends": ["local>mitodl/.github:renovate-config"],
   "packageRules": [
     {
-      "matchFileNames": ["frontends/mit-learn/package.json"],
-      "matchUpdateTypes": ["major"],
-      "enabled": false
-    },
-    {
-      "groupName": "ckeditor5",
-      "matchSourceUrls": ["https://github.com/ckeditor/ckeditor5/{/,}**"]
-    },
-    {
       "allowedVersions": "<5",
       "matchPackageNames": ["django", "Django"]
     }


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6526

### Description (What does it do?)
Removes two unused pieces of MIT Learn's renovate config. Maybe this will fix the issue?

### How can this be tested?
Will need to merge and try it.

If you want, you can run ` npx --package renovate renovate-config-validator` to validate the config change:
```sh
➜ npx --package renovate renovate-config-validator
Need to install the following packages:
renovate@39.120.0
Ok to proceed? (y) y

 INFO: Validating renovate.json
 INFO: Config validated successfully
```