### PR TITLE
reverse nav drawer posthog events

### DIFF
--- a/frontends/main/src/page-components/Header/Header.tsx
+++ b/frontends/main/src/page-components/Header/Header.tsx
@@ -275,8 +275,8 @@ const Header: FunctionComponent = () => {
   const desktopTrigger = React.useRef<HTMLButtonElement>(null)
   const mobileTrigger = React.useRef<HTMLButtonElement>(null)
   const drawerToggleEvent = drawerOpen
-    ? "opened_nav_drawer"
-    : "closed_nav_drawer"
+    ? "closed_nav_drawer"
+    : "opened_nav_drawer"
   const posthogCapture = (event: string) => {
     if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
       posthog.capture(event)

--- a/frontends/main/src/page-components/Header/Header.tsx
+++ b/frontends/main/src/page-components/Header/Header.tsx
@@ -317,7 +317,10 @@ const Header: FunctionComponent = () => {
         ]}
         navData={navData}
         open={drawerOpen}
-        onClose={toggleDrawer.off}
+        onClose={() => {
+          posthogCapture(drawerToggleEvent)
+          toggleDrawer.off()
+        }}
         posthogCapture={posthogCapture}
       />
     </div>


### PR DESCRIPTION
### What are the relevant tickets?
Follow up for https://github.com/mitodl/mit-learn/pull/1997

### Description (What does it do?)
In the above PR, a mistake was made that reversed the nav drawer events. When you open the drawer, the close drawer event was firing and vice versa.

### How can this be tested?
- Make sure you have Posthog configured and pointing at your own custom project
- Visit the site on any page and open your browser debugger to `Header.tsx`, setting a breakpoint at `posthog.capture(event)`
- Open and close the nav drawer, verifying that the proper event is being sent
