### PR TITLE
Fix support for hardware accelerated embedding generation via ollama

### DIFF
--- a/docs/how-to/embeddings.md
+++ b/docs/how-to/embeddings.md
@@ -52,17 +52,17 @@ To get setup:
 
 ```
 QDRANT_ENCODER=vector_search.encoders.litellm.LiteLLMEncoder
-LITELLM_API_BASE=http://docker.for.mac.host.internal:11434
+LITELLM_API_BASE=http://docker.for.mac.host.internal:11434/v1/
 QDRANT_DENSE_MODEL=<ollama model name>
 ```
 
-_Note_ - "LITELLM_API_BASE=http://docker.for.mac.host.internal:11434" is Mac specific - if you are using another OS you will need to figure out what your host machine's docker address is.
+_Note_ - "LITELLM_API_BASE=http://docker.for.mac.host.internal:11434/v1/" is Mac specific - if you are using another OS you will need to figure out what your host machine's docker address is.
 
 Sample .env file configuration on Mac:
 
 ```
 QDRANT_ENCODER=vector_search.encoders.litellm.LiteLLMEncoder
-LITELLM_API_BASE=http://docker.for.mac.host.internal:11434
+LITELLM_API_BASE=http://docker.for.mac.host.internal:11434/v1/
 QDRANT_DENSE_MODEL=all-minilm
 ```
 

--- a/main/settings.py
+++ b/main/settings.py
@@ -816,7 +816,7 @@ QDRANT_ENCODER = get_string(
 LITELLM_TOKEN_ENCODING_NAME = get_string(
     name="LITELLM_TOKEN_ENCODING_NAME", default=None
 )
-LITELLM_CUSTOM_PROVIDER = get_string(name="LITELLM_CUSTOM_PROVIDER", default="ollama")
+LITELLM_CUSTOM_PROVIDER = get_string(name="LITELLM_CUSTOM_PROVIDER", default="openai")
 LITELLM_API_BASE = get_string(name="LITELLM_API_BASE", default=None)
 
 

--- a/vector_search/encoders/litellm.py
+++ b/vector_search/encoders/litellm.py
@@ -28,11 +28,12 @@ class LiteLLMEncoder(BaseEncoder):
         return [result["embedding"] for result in self.get_embedding(documents)["data"]]
 
     def get_embedding(self, texts):
-        if settings.LITELLM_CUSTOM_PROVIDER and settings.LITELLM_API_BASE:
-            return embedding(
-                model=self.model_name,
-                input=texts,
-                api_base=settings.LITELLM_API_BASE,
-                custom_llm_provider=settings.LITELLM_CUSTOM_PROVIDER,
-            ).to_dict()
-        return embedding(model=self.model_name, input=texts).to_dict()
+        config = {
+            "model": self.model_name,
+            "input": texts,
+        }
+        if settings.LITELLM_CUSTOM_PROVIDER:
+            config["custom_llm_provider"] = settings.LITELLM_CUSTOM_PROVIDER
+        if settings.LITELLM_API_BASE:
+            config["api_base"] = settings.LITELLM_API_BASE
+        return embedding(**config).to_dict()


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/6649
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR re-enables support for using ollama as an embedding provider. initial support for this was broken during a recent update of litellm - see [ticket](https://github.com/BerriAI/litellm/issues/7332).  Someone posted a workaround of using the openai compatable endpoint which seems to work.


### How can this be tested?
1. Checkout this branch
2. Follow the updated instructions [in the docs on this branch](https://github.com/BerriAI/litellm/issues/7332)

