### PR TITLE
drawer v2 podcast carousels

### DIFF
--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.test.tsx
@@ -64,7 +64,8 @@ describe("LearningResourceDrawerV2", () => {
 
     if (
       resource.resource_type === ResourceTypeEnum.Program ||
-      resource.resource_type === ResourceTypeEnum.VideoPlaylist
+      resource.resource_type === ResourceTypeEnum.VideoPlaylist ||
+      resource.resource_type === ResourceTypeEnum.Podcast
     ) {
       const items = factories.learningResources.resources({
         count: 10,

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -187,6 +187,23 @@ const DrawerContent: React.FC<{
       itemsCarousel("Videos in this Series", resourceId, resourceId),
     )
   }
+  if (
+    resource.data?.resource_type === ResourceTypeEnum.PodcastEpisode &&
+    resource.data?.podcast_episode?.podcasts?.length > 0
+  ) {
+    bottomCarousels.push(
+      itemsCarousel(
+        "Other Episodes in this Podcast",
+        parseInt(resource.data.podcast_episode.podcasts[0]),
+        resourceId,
+      ),
+    )
+  }
+  if (resource.data?.resource_type === ResourceTypeEnum.Podcast) {
+    bottomCarousels.push(
+      itemsCarousel("Episodes in this Podcast", resourceId, resourceId),
+    )
+  }
   bottomCarousels.push(similarResourcesCarousel)
   bottomCarousels.push(...(topicCarousels || []))
 

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -201,7 +201,7 @@ const DrawerContent: React.FC<{
   }
   if (resource.data?.resource_type === ResourceTypeEnum.Podcast) {
     bottomCarousels.push(
-      itemsCarousel("Episodes in this Podcast", resourceId, resourceId),
+      itemsCarousel("Recent Episodes", resourceId, resourceId),
     )
   }
   bottomCarousels.push(similarResourcesCarousel)

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawerV2.tsx
@@ -104,77 +104,33 @@ const DrawerContent: React.FC<{
       }
     }, [user])
   useCapturePageView(Number(resourceId))
-  const coursesInProgramCarousel =
-    resource.data?.resource_type === ResourceTypeEnum.Program ? (
+  const itemsCarousel = (
+    title: string,
+    learningResourceId: number,
+    excludeResourceId: number,
+  ) => {
+    return (
       <ResourceCarousel
         titleComponent="p"
         titleVariant="subtitle1"
-        title="Courses in this Program"
+        title={title}
         config={[
           {
-            label: "Courses in this Program",
+            label: title,
             cardProps: { size: "small" },
             data: {
               type: "resource_items",
               params: {
-                learning_resource_id: resourceId,
+                learning_resource_id: learningResourceId,
                 limit: carouselResultsLimit,
               },
             },
           },
         ]}
-        excludeResourceId={resourceId}
+        excludeResourceId={excludeResourceId}
       />
-    ) : null
-  const topCarousels = coursesInProgramCarousel
-    ? [coursesInProgramCarousel]
-    : undefined
-  const otherVideosInThisSeries =
-    resource.data?.resource_type === ResourceTypeEnum.Video ? (
-      resource.data?.playlists?.length > 0 ? (
-        <ResourceCarousel
-          titleComponent="p"
-          titleVariant="subtitle1"
-          title="Other Videos in this Series"
-          config={[
-            {
-              label: "Other Videos in this Series",
-              cardProps: { size: "small" },
-              data: {
-                type: "resource_items",
-                params: {
-                  learning_resource_id: parseInt(resource.data.playlists[0]),
-                  limit: carouselResultsLimit,
-                },
-              },
-            },
-          ]}
-          excludeResourceId={resourceId}
-        />
-      ) : null
-    ) : null
-  const videosInThisPlaylist =
-    resource.data?.resource_type === ResourceTypeEnum.VideoPlaylist ? (
-      <ResourceCarousel
-        titleComponent="p"
-        titleVariant="subtitle1"
-        title="Videos in this Series"
-        config={[
-          {
-            label: "Videos in this Series",
-            cardProps: { size: "small" },
-            data: {
-              type: "resource_items",
-              params: {
-                learning_resource_id: resourceId,
-                limit: carouselResultsLimit,
-              },
-            },
-          },
-        ]}
-        excludeResourceId={resourceId}
-      />
-    ) : null
+    )
+  }
   const similarResourcesCarousel = (
     <ResourceCarousel
       titleComponent="p"
@@ -207,12 +163,29 @@ const DrawerContent: React.FC<{
       excludeResourceId={resourceId}
     />
   ))
-  const bottomCarousels = []
-  if (otherVideosInThisSeries) {
-    bottomCarousels.push(otherVideosInThisSeries)
+  const topCarousels = []
+  if (resource.data?.resource_type === ResourceTypeEnum.Program) {
+    topCarousels.push(
+      itemsCarousel("Courses in this Program", resourceId, resourceId),
+    )
   }
-  if (videosInThisPlaylist) {
-    bottomCarousels.push(videosInThisPlaylist)
+  const bottomCarousels = []
+  if (
+    resource.data?.resource_type === ResourceTypeEnum.Video &&
+    resource.data?.playlists?.length > 0
+  ) {
+    bottomCarousels.push(
+      itemsCarousel(
+        "Other Videos in this Series",
+        parseInt(resource.data.playlists[0]),
+        resourceId,
+      ),
+    )
+  }
+  if (resource.data?.resource_type === ResourceTypeEnum.VideoPlaylist) {
+    bottomCarousels.push(
+      itemsCarousel("Videos in this Series", resourceId, resourceId),
+    )
   }
   bottomCarousels.push(similarResourcesCarousel)
   bottomCarousels.push(...(topicCarousels || []))


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5885
https://github.com/mitodl/hq/issues/5887

### Description (What does it do?)
This PR adds the "other episodes in this podcast" carousel to the learning resource drawer for `PodcastEpisode` resources, as well as the "recent episodes" carousel for `Podcast` resources.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/27a673c8-c59b-4d80-8d45-a39874c37e6e)
![image](https://github.com/user-attachments/assets/ed18612d-ebef-4649-8f8b-f5f0d7dc5608)
![image](https://github.com/user-attachments/assets/8e809989-7408-462a-91a3-493c3dc52129)
![image](https://github.com/user-attachments/assets/a8c85901-dbc2-499f-ac7d-6682c0461a52)

### How can this be tested?
 - If you have Posthog set up locally, enable the `lr_drawer_v2` flag
 - If you don't have Posthog set up locally, you can force `drawerV2` to be `true` in `LearningResourceDrawer.tsx`
 - Ensure that you have backpopulated some podcasts into your database
 - Spin up `mit-learn` on this branch
 - VIsit the search page at http://localhost:8062/search
 - Click the "Learning Materials" tab
 - In the facets on the left, select "Podcast Episode"
 - Select one of the podcast episodes to bring up the drawer
 - Verify that you see "Other Episodes in this Podcast" before the "Similar Learning Resources" carousel and that the podcast episodes displayed in the carousel belong to the same podcast as the one you clicked
 - Unselect the "Podcast Episode" facet and select "Podcast"
 - Select one of the podcasts to bring up the drawer
 - Verify that you see "Recent Episodes" before the "Similar Learning Resources" carousel and that the podcast episodes are part of the playlist you clicked
