### PR TITLE
Better React Testing Library Errors

### DIFF
--- a/frontends/jest-shared-setup.ts
+++ b/frontends/jest-shared-setup.ts
@@ -85,7 +85,7 @@ afterEach(() => {
  *
  * However, method calls occurring in beforeEach hooks earlier or afterEach hooks
  * after this line will not error.
- * - beforeEach hooks declared earlier than this all
+ * - beforeEach hooks declared earlier than this call
  * - afterEach hooks declared later than this call
  */
 failOnConsole()

--- a/frontends/jest-shared-setup.ts
+++ b/frontends/jest-shared-setup.ts
@@ -1,7 +1,6 @@
 import failOnConsole from "jest-fail-on-console"
 import "@testing-library/jest-dom"
 import "cross-fetch/polyfill"
-import { configure } from "@testing-library/react"
 import { resetAllWhenMocks } from "jest-when"
 import * as matchers from "jest-extended"
 import { mockRouter } from "ol-test-utilities/mocks/nextNavigation"
@@ -59,25 +58,6 @@ const polyfillResizeObserver = () => {
 }
 polyfillResizeObserver()
 
-failOnConsole()
-
-configure({
-  /**
-   * Adapted from https://github.com/testing-library/dom-testing-library/issues/773
-   * to make the error messages a bit more succinct.
-   *
-   * By default, testing-library prints much too much of the DOM.
-   *
-   * This does change the stacktrace a bit: The line causing the error is still
-   * there, but the line where the error is generated (below) is most visible.
-   */
-  getElementError(message, _container) {
-    const error = new Error(message ?? "")
-    error.name = "TestingLibraryElementError"
-    return error
-  },
-})
-
 jest.mock("next/navigation", () => {
   return {
     ...jest.requireActual("ol-test-utilities/mocks/nextNavigation")
@@ -85,6 +65,10 @@ jest.mock("next/navigation", () => {
   }
 })
 
+beforeEach(() => {
+  mockRouter.setCurrentUrl("/")
+  window.history.replaceState({}, "", "/")
+})
 afterEach(() => {
   /**
    * Clear all mock call counts between tests.
@@ -93,6 +77,15 @@ afterEach(() => {
    */
   jest.clearAllMocks()
   resetAllWhenMocks()
-  mockRouter.setCurrentUrl("/")
-  window.history.replaceState({}, "", "/")
 })
+
+/**
+ * NOTE: This registers hooks (afterEach, etc) with Jest that cause tests to
+ * fail when console.warn or console.error are called.
+ *
+ * However, method calls occurring in beforeEach hooks earlier or afterEach hooks
+ * after this line will not error.
+ * - beforeEach hooks declared earlier than this all
+ * - afterEach hooks declared later than this call
+ */
+failOnConsole()


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This PR makes the errors from `@testing-library/react` unfound matchers slightly better. In particular:

**Before:**
<img width="1185" alt="Screenshot 2025-01-30 at 11 53 19 AM" src="https://github.com/user-attachments/assets/40181568-6866-4d27-81b5-349d3b60c77a" />

**After**
<img width="1252" alt="Screenshot 2025-01-30 at 11 50 41 AM" src="https://github.com/user-attachments/assets/4f9743cc-a540-4c89-9cdf-1533297f0880" />

### How can this be tested?
Tests should pass.

If you want to see the behavior change, you can add a fake error to a test file, e.g.,
```ts
// ResourceCard.test.tsx
  test.only("Applies className to the resource card", () => {
    const { view } = setup({ user: {}, props: { className: "test-class" } })
    expect(view.container.firstChild).toHaveClass("test-class")
    screen.getByRole("button", { name: "Fake Element" })
  })
```
and run `yarn test frontends/main/src/page-components/ResourceCard/ResourceCard.test.tsx` on this branch vs `main`.


