### PR TITLE
track browse actions in posthog

### DIFF
--- a/frontends/main/src/app-pages/ChannelPage/TopicChannelTemplate.tsx
+++ b/frontends/main/src/app-pages/ChannelPage/TopicChannelTemplate.tsx
@@ -105,7 +105,9 @@ const TopicChipsInternal: React.FC<TopicChipsInternalProps> = (props) => {
             key={topic.id}
             href={topic.channel_url ?? ""}
             onClick={() => {
-              posthog.capture("related_topic_link_clicked", { topic })
+              if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+                posthog.capture("related_topic_link_clicked", { topic })
+              }
             }}
             label={topic.name}
           />

--- a/frontends/main/src/app-pages/ChannelPage/TopicChannelTemplate.tsx
+++ b/frontends/main/src/app-pages/ChannelPage/TopicChannelTemplate.tsx
@@ -26,6 +26,7 @@ import {
 import { propsNotNil, backgroundSrcSetCSS } from "ol-utilities"
 import invariant from "tiny-invariant"
 import backgroundSteps from "@/public/images/backgrounds/background_steps.jpg"
+import { usePostHog } from "posthog-js/react"
 
 const ChildrenContainer = styled.div(({ theme }) => ({
   paddingTop: "40px",
@@ -84,6 +85,7 @@ type TopicChipsInternalProps = {
 }
 
 const TopicChipsInternal: React.FC<TopicChipsInternalProps> = (props) => {
+  const posthog = usePostHog()
   const { title, topicId, parentTopicId } = props
   const subTopicsQuery = useLearningResourceTopics({
     parent_topic_id: [parentTopicId],
@@ -102,6 +104,9 @@ const TopicChipsInternal: React.FC<TopicChipsInternalProps> = (props) => {
             variant="darker"
             key={topic.id}
             href={topic.channel_url ?? ""}
+            onClick={() => {
+              posthog.capture("related_topic_link_clicked", { topic })
+            }}
             label={topic.name}
           />
         ))}

--- a/frontends/main/src/app-pages/DepartmentListingPage/DepartmentListingPage.tsx
+++ b/frontends/main/src/app-pages/DepartmentListingPage/DepartmentListingPage.tsx
@@ -30,6 +30,7 @@ import { HOME } from "@/common/urls"
 import backgroundSteps from "@/public/images/backgrounds/background_steps.jpg"
 import { aggregateProgramCounts, aggregateCourseCounts } from "@/common/utils"
 import { useChannelCounts } from "api/hooks/channels"
+import { usePostHog } from "posthog-js/react"
 
 const SCHOOL_ICONS: Record<string, React.ReactNode> = {
   // School of Architecture and Planning
@@ -128,6 +129,7 @@ const SchoolDepartments: React.FC<SchoolDepartmentProps> = ({
   programCounts,
   className,
 }) => {
+  const posthog = usePostHog()
   return (
     <section className={className}>
       <SchoolTitle>
@@ -152,6 +154,9 @@ const SchoolDepartments: React.FC<SchoolDepartmentProps> = ({
                   department.channel_url &&
                   new URL(department.channel_url).pathname
                 }
+                onClick={() => {
+                  posthog.capture("department_link_clicked", { department })
+                }}
               >
                 <ListItemText
                   primary={department.name}

--- a/frontends/main/src/app-pages/TopicsListingPage/TopicsListingPage.tsx
+++ b/frontends/main/src/app-pages/TopicsListingPage/TopicsListingPage.tsx
@@ -22,6 +22,7 @@ import { HOME } from "@/common/urls"
 import { aggregateProgramCounts, aggregateCourseCounts } from "@/common/utils"
 import { useChannelCounts } from "api/hooks/channels"
 import backgroundSteps from "@/public/images/backgrounds/background_steps.jpg"
+import { usePostHog } from "posthog-js/react"
 
 type ChannelSummary = {
   id: number | string
@@ -124,11 +125,15 @@ const TopicBox = ({
   courseCount,
   programCount,
 }: TopicBoxProps) => {
+  const posthog = usePostHog()
   const counts = [
     { label: "Courses", count: courseCount },
     { label: "Programs", count: programCount },
   ].filter((item) => item.count)
   const { title, href, icon, channels } = topicGroup
+  const captureTopicClicked = (topic: string) => {
+    posthog.capture("topic_clicked", { topic })
+  }
 
   return (
     <li className={className}>
@@ -148,6 +153,9 @@ const TopicBox = ({
               variant="outlinedWhite"
               key={c.id}
               href={c.channel_url && new URL(c.channel_url).pathname}
+              onClick={() => {
+                captureTopicClicked(c.name)
+              }}
               label={c.name}
             />
           ))}
@@ -159,6 +167,9 @@ const TopicBox = ({
               variant="outlinedWhite"
               key={c.id}
               href={c.channel_url && new URL(c.channel_url).pathname}
+              onClick={() => {
+                captureTopicClicked(c.name)
+              }}
               label={c.name}
             />
           ))}

--- a/frontends/main/src/app-pages/TopicsListingPage/TopicsListingPage.tsx
+++ b/frontends/main/src/app-pages/TopicsListingPage/TopicsListingPage.tsx
@@ -132,7 +132,9 @@ const TopicBox = ({
   ].filter((item) => item.count)
   const { title, href, icon, channels } = topicGroup
   const captureTopicClicked = (topic: string) => {
-    posthog.capture("topic_clicked", { topic })
+    if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+      posthog.capture("topic_clicked", { topic })
+    }
   }
 
   return (

--- a/frontends/main/src/app-pages/TopicsListingPage/TopicsListingPage.tsx
+++ b/frontends/main/src/app-pages/TopicsListingPage/TopicsListingPage.tsx
@@ -154,7 +154,7 @@ const TopicBox = ({
               key={c.id}
               href={c.channel_url && new URL(c.channel_url).pathname}
               onClick={() => {
-                captureTopicClicked(c.name)
+                captureTopicClicked(title)
               }}
               label={c.name}
             />
@@ -168,7 +168,7 @@ const TopicBox = ({
               key={c.id}
               href={c.channel_url && new URL(c.channel_url).pathname}
               onClick={() => {
-                captureTopicClicked(c.name)
+                captureTopicClicked(title)
               }}
               label={c.name}
             />

--- a/frontends/main/src/app-pages/UnitsListingPage/UnitCard.tsx
+++ b/frontends/main/src/app-pages/UnitsListingPage/UnitCard.tsx
@@ -131,7 +131,9 @@ const UnitCard: React.FC<UnitCardProps> = (props) => {
               <Link
                 href={href}
                 onClick={() => {
-                  posthog.capture("provider_link_clicked", { provider: unit })
+                  if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+                    posthog.capture("provider_link_clicked", { provider: unit })
+                  }
                 }}
                 data-card-link
               >

--- a/frontends/main/src/app-pages/UnitsListingPage/UnitCard.tsx
+++ b/frontends/main/src/app-pages/UnitsListingPage/UnitCard.tsx
@@ -10,6 +10,7 @@ import {
   UnitLogo,
 } from "ol-components"
 import Link from "next/link"
+import { usePostHog } from "posthog-js/react"
 
 const CardStyled = styled(Card)({
   height: "100%",
@@ -114,6 +115,7 @@ interface UnitCardProps {
 }
 
 const UnitCard: React.FC<UnitCardProps> = (props) => {
+  const posthog = usePostHog()
   const { channel, courseCount, programCount } = props
   const unit = channel.unit_detail.unit
 
@@ -126,7 +128,13 @@ const UnitCard: React.FC<UnitCardProps> = (props) => {
         <UnitCardContainer>
           <UnitCardContent>
             <LogoContainer>
-              <Link href={href} data-card-link>
+              <Link
+                href={href}
+                onClick={() => {
+                  posthog.capture("provider_link_clicked", { provider: unit })
+                }}
+                data-card-link
+              >
                 <UnitLogo unitCode={unit.code as OfferedByEnum} height={50} />
               </Link>
             </LogoContainer>

--- a/frontends/main/src/page-components/Header/Header.tsx
+++ b/frontends/main/src/page-components/Header/Header.tsx
@@ -37,6 +37,7 @@ import {
   SEARCH_LEARNING_MATERIAL,
 } from "@/common/urls"
 import { useUserMe } from "api/hooks/user"
+import { usePostHog } from "posthog-js/react"
 
 const Bar = styled(AppBar)(({ theme }) => ({
   padding: "16px 8px",
@@ -187,6 +188,7 @@ const navData: NavData = {
           description:
             "Single courses on a specific subject, taught by MIT instructors",
           href: SEARCH_COURSE,
+          posthogEvent: "clicked_nav_browse_courses",
         },
         {
           title: "Programs",
@@ -194,6 +196,7 @@ const navData: NavData = {
           description:
             "A series of courses for in-depth learning across a range of topics",
           href: SEARCH_PROGRAM,
+          posthogEvent: "clicked_nav_browse_programs",
         },
         {
           title: "Learning Materials",
@@ -201,6 +204,7 @@ const navData: NavData = {
           description:
             "Free learning and teaching materials, including videos, podcasts, lecture notes, and more",
           href: SEARCH_LEARNING_MATERIAL,
+          posthogEvent: "clicked_nav_browse_learning_materials",
         },
       ],
     },
@@ -211,16 +215,19 @@ const navData: NavData = {
           title: "By Topic",
           icon: <RiPresentationLine />,
           href: TOPICS,
+          posthogEvent: "clicked_nav_browse_topics",
         },
         {
           title: "By Department",
           icon: <RiNodeTree />,
           href: DEPARTMENTS,
+          posthogEvent: "clicked_nav_browse_departments",
         },
         {
           title: "By Provider",
           icon: <RiVerifiedBadgeLine />,
           href: UNITS,
+          posthogEvent: "clicked_nav_browse_providers",
         },
       ],
     },
@@ -231,26 +238,31 @@ const navData: NavData = {
           title: "Recently Added",
           icon: <RiFileAddLine />,
           href: SEARCH_NEW,
+          posthogEvent: "clicked_nav_browse_new",
         },
         {
           title: "Upcoming",
           icon: <RiTimeLine />,
           href: SEARCH_UPCOMING,
+          posthogEvent: "clicked_nav_browse_upcoming",
         },
         {
           title: "Popular",
           href: SEARCH_POPULAR,
           icon: <RiHeartLine />,
+          posthogEvent: "clicked_nav_browse_popular",
         },
         {
           title: "Free",
           icon: <RiPriceTag3Line />,
           href: SEARCH_FREE,
+          posthogEvent: "clicked_nav_browse_free",
         },
         {
           title: "With Certificate",
           icon: <RiAwardLine />,
           href: SEARCH_CERTIFICATE,
+          posthogEvent: "clicked_nav_browse_certificate",
         },
       ],
     },
@@ -258,6 +270,7 @@ const navData: NavData = {
 }
 
 const Header: FunctionComponent = () => {
+  const posthog = usePostHog()
   const [drawerOpen, toggleDrawer] = useToggle(false)
   const desktopTrigger = React.useRef<HTMLButtonElement>(null)
   const mobileTrigger = React.useRef<HTMLButtonElement>(null)
@@ -293,6 +306,9 @@ const Header: FunctionComponent = () => {
         navData={navData}
         open={drawerOpen}
         onClose={toggleDrawer.off}
+        posthogCapture={(event: string) => {
+          posthog.capture(event)
+        }}
       />
     </div>
   )

--- a/frontends/main/src/page-components/Header/Header.tsx
+++ b/frontends/main/src/page-components/Header/Header.tsx
@@ -277,6 +277,15 @@ const Header: FunctionComponent = () => {
   const drawerToggleEvent = drawerOpen
     ? "opened_nav_drawer"
     : "closed_nav_drawer"
+  const posthogCapture = (event: string) => {
+    if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+      posthog.capture(event)
+    }
+  }
+  const menuClick = () => {
+    toggleDrawer.toggle()
+    posthogCapture(drawerToggleEvent)
+  }
 
   return (
     <div>
@@ -288,24 +297,11 @@ const Header: FunctionComponent = () => {
             <MenuButton
               ref={desktopTrigger}
               text="Explore MIT"
-              onClick={() => {
-                toggleDrawer.toggle()
-                if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
-                  posthog.capture(drawerToggleEvent)
-                }
-              }}
+              onClick={menuClick}
             />
           </DesktopOnly>
           <MobileOnly>
-            <MenuButton
-              ref={mobileTrigger}
-              onClick={() => {
-                toggleDrawer.toggle()
-                if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
-                  posthog.capture(drawerToggleEvent)
-                }
-              }}
-            />
+            <MenuButton ref={mobileTrigger} onClick={menuClick} />
             <LeftSpacer />
             <StyledMITLogoLink logo="learn" />
           </MobileOnly>
@@ -322,11 +318,7 @@ const Header: FunctionComponent = () => {
         navData={navData}
         open={drawerOpen}
         onClose={toggleDrawer.off}
-        posthogCapture={(event: string) => {
-          if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
-            posthog.capture(event)
-          }
-        }}
+        posthogCapture={posthogCapture}
       />
     </div>
   )

--- a/frontends/main/src/page-components/Header/Header.tsx
+++ b/frontends/main/src/page-components/Header/Header.tsx
@@ -290,7 +290,9 @@ const Header: FunctionComponent = () => {
               text="Explore MIT"
               onClick={() => {
                 toggleDrawer.toggle()
-                posthog.capture(drawerToggleEvent)
+                if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+                  posthog.capture(drawerToggleEvent)
+                }
               }}
             />
           </DesktopOnly>
@@ -299,7 +301,9 @@ const Header: FunctionComponent = () => {
               ref={mobileTrigger}
               onClick={() => {
                 toggleDrawer.toggle()
-                posthog.capture(drawerToggleEvent)
+                if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+                  posthog.capture(drawerToggleEvent)
+                }
               }}
             />
             <LeftSpacer />
@@ -319,7 +323,9 @@ const Header: FunctionComponent = () => {
         open={drawerOpen}
         onClose={toggleDrawer.off}
         posthogCapture={(event: string) => {
-          posthog.capture(event)
+          if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+            posthog.capture(event)
+          }
         }}
       />
     </div>

--- a/frontends/main/src/page-components/Header/Header.tsx
+++ b/frontends/main/src/page-components/Header/Header.tsx
@@ -274,6 +274,9 @@ const Header: FunctionComponent = () => {
   const [drawerOpen, toggleDrawer] = useToggle(false)
   const desktopTrigger = React.useRef<HTMLButtonElement>(null)
   const mobileTrigger = React.useRef<HTMLButtonElement>(null)
+  const drawerToggleEvent = drawerOpen
+    ? "opened_nav_drawer"
+    : "closed_nav_drawer"
 
   return (
     <div>
@@ -285,11 +288,20 @@ const Header: FunctionComponent = () => {
             <MenuButton
               ref={desktopTrigger}
               text="Explore MIT"
-              onClick={toggleDrawer.toggle}
+              onClick={() => {
+                toggleDrawer.toggle()
+                posthog.capture(drawerToggleEvent)
+              }}
             />
           </DesktopOnly>
           <MobileOnly>
-            <MenuButton ref={mobileTrigger} onClick={toggleDrawer.toggle} />
+            <MenuButton
+              ref={mobileTrigger}
+              onClick={() => {
+                toggleDrawer.toggle()
+                posthog.capture(drawerToggleEvent)
+              }}
+            />
             <LeftSpacer />
             <StyledMITLogoLink logo="learn" />
           </MobileOnly>

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
@@ -63,7 +63,9 @@ const DrawerContent: React.FC<{
    */
   const posthog = usePostHog()
   const resource = useLearningResourcesDetail(Number(resourceId))
-  posthog.capture("lrd_open", { resource: resource?.data })
+  if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+    posthog.capture("lrd_open", { resource: resource?.data })
+  }
   const [signupEl, setSignupEl] = React.useState<HTMLElement | null>(null)
   const { data: user } = useUserMe()
   const { data: inLearningPath } = useIsLearningPathMember(resourceId)

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
@@ -61,7 +61,9 @@ const DrawerContent: React.FC<{
    *   The triggering component likely has the data already via some other API
    *   call.
    */
+  const posthog = usePostHog()
   const resource = useLearningResourcesDetail(Number(resourceId))
+  posthog.capture("lrd_open", { resource: resource?.data })
   const [signupEl, setSignupEl] = React.useState<HTMLElement | null>(null)
   const { data: user } = useUserMe()
   const { data: inLearningPath } = useIsLearningPathMember(resourceId)

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceExpanded.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceExpanded.tsx
@@ -549,8 +549,14 @@ const CallToActionSection = ({
           endIcon={<RiExternalLinkLine />}
           href={resource.url || ""}
           onClick={() => {
-            posthog.capture("cta_clicked", { resource })
+            if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+              posthog.capture("cta_clicked", { resource })
+            }
           }}
+          data-ph-action="click-cta"
+          data-ph-offered-by={offeredBy?.code}
+          data-ph-resource-type={resource.resource_type}
+          data-ph-resource-id={resource.id}
         >
           {cta}
         </StyledLink>

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceExpanded.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceExpanded.tsx
@@ -36,6 +36,7 @@ import {
 import InfoSection from "./InfoSection"
 import type { User } from "api/hooks/user"
 import VideoFrame from "./VideoFrame"
+import { usePostHog } from "posthog-js/react"
 
 const DRAWER_WIDTH = "900px"
 
@@ -508,6 +509,7 @@ const CallToActionSection = ({
   onAddToLearningPathClick?: LearningResourceCardProps["onAddToLearningPathClick"]
   onAddToUserListClick?: LearningResourceCardProps["onAddToUserListClick"]
 }) => {
+  const posthog = usePostHog()
   const [shareExpanded, setShareExpanded] = useState(false)
   const [copyText, setCopyText] = useState("Copy Link")
   if (hide) {
@@ -544,12 +546,11 @@ const CallToActionSection = ({
         <StyledLink
           target="_blank"
           size="medium"
-          data-ph-action="click-cta"
-          data-ph-offered-by={offeredBy?.code}
-          data-ph-resource-type={resource.resource_type}
-          data-ph-resource-id={resource.id}
           endIcon={<RiExternalLinkLine />}
           href={resource.url || ""}
+          onClick={() => {
+            posthog.capture("cta_clicked", { resource })
+          }}
         >
           {cta}
         </StyledLink>

--- a/frontends/ol-components/src/components/Chips/ChipLink.tsx
+++ b/frontends/ol-components/src/components/Chips/ChipLink.tsx
@@ -6,7 +6,7 @@ import type { ChipProps } from "@mui/material/Chip"
 
 type ChipLinkProps = { href: string } & Pick<
   ChipProps<typeof Link>,
-  "label" | "disabled" | "className" | "variant" | "size" | "icon"
+  "label" | "disabled" | "className" | "variant" | "size" | "icon" | "onClick"
 >
 
 /**
@@ -15,8 +15,15 @@ type ChipLinkProps = { href: string } & Pick<
  * See https://mui.com/material-ui/react-chip/#clickable-link
  */
 const ChipLink = React.forwardRef<HTMLAnchorElement, ChipLinkProps>(
-  ({ href, ...others }, ref) => (
-    <Chip {...others} ref={ref} component={Link} href={href || ""} clickable />
+  ({ href, onClick, ...others }, ref) => (
+    <Chip
+      {...others}
+      ref={ref}
+      component={Link}
+      href={href || ""}
+      onClick={onClick}
+      clickable
+    />
   ),
 )
 

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.test.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.test.tsx
@@ -5,6 +5,8 @@ import React from "react"
 import Image from "next/image"
 import { renderWithTheme } from "../../test-utils"
 
+const mockedPostHogCapture = jest.fn()
+
 describe("NavDrawer", () => {
   it("Renders the expected drawer contents", () => {
     const navData: NavData = {
@@ -40,7 +42,14 @@ describe("NavDrawer", () => {
       ],
     }
     renderWithTheme(
-      <NavDrawer onClose={jest.fn()} navData={navData} open={true} />,
+      <NavDrawer
+        onClose={jest.fn()}
+        navData={navData}
+        open={true}
+        posthogCapture={(event: string) => {
+          mockedPostHogCapture(event)
+        }}
+      />,
     )
     const links = screen.getAllByTestId("nav-link")
     const icons = screen.getAllByTestId("nav-link-icon")
@@ -80,7 +89,14 @@ describe("NavDrawer", () => {
   test("close button calls onClose", async () => {
     const onClose = jest.fn()
     renderWithTheme(
-      <NavDrawer onClose={onClose} navData={NAV_DATA} open={true} />,
+      <NavDrawer
+        onClose={onClose}
+        posthogCapture={(event: string) => {
+          mockedPostHogCapture(event)
+        }}
+        navData={NAV_DATA}
+        open={true}
+      />,
     )
     const close = screen.getByRole("button", { name: "Close Navigation" })
     await user.click(close)
@@ -90,7 +106,14 @@ describe("NavDrawer", () => {
   test("escape calls onClose", async () => {
     const onClose = jest.fn()
     renderWithTheme(
-      <NavDrawer onClose={onClose} navData={NAV_DATA} open={true} />,
+      <NavDrawer
+        onClose={onClose}
+        posthogCapture={(event: string) => {
+          mockedPostHogCapture(event)
+        }}
+        navData={NAV_DATA}
+        open={true}
+      />,
     )
     const links = screen.getAllByRole("link")
     links[0].focus()
@@ -107,6 +130,9 @@ describe("NavDrawer", () => {
           <NavDrawer
             getClickAwayExcluded={() => [excluded.current]}
             onClose={onClose}
+            posthogCapture={(event: string) => {
+              mockedPostHogCapture(event)
+            }}
             navData={NAV_DATA}
             open={true}
           />
@@ -131,7 +157,14 @@ describe("NavDrawer", () => {
   test("clicking a link navigates and closes the drawer", async () => {
     const onClose = jest.fn()
     renderWithTheme(
-      <NavDrawer onClose={onClose} navData={NAV_DATA} open={true} />,
+      <NavDrawer
+        onClose={onClose}
+        posthogCapture={(event: string) => {
+          mockedPostHogCapture(event)
+        }}
+        navData={NAV_DATA}
+        open={true}
+      />,
     )
 
     const link = screen.getByRole("link", { name: "Title 1 Description 1" })

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
@@ -187,6 +187,7 @@ const NavDrawer = ({
           if (item.posthogEvent) {
             posthogCapture(item.posthogEvent)
           }
+          onClose()
         }}
       />
     ))

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
@@ -122,6 +122,7 @@ interface NavItem {
   icon?: ReactElement
   description?: string
   href: string
+  posthogEvent: string
 }
 
 type NavItemProps = NavItem & {
@@ -163,12 +164,14 @@ type NavDrawerProps = {
    * on click-away
    */
   getClickAwayExcluded?: () => (Element | null)[]
+  posthogCapture: (event: string) => void
 } & DrawerProps
 
 const NavDrawer = ({
   navData,
   onClose,
   getClickAwayExcluded = () => [],
+  posthogCapture,
   ...others
 }: NavDrawerProps) => {
   const navSections = navData.sections.map((section, i) => {
@@ -179,7 +182,10 @@ const NavDrawer = ({
         icon={item.icon}
         description={item.description}
         href={item.href}
-        onClick={onClose}
+        posthogEvent={item.posthogEvent}
+        onClick={() => {
+          posthogCapture(item.posthogEvent)
+        }}
       />
     ))
     return (

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
@@ -164,7 +164,7 @@ type NavDrawerProps = {
    * on click-away
    */
   getClickAwayExcluded?: () => (Element | null)[]
-  posthogCapture: (event: string) => void
+  posthogCapture?: (event: string) => void
 } & DrawerProps
 
 const NavDrawer = ({
@@ -184,7 +184,7 @@ const NavDrawer = ({
         href={item.href}
         posthogEvent={item.posthogEvent}
         onClick={() => {
-          if (item.posthogEvent) {
+          if (item.posthogEvent && posthogCapture) {
             posthogCapture(item.posthogEvent)
           }
           onClose()

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
@@ -122,7 +122,7 @@ interface NavItem {
   icon?: ReactElement
   description?: string
   href: string
-  posthogEvent: string
+  posthogEvent?: string
 }
 
 type NavItemProps = NavItem & {
@@ -184,7 +184,9 @@ const NavDrawer = ({
         href={item.href}
         posthogEvent={item.posthogEvent}
         onClick={() => {
-          posthogCapture(item.posthogEvent)
+          if (item.posthogEvent) {
+            posthogCapture(item.posthogEvent)
+          }
         }}
       />
     ))


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6400

### Description (What does it do?)
This PR adds a number of custom Posthog events to track the "browse" workflow in the nav drawer. The following events were added:

- Opening / closing the nav drawer
- Clicking any link within the nav drawer
- Clicking a topic / department / unit on their respective listing pages
- Clicking a subtopic / related topic from a topic channel page
- Opening the learning resource drawer
- Clicking the CTA

### How can this be tested?
- Make sure you have Posthog configured and pointing at your own custom project
- Follow the flow described in the issue above multiple times to ensure that you have data for testing
- Go to your Posthog project's dashboard, then go to Product Analytics and create a new funnel
- Create funnels as described in the issue based on the flow described, starting with a Pageview at `/`, to indicate visiting the home page and using the new custom events added in this PR
- Ensure that you see data coming in from your test activity