### PR TITLE
drawer topic carousels should not be filtered on just courses

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/DashboardPage.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/DashboardPage.tsx
@@ -43,6 +43,7 @@ import UserListDetailsTab from "./UserListDetailsTab"
 import { SettingsPage } from "./SettingsPage"
 import { DASHBOARD_HOME, MY_LISTS, PROFILE, SETTINGS } from "@/common/urls"
 import dynamic from "next/dynamic"
+import { ResourceTypeEnum } from "api"
 
 const LearningResourceDrawer = dynamic(
   () =>
@@ -451,7 +452,9 @@ const DashboardPage: React.FC = () => {
                           titleComponent="h2"
                           title={`Popular courses in ${topic}`}
                           isLoading={isLoadingProfile}
-                          config={TopicCarouselConfig(topic)}
+                          config={TopicCarouselConfig(topic, [
+                            ResourceTypeEnum.Course,
+                          ])}
                           data-testid={`topic-carousel-${topic}`}
                         />
                       ))}

--- a/frontends/main/src/common/carousels.ts
+++ b/frontends/main/src/common/carousels.ts
@@ -1,5 +1,11 @@
-import type { ResourceCarouselProps } from "@/page-components/ResourceCarousel/ResourceCarousel"
-import { LearningResourcesSearchRetrieveDeliveryEnum } from "api"
+import type {
+  ResourceCarouselProps,
+  TabConfig,
+} from "@/page-components/ResourceCarousel/ResourceCarousel"
+import {
+  LearningResourcesSearchRetrieveDeliveryEnum,
+  LearningResourcesSearchRetrieveResourceTypeEnum,
+} from "api"
 import { Profile } from "api/v0"
 
 type TopPicksCarouselConfigProps = (
@@ -38,19 +44,21 @@ const TopPicksCarouselConfig: TopPicksCarouselConfigProps = (
 
 type TopicCarouselConfigProps = (
   topic: string | undefined,
+  resourceType?: LearningResourcesSearchRetrieveResourceTypeEnum[] | undefined,
 ) => ResourceCarouselProps["config"]
 
 const TopicCarouselConfig: TopicCarouselConfigProps = (
   topic: string | undefined,
+  resourceType?: LearningResourcesSearchRetrieveResourceTypeEnum[] | undefined,
 ) => {
-  return [
+  const config: TabConfig[] = [
     {
       label: "All",
       cardProps: { size: "small" },
       data: {
         type: "lr_search",
         params: {
-          resource_type: ["course"],
+          resource_type: resourceType || [],
           limit: 12,
           topic: [topic || ""],
           sortby: "-views",
@@ -58,6 +66,7 @@ const TopicCarouselConfig: TopicCarouselConfigProps = (
       },
     },
   ]
+  return config
 }
 
 const CERTIFICATE_COURSES_CAROUSEL: ResourceCarouselProps["config"] = [

--- a/frontends/main/src/common/carousels.ts
+++ b/frontends/main/src/common/carousels.ts
@@ -44,12 +44,12 @@ const TopPicksCarouselConfig: TopPicksCarouselConfigProps = (
 
 type TopicCarouselConfigProps = (
   topic: string | undefined,
-  resourceType?: LearningResourcesSearchRetrieveResourceTypeEnum[] | undefined,
+  resourceTypes?: LearningResourcesSearchRetrieveResourceTypeEnum[] | undefined,
 ) => ResourceCarouselProps["config"]
 
 const TopicCarouselConfig: TopicCarouselConfigProps = (
   topic: string | undefined,
-  resourceType?: LearningResourcesSearchRetrieveResourceTypeEnum[] | undefined,
+  resourceTypes?: LearningResourcesSearchRetrieveResourceTypeEnum[] | undefined,
 ) => {
   const config: TabConfig[] = [
     {
@@ -58,7 +58,7 @@ const TopicCarouselConfig: TopicCarouselConfigProps = (
       data: {
         type: "lr_search",
         params: {
-          resource_type: resourceType || [],
+          resource_type: resourceTypes || [],
           limit: 12,
           topic: [topic || ""],
           sortby: "-views",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6565

### Description (What does it do?)
When adding the topic carousels to the new learning resource drawer, the `TopicCarouselConfig` class was reused from the Dashboard. This config was set up by default to filter on only courses. The carousels in the drawer are not supposed to be this way. By default the `TopicCarouselConfig` does not filter on courses now, and that is only set in the Dashboard.

### How can this be tested?
 - Spin up this branch of `mit-learn`
 - Ensure you have a variety of resources of different types populated in your database
 - Visit the search page at http://localhost:8062/search/
 - Click on some search results and verify that the topic carousels pull in more than just courses
 - You should test several resources as some topics may show all courses just by chance
