### PR TITLE
Remove imports for builtin django User model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ storybook-static/
 
 /**/.yarn/cache
 .swc
+
+# ignore local ssl certs
+certs/

--- a/channels/api.py
+++ b/channels/api.py
@@ -1,10 +1,17 @@
 """API for channels"""
 
-from django.contrib.auth.models import Group, User
+from typing import TYPE_CHECKING
+
+from django.contrib.auth.models import Group
 from django.db import transaction
 
 from channels.constants import CHANNEL_ROLE_CHOICES, CHANNEL_ROLE_MODERATORS
 from channels.models import Channel, ChannelGroupRole
+
+if TYPE_CHECKING:
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
 
 
 def create_channel_groups_and_roles(
@@ -31,14 +38,14 @@ def get_role_model(channel: Channel, role: str) -> ChannelGroupRole:
     return ChannelGroupRole.objects.get(channel=channel, role=role)
 
 
-def add_user_role(channel: Channel, role: str, user: User):
+def add_user_role(channel: Channel, role: str, user: "User"):
     """
     Add a user to a channel role's group
     """
     get_role_model(channel, role).group.user_set.add(user)
 
 
-def remove_user_role(channel: Channel, role: str, user: User):
+def remove_user_role(channel: Channel, role: str, user: "User"):
     """
     Remove a user from a channel role's group
     """
@@ -51,7 +58,7 @@ def get_group_role_name(channel_id: int, role: str) -> str:
     return f"channel_{channel_name}_{role}"
 
 
-def is_moderator(user: User, channel_id: int) -> bool:
+def is_moderator(user: "User", channel_id: int) -> bool:
     """
     Determine if the user is a moderator for a channel (or a staff user)
     """

--- a/channels/views.py
+++ b/channels/views.py
@@ -3,7 +3,7 @@
 import logging
 
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.db.models import Prefetch
 from django.utils.decorators import method_decorator
 from django_filters.rest_framework import DjangoFilterBackend
@@ -169,6 +169,8 @@ class ChannelModeratorListView(ListCreateAPIView):
         """
         Build a queryset of relevant users with moderator permissions for this channel
         """
+        User = get_user_model()
+
         channel_group_name = get_group_role_name(
             self.kwargs["id"],
             CHANNEL_ROLE_MODERATORS,
@@ -190,6 +192,8 @@ class ChannelModeratorDetailView(APIView):
 
     def delete(self, request, *args, **kwargs):  # noqa: ARG002
         """Remove the user from the moderator groups for this website"""
+        User = get_user_model()
+
         user = User.objects.get(username=self.kwargs["moderator_name"])
         remove_user_role(
             Channel.objects.get(id=self.kwargs["id"]), CHANNEL_ROLE_MODERATORS, user

--- a/channels/views_test.py
+++ b/channels/views_test.py
@@ -5,7 +5,8 @@ import random
 from math import ceil
 
 import pytest
-from django.contrib.auth.models import Group, User
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 from django.urls import reverse
 
 from channels.api import add_user_role
@@ -25,6 +26,8 @@ from learning_resources.factories import (
 from main.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
+
+User = get_user_model()
 
 
 def test_list_channels(user_client):

--- a/learning_resources/management/commands/backpopulate_favorites_lists.py
+++ b/learning_resources/management/commands/backpopulate_favorites_lists.py
@@ -1,6 +1,6 @@
 """Management command to create user Favorites lists"""
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.core.management import BaseCommand
 
 from learning_resources.constants import FAVORITES_TITLE
@@ -24,6 +24,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):  # noqa: ARG002
         """Create a Favorites userlist for every active user"""
+        User = get_user_model()
+
         if options["delete"]:
             self.stdout.write("Deleting all existing Favorites userlists")
             UserList.objects.filter(title=FAVORITES_TITLE).delete()

--- a/learning_resources/management/commands/populate_featured_lists.py
+++ b/learning_resources/management/commands/populate_featured_lists.py
@@ -3,7 +3,7 @@
 import sys
 
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.core.management import BaseCommand
 
 from channels.models import Channel
@@ -17,6 +17,8 @@ from learning_resources.models import (
     LearningResourceOfferor,
 )
 from main.utils import clear_search_cache, now_in_utc
+
+User = get_user_model()
 
 
 class Command(BaseCommand):

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -3,9 +3,9 @@
 import uuid
 from abc import abstractmethod
 from functools import cached_property
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from django.contrib.auth.models import User
+from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.db.models import CharField, Count, JSONField, OuterRef, Prefetch, Q
@@ -24,6 +24,11 @@ from learning_resources.constants import (
     PrivacyLevel,
 )
 from main.models import TimestampedModel, TimestampedModelQuerySet
+
+if TYPE_CHECKING:
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
 
 
 def default_delivery():
@@ -328,7 +333,7 @@ class LearningResourceInstructor(TimestampedModel):
 class LearningResourceQuerySet(TimestampedModelQuerySet):
     """QuerySet for LearningResource"""
 
-    def for_serialization(self, *, user: User | None = None):
+    def for_serialization(self, *, user: Optional["User"] = None):
         """Return the list of prefetches"""
         return (
             self.prefetch_related(
@@ -792,7 +797,9 @@ class LearningPath(LearningResourceDetailModel):
         on_delete=models.CASCADE,
     )
     author = models.ForeignKey(
-        User, related_name="learning_paths", on_delete=models.PROTECT
+        settings.AUTH_USER_MODEL,
+        related_name="learning_paths",
+        on_delete=models.PROTECT,
     )
 
     def __str__(self):
@@ -896,7 +903,9 @@ class UserList(TimestampedModel):
     """
 
     author = models.ForeignKey(
-        User, on_delete=models.deletion.CASCADE, related_name="user_lists"
+        settings.AUTH_USER_MODEL,
+        on_delete=models.deletion.CASCADE,
+        related_name="user_lists",
     )
     title = models.CharField(max_length=256)
     description = models.TextField(default="", blank=True)

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -4,7 +4,7 @@ import logging
 from decimal import Decimal
 from uuid import uuid4
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.db.models import F, Max
 from drf_spectacular.utils import extend_schema_field
@@ -845,6 +845,8 @@ class UserListSerializer(serializers.ModelSerializer, WriteableTopicsMixin):
 
     def create(self, validated_data):
         """Create a new user list"""
+        User = get_user_model()
+
         request = self.context.get("request")
         if request and hasattr(request, "user") and isinstance(request.user, User):
             validated_data["author"] = request.user

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -2,13 +2,14 @@
 
 import logging
 import re
+from typing import TYPE_CHECKING
 
 import rapidjson
 import requests
 import yaml
 from botocore.exceptions import ClientError
 from django.conf import settings
-from django.contrib.auth.models import Group, User
+from django.contrib.auth.models import Group
 from django.db import transaction
 from django.db.models import Q
 from retry import retry
@@ -32,6 +33,11 @@ from learning_resources.models import (
 from main.utils import generate_filepath
 
 log = logging.getLogger()
+
+if TYPE_CHECKING:
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
 
 
 def user_list_image_upload_uri(instance, filename):
@@ -229,7 +235,7 @@ def parse_instructors(staff):
     return instructors
 
 
-def update_editor_group(user: User, is_editor: False):
+def update_editor_group(user: "User", is_editor: False):
     """Assign or unassign user to staff list editors group"""
     group, _ = Group.objects.get_or_create(name=GROUP_STAFF_LISTS_EDITORS)
     if is_editor:

--- a/main/factories.py
+++ b/main/factories.py
@@ -3,7 +3,7 @@ Factory for Users
 """
 
 import ulid
-from django.contrib.auth.models import Group, User
+from django.conf import settings
 from factory import LazyFunction, RelatedFactory, SubFactory, Trait
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyText
@@ -21,7 +21,7 @@ class UserFactory(DjangoModelFactory):
     profile = RelatedFactory("profiles.factories.ProfileFactory", "user")
 
     class Meta:
-        model = User
+        model = settings.AUTH_USER_MODEL
         skip_postgeneration_save = True
 
     class Params:
@@ -34,7 +34,7 @@ class GroupFactory(DjangoModelFactory):
     name = FuzzyText()
 
     class Meta:
-        model = Group
+        model = "auth.Group"
 
 
 class UserSocialAuthFactory(DjangoModelFactory):

--- a/main/settings.py
+++ b/main/settings.py
@@ -69,6 +69,8 @@ DEBUG = get_bool("DEBUG", False)  # noqa: FBT003
 
 ALLOWED_HOSTS = ["*"]
 
+AUTH_USER_MODEL = "auth.User"
+
 SECURE_SSL_REDIRECT = get_bool("MITOL_SECURE_SSL_REDIRECT", True)  # noqa: FBT003
 
 SITE_ID = 1

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -3,7 +3,6 @@
 from cairosvg import svg2png  # pylint:disable=no-name-in-module
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.models import User
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
@@ -137,6 +136,8 @@ def name_initials_avatar_view(
     bgcolor,
 ):  # pylint:disable=unused-argument
     """View for initial avatar"""
+    User = get_user_model()
+
     user = User.objects.filter(username=username).first()
     if not user:
         return redirect(DEFAULT_PROFILE_IMAGE)

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -5,7 +5,7 @@ import json
 
 import pytest
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework import status
 
@@ -24,6 +24,8 @@ from profiles.serializers import (
 from profiles.utils import DEFAULT_PROFILE_IMAGE, IMAGE_MEDIUM, IMAGE_SMALL, image_uri
 
 pytestmark = [pytest.mark.django_db]
+
+User = get_user_model()
 
 
 def test_list_users(staff_client, staff_user):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,9 @@ convention = "pep257"
 [tool.ruff.lint.flake8-quotes]
 inline-quotes = "double"
 
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"django.contrib.auth.models.User".msg = "use get_user_model() or settings.AUTH_USER_MODEL"
+
 [tool.ruff.lint.per-file-ignores]
 "*_test.py" = ["ARG001", "E501", "S101", "PLR2004"]
 "test_*.py" = ["ARG001", "E501", "S101", "PLR2004"]


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/6679

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Adds a lint to block direct importing of `django.contrib.auth.models.User`
- Replaces all such imports with `get_user_model()` or `settings.AUTH_USER_MODEL`

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
You should be able to run the app without issue.

You can also test the lint rule by adding an import to `django.contrib.auth.models.User` in any file and run `pre-commit run` and it should error.

You can observe that the initial commit for this PR that added this check failed for all of the existing usages: https://results.pre-commit.ci/run/github/672068771/1738783559.KuMD_PjETSqF69WSAV5Ufg