### PR TITLE
Skip existing embeddings

### DIFF
--- a/vector_search/constants.py
+++ b/vector_search/constants.py
@@ -1,8 +1,6 @@
 from django.conf import settings
-from django.contrib.auth.models import User
 from qdrant_client import models
 
-user = User()
 RESOURCES_COLLECTION_NAME = f"{settings.QDRANT_BASE_COLLECTION_NAME}.resources"
 CONTENT_FILES_COLLECTION_NAME = f"{settings.QDRANT_BASE_COLLECTION_NAME}.content_files"
 

--- a/vector_search/constants.py
+++ b/vector_search/constants.py
@@ -1,6 +1,8 @@
 from django.conf import settings
+from django.contrib.auth.models import User
 from qdrant_client import models
 
+user = User()
 RESOURCES_COLLECTION_NAME = f"{settings.QDRANT_BASE_COLLECTION_NAME}.resources"
 CONTENT_FILES_COLLECTION_NAME = f"{settings.QDRANT_BASE_COLLECTION_NAME}.content_files"
 

--- a/vector_search/management/commands/create_qdrant_collections.py
+++ b/vector_search/management/commands/create_qdrant_collections.py
@@ -3,7 +3,7 @@
 from django.core.management.base import BaseCommand
 
 from vector_search.utils import (
-    create_qdrand_collections,
+    create_qdrant_collections,
 )
 
 
@@ -26,8 +26,8 @@ class Command(BaseCommand):
         """Create Qdrant collections"""
 
         if options["force"]:
-            create_qdrand_collections(force_recreate=True)
+            create_qdrant_collections(force_recreate=True)
         else:
-            create_qdrand_collections(force_recreate=False)
+            create_qdrant_collections(force_recreate=False)
 
         self.stdout.write("Created Qdrant collections")

--- a/vector_search/management/commands/generate_embeddings.py
+++ b/vector_search/management/commands/generate_embeddings.py
@@ -42,6 +42,12 @@ class Command(BaseCommand):
             action="store_true",
             help="Skip embedding content files",
         )
+        parser.add_argument(
+            "--overwrite",
+            dest="overwrite",
+            action="store_true",
+            help="Force overwrite existing embeddings",
+        )
 
         for object_type in sorted(LEARNING_RESOURCE_TYPES):
             parser.add_argument(
@@ -79,10 +85,13 @@ class Command(BaseCommand):
                     for resource_id in options["resource-ids"].split(",")
                 ],
                 skip_content_files=options["skip_content_files"],
+                overwrite=options["overwrite"],
             )
         else:
             task = start_embed_resources.delay(
-                indexes_to_update, skip_content_files=options["skip_content_files"]
+                indexes_to_update,
+                skip_content_files=options["skip_content_files"],
+                overwrite=options["overwrite"],
             )
         self.stdout.write(
             f"Started celery task {task} to index content for the following"

--- a/vector_search/management/commands/generate_embeddings.py
+++ b/vector_search/management/commands/generate_embeddings.py
@@ -6,7 +6,7 @@ from learning_resources_search.constants import LEARNING_RESOURCE_TYPES
 from main.utils import clear_search_cache, now_in_utc
 from vector_search.tasks import embed_learning_resources_by_id, start_embed_resources
 from vector_search.utils import (
-    create_qdrand_collections,
+    create_qdrant_collections,
 )
 
 
@@ -77,7 +77,7 @@ class Command(BaseCommand):
                     self.stdout.write(f"  --{object_type}s")
                 return
         if options["recreate_collections"]:
-            create_qdrand_collections(force_recreate=True)
+            create_qdrant_collections(force_recreate=True)
         if options["resource-ids"]:
             task = embed_learning_resources_by_id.delay(
                 [

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -66,9 +66,11 @@ def test_start_embed_resources(mocker, mocked_celery, index):
     )
 
     with pytest.raises(mocked_celery.replace_exception_class):
-        start_embed_resources.delay([index], skip_content_files=True)
+        start_embed_resources.delay([index], skip_content_files=True, overwrite=True)
 
-    generate_embeddings_mock.si.assert_called_once_with(resource_ids, index)
+    generate_embeddings_mock.si.assert_called_once_with(
+        resource_ids, index, overwrite=True
+    )
     assert mocked_celery.replace.call_count == 1
     assert mocked_celery.replace.call_args[0][1] == mocked_celery.chain.return_value
 
@@ -101,7 +103,7 @@ def test_start_embed_resources_without_settings(mocker, mocked_celery, index):
     generate_embeddings_mock = mocker.patch(
         "vector_search.tasks.generate_embeddings", autospec=True
     )
-    start_embed_resources.delay([index], skip_content_files=True)
+    start_embed_resources.delay([index], skip_content_files=True, overwrite=True)
 
     generate_embeddings_mock.si.assert_not_called()
 
@@ -172,7 +174,9 @@ def test_embed_learning_resources_by_id(mocker, mocked_celery):
         content_ids.append(cf.id)
 
     with pytest.raises(mocked_celery.replace_exception_class):
-        embed_learning_resources_by_id.delay(resource_ids, skip_content_files=False)
+        embed_learning_resources_by_id.delay(
+            resource_ids, skip_content_files=False, overwrite=True
+        )
     for mock_call in generate_embeddings_mock.si.mock_calls[1:]:
         assert mock_call.args[0][0] in content_ids
         assert mock_call.args[1] == "content_file"

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -69,7 +69,9 @@ def test_start_embed_resources(mocker, mocked_celery, index):
         start_embed_resources.delay([index], skip_content_files=True, overwrite=True)
 
     generate_embeddings_mock.si.assert_called_once_with(
-        resource_ids, index, overwrite=True
+        resource_ids,
+        index,
+        True,  # noqa: FBT003
     )
     assert mocked_celery.replace.call_count == 1
     assert mocked_celery.replace.call_args[0][1] == mocked_celery.chain.return_value

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -307,11 +307,10 @@ def embed_learning_resources(ids, resource_type, overwrite):
 
     create_qdrand_collections(force_recreate=False)
     if resource_type != CONTENT_FILE_TYPE:
-        serialized_resources = serialize_bulk_learning_resources(ids)
+        serialized_resources = list(serialize_bulk_learning_resources(ids))
         existing_readable_ids = [
             serialized["readable_id"] for serialized in serialized_resources
         ]
-
         new_resource_ids = filter_existing_qdrant_points(
             values=existing_readable_ids,
             lookup_field="readable_id",
@@ -323,13 +322,14 @@ def embed_learning_resources(ids, resource_type, overwrite):
             if resource["readable_id"] in new_resource_ids
         ]
         collection_name = RESOURCES_COLLECTION_NAME
+
         points = _process_resource_embeddings(serialized_resources)
     else:
         serialized_resources = serialize_bulk_content_files(ids)
         collection_name = CONTENT_FILES_COLLECTION_NAME
         points = _process_content_embeddings(serialized_resources, overwrite)
-    if points:
-        client.upload_points(collection_name, points=points, wait=False)
+
+    client.upload_points(collection_name, points=points, wait=False)
 
 
 def _resource_vector_hits(search_result):

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -225,13 +225,6 @@ def _process_content_embeddings(serialized_content):
     for doc in serialized_content:
         if not doc.get("content"):
             continue
-        """
-        if not overwrite and document_exists(
-            {"key": doc["key"], "run_readable_id": doc["run_readable_id"]},
-            collection_name=CONTENT_FILES_COLLECTION_NAME,
-        ):
-            continue
-        """
         split_docs = _chunk_documents(encoder, [doc.get("content")], [doc])
         split_texts = [d.page_content for d in split_docs if d.page_content]
         resource_vector_point_id = vector_point_id(doc["resource_readable_id"])

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -322,14 +322,13 @@ def embed_learning_resources(ids, resource_type, overwrite):
             if resource["readable_id"] in new_resource_ids
         ]
         collection_name = RESOURCES_COLLECTION_NAME
-
         points = _process_resource_embeddings(serialized_resources)
     else:
         serialized_resources = serialize_bulk_content_files(ids)
         collection_name = CONTENT_FILES_COLLECTION_NAME
         points = _process_content_embeddings(serialized_resources, overwrite)
-
-    client.upload_points(collection_name, points=points, wait=False)
+    if points:
+        client.upload_points(collection_name, points=points, wait=False)
 
 
 def _resource_vector_hits(search_result):

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -63,7 +63,7 @@ def points_generator(
         yield models.PointStruct(id=idx, payload=payload, vector=point_vector)
 
 
-def create_qdrand_collections(force_recreate):
+def create_qdrant_collections(force_recreate):
     """
     Create or recreate QDrant collections
 
@@ -300,7 +300,7 @@ def embed_learning_resources(ids, resource_type, overwrite):
 
     client = qdrant_client()
 
-    create_qdrand_collections(force_recreate=False)
+    create_qdrant_collections(force_recreate=False)
     if resource_type != CONTENT_FILE_TYPE:
         serialized_resources = list(serialize_bulk_learning_resources(ids))
         points = [

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -35,8 +35,14 @@ def test_vector_point_id_used_for_embed(mocker, content_type):
         "vector_search.utils.qdrant_client",
         return_value=mock_qdrant,
     )
-
-    embed_learning_resources([resource.id for resource in resources], content_type)
+    if content_type == "learning_resource":
+        mocker.patch(
+            "vector_search.utils.filter_existing_qdrant_points",
+            return_value=[r.readable_id for r in resources],
+        )
+    embed_learning_resources(
+        [resource.id for resource in resources], content_type, overwrite=True
+    )
 
     if content_type == "learning_resource":
         point_ids = [vector_point_id(resource.readable_id) for resource in resources]
@@ -47,7 +53,6 @@ def test_vector_point_id_used_for_embed(mocker, content_type):
             )
             for resource in serialize_bulk_content_files([r.id for r in resources])
         ]
-
     assert sorted(
         [p.id for p in mock_qdrant.upload_points.mock_calls[0].kwargs["points"]]
     ) == sorted(point_ids)

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -13,7 +13,7 @@ from vector_search.constants import (
 from vector_search.encoders.utils import dense_encoder
 from vector_search.utils import (
     _chunk_documents,
-    create_qdrand_collections,
+    create_qdrant_collections,
     embed_learning_resources,
     filter_existing_qdrant_points,
     qdrant_query_conditions,
@@ -139,7 +139,7 @@ def test_filter_existing_qdrant_points(mocker):
     assert filtered_resources.count() == 7
 
 
-def test_force_create_qdrand_collections(mocker):
+def test_force_create_qdrant_collections(mocker):
     """
     Test that the force flag will recreate collections
     even if they exist
@@ -150,7 +150,7 @@ def test_force_create_qdrand_collections(mocker):
         return_value=mock_qdrant,
     )
     mock_qdrant.collection_exists.return_value = True
-    create_qdrand_collections(force_recreate=True)
+    create_qdrant_collections(force_recreate=True)
     assert (
         mock_qdrant.recreate_collection.mock_calls[0].kwargs["collection_name"]
         == RESOURCES_COLLECTION_NAME
@@ -169,7 +169,7 @@ def test_force_create_qdrand_collections(mocker):
     )
 
 
-def test_auto_create_qdrand_collections(mocker):
+def test_auto_create_qdrant_collections(mocker):
     """
     Test that collections will get autocreated if they
     don't exist
@@ -180,7 +180,7 @@ def test_auto_create_qdrand_collections(mocker):
         return_value=mock_qdrant,
     )
     mock_qdrant.collection_exists.return_value = False
-    create_qdrand_collections(force_recreate=False)
+    create_qdrant_collections(force_recreate=False)
     assert (
         mock_qdrant.recreate_collection.mock_calls[0].kwargs["collection_name"]
         == RESOURCES_COLLECTION_NAME
@@ -210,7 +210,7 @@ def test_skip_creating_qdrand_collections(mocker):
         return_value=mock_qdrant,
     )
     mock_qdrant.collection_exists.return_value = False
-    create_qdrand_collections(force_recreate=False)
+    create_qdrant_collections(force_recreate=False)
     assert (
         mock_qdrant.recreate_collection.mock_calls[0].kwargs["collection_name"]
         == RESOURCES_COLLECTION_NAME

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -73,14 +73,19 @@ def test_embed_learning_resources_no_overwrite(mocker, content_type):
     if content_type == "learning_resource":
         # filter out 3 resources that are already embedded
         mocker.patch(
-            "vector_search.utils.filter_existing_qdrant_points",
-            return_value=[r.readable_id for r in resources[0:2]],
+            "vector_search.utils.filter_existing_qdrant_points_by_ids",
+            return_value=[vector_point_id(r.readable_id) for r in resources[0:2]],
         )
     else:
         # all contentfiles exist in qdrant
         mocker.patch(
-            "vector_search.utils.document_exists",
-            return_value=True,
+            "vector_search.utils.filter_existing_qdrant_points_by_ids",
+            return_value=[
+                vector_point_id(
+                    f"{doc['resource_readable_id']}.{doc['run_readable_id']}.{doc['key']}.0"
+                )
+                for doc in serialize_bulk_content_files([r.id for r in resources[0:3]])
+            ],
         )
     embed_learning_resources(
         [resource.id for resource in resources], content_type, overwrite=False
@@ -88,7 +93,7 @@ def test_embed_learning_resources_no_overwrite(mocker, content_type):
     if content_type == "learning_resource":
         assert len(list(mock_qdrant.upload_points.mock_calls[0].kwargs["points"])) == 2
     else:
-        mock_qdrant.upload_points.assert_not_called()
+        assert len(list(mock_qdrant.upload_points.mock_calls[0].kwargs["points"])) == 3
 
 
 def test_filter_existing_qdrant_points(mocker):


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/6670


### Description (What does it do?)
This PR makes it so that the embedding generation for both learning resources and contentfiles skips over existing embeddings by default. We can force re-embed by passing the --overwrite flag to the generate_embeddngs command.

### How can this be tested?
1. checkout this branch
2. restart celery
3.get the id of learning resource that has associated contentfiles and pass it into the generate_embeddings command `python manage.py generate_embeddings --resource-ids <the id>`
4. observe the celery container's output - there should be some output indicating that embeddings are being generated (different output depending on if fastembed or [ollama via litellm](https://github.com/mitodl/mit-learn/blob/main/docs/how-to/embeddings.md#ollama-for-hardware-accelerated-embedding) is used).
5. Once that completes, verify there are embeddings on the [qdrant dashboard](http://localhost:6333/dashboard#/collections)
6. while keeping an eye on the celery output, re-run the embedding command
7. note that embeddings are not skipped
8. re-run the command with the overwrite flag `python manage.py generate_embeddings --resource-ids <the id> --overwrite` and note that once again embeddings are getting generated



