### PR TITLE
Update React Query to v5

### DIFF
--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -27,7 +27,7 @@
     "ol-test-utilities": "0.0.0"
   },
   "dependencies": {
-    "@tanstack/react-query": "^4.36.1",
+    "@tanstack/react-query": "^5.66.0",
     "axios": "^1.6.3"
   }
 }

--- a/frontends/api/src/hooks/articles/index.test.ts
+++ b/frontends/api/src/hooks/articles/index.test.ts
@@ -71,9 +71,9 @@ describe("Article CRUD", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(makeRequest).toHaveBeenCalledWith("post", url, requestData)
-    expect(queryClient.invalidateQueries).toHaveBeenCalledWith(
-      articleKeys.listRoot(),
-    )
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: articleKeys.listRoot(),
+    })
   })
 
   test("useArticlePartialUpdate calls correct API", async () => {
@@ -89,7 +89,9 @@ describe("Article CRUD", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     const { id, ...patchData } = article
     expect(makeRequest).toHaveBeenCalledWith("patch", url, patchData)
-    expect(queryClient.invalidateQueries).toHaveBeenCalledWith(articleKeys.root)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: articleKeys.root,
+    })
   })
 
   test("useArticleDestroy calls correct API", async () => {
@@ -104,8 +106,8 @@ describe("Article CRUD", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(makeRequest).toHaveBeenCalledWith("delete", url, undefined)
-    expect(queryClient.invalidateQueries).toHaveBeenCalledWith(
-      articleKeys.listRoot(),
-    )
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: articleKeys.listRoot(),
+    })
   })
 })

--- a/frontends/api/src/hooks/articles/index.ts
+++ b/frontends/api/src/hooks/articles/index.ts
@@ -1,9 +1,4 @@
-import {
-  UseQueryOptions,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
 import { articlesApi } from "../../clients"
 import type {
@@ -14,7 +9,7 @@ import { articleQueries, articleKeys } from "./queries"
 
 const useArticleList = (
   params: ArticleListRequest = {},
-  opts: Pick<UseQueryOptions, "enabled"> = {},
+  opts?: { enabled?: boolean },
 ) => {
   return useQuery({
     ...articleQueries.list(params),
@@ -40,7 +35,7 @@ const useArticleCreate = () => {
         .articlesCreate({ ArticleRequest: data })
         .then((response) => response.data),
     onSuccess: () => {
-      client.invalidateQueries(articleKeys.listRoot())
+      client.invalidateQueries({ queryKey: articleKeys.listRoot() })
     },
   })
 }
@@ -49,7 +44,7 @@ const useArticleDestroy = () => {
   return useMutation({
     mutationFn: (id: number) => articlesApi.articlesDestroy({ id }),
     onSuccess: () => {
-      client.invalidateQueries(articleKeys.listRoot())
+      client.invalidateQueries({ queryKey: articleKeys.listRoot() })
     },
   })
 }
@@ -64,7 +59,7 @@ const useArticlePartialUpdate = () => {
         })
         .then((response) => response.data),
     onSuccess: (_data) => {
-      client.invalidateQueries(articleKeys.root)
+      client.invalidateQueries({ queryKey: articleKeys.root })
     },
   })
 }

--- a/frontends/api/src/hooks/articles/queries.ts
+++ b/frontends/api/src/hooks/articles/queries.ts
@@ -1,4 +1,4 @@
-import { QueryOptions } from "@tanstack/react-query"
+import { queryOptions } from "@tanstack/react-query"
 import { articlesApi } from "../../clients"
 import type { ArticlesApiArticlesListRequest as ArticleListRequest } from "../../generated/v1"
 
@@ -12,16 +12,16 @@ const articleKeys = {
 
 const articleQueries = {
   list: (params: ArticleListRequest) =>
-    ({
+    queryOptions({
       queryKey: articleKeys.list(params),
       queryFn: () => articlesApi.articlesList(params).then((res) => res.data),
-    }) satisfies QueryOptions,
+    }),
   detail: (id: number) =>
-    ({
+    queryOptions({
       queryKey: articleKeys.detail(id),
       queryFn: () =>
         articlesApi.articlesRetrieve({ id }).then((res) => res.data),
-    }) satisfies QueryOptions,
+    }),
 }
 
 export { articleQueries, articleKeys }

--- a/frontends/api/src/hooks/channels/index.ts
+++ b/frontends/api/src/hooks/channels/index.ts
@@ -1,9 +1,4 @@
-import {
-  UseQueryOptions,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
 import { channelsApi } from "../../clients"
 import type {
@@ -14,7 +9,7 @@ import { channelKeys, channelQueries } from "./queries"
 
 const useChannelsList = (
   params: ChannelsApiChannelsListRequest = {},
-  opts: Pick<UseQueryOptions, "enabled"> = {},
+  opts?: { enabled?: boolean },
 ) => {
   return useQuery({
     ...channelQueries.list(params),
@@ -45,7 +40,7 @@ const useChannelPartialUpdate = () => {
         })
         .then((response) => response.data),
     onSuccess: (_data) => {
-      client.invalidateQueries(channelKeys.root)
+      client.invalidateQueries({ queryKey: channelKeys.root })
     },
   })
 }

--- a/frontends/api/src/hooks/channels/queries.ts
+++ b/frontends/api/src/hooks/channels/queries.ts
@@ -1,4 +1,4 @@
-import { QueryOptions } from "@tanstack/react-query"
+import { queryOptions } from "@tanstack/react-query"
 import { channelsApi } from "../../clients"
 import type { ChannelsApiChannelsListRequest as FieldsApiListRequest } from "../../generated/v0"
 
@@ -22,34 +22,34 @@ const channelKeys = {
 
 const channelQueries = {
   list: (params: FieldsApiListRequest) =>
-    ({
+    queryOptions({
       queryKey: channelKeys.list(params),
       queryFn: () => channelsApi.channelsList(params).then((res) => res.data),
-    }) satisfies QueryOptions,
+    }),
   detail: (id: number) =>
-    ({
+    queryOptions({
       queryKey: channelKeys.detail(id),
       queryFn: () =>
         channelsApi.channelsRetrieve({ id }).then((res) => res.data),
-    }) satisfies QueryOptions,
+    }),
   detailByType: (channelType: string, name: string) =>
-    ({
+    queryOptions({
       queryKey: channelKeys.detailByType(channelType, name),
       queryFn: () => {
         return channelsApi
           .channelsTypeRetrieve({ channel_type: channelType, name: name })
           .then((res) => res.data)
       },
-    }) satisfies QueryOptions,
+    }),
   countsByType: (channelType: string) =>
-    ({
+    queryOptions({
       queryKey: channelKeys.countsByType(channelType),
       queryFn: () => {
         return channelsApi
           .channelsCountsList({ channel_type: channelType })
           .then((res) => res.data)
       },
-    }) satisfies QueryOptions,
+    }),
 }
 
 export { channelQueries, channelKeys }

--- a/frontends/api/src/hooks/learningPaths/index.test.ts
+++ b/frontends/api/src/hooks/learningPaths/index.test.ts
@@ -157,10 +157,9 @@ describe("LearningPath CRUD", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(makeRequest).toHaveBeenCalledWith("post", url, requestData)
 
-    expect(queryClient.invalidateQueries).toHaveBeenCalledWith([
-      "learningPaths",
-      "list",
-    ])
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["learningPaths", "list"],
+    })
   })
 
   test("useLearningPathDestroy calls correct API", async () => {
@@ -178,14 +177,12 @@ describe("LearningPath CRUD", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(makeRequest).toHaveBeenCalledWith("delete", url, undefined)
 
-    expect(queryClient.invalidateQueries).toHaveBeenCalledWith([
-      "learningPaths",
-      "list",
-    ])
-    expect(queryClient.invalidateQueries).toHaveBeenCalledWith([
-      "learningPaths",
-      "membershipList",
-    ])
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["learningPaths", "list"],
+    })
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["learningPaths", "membershipList"],
+    })
   })
 
   test("useLearningPathUpdate calls correct API", async () => {
@@ -203,14 +200,11 @@ describe("LearningPath CRUD", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(makeRequest).toHaveBeenCalledWith("patch", url, patch)
 
-    expect(queryClient.invalidateQueries).toHaveBeenCalledWith([
-      "learningPaths",
-      "list",
-    ])
-    expect(queryClient.invalidateQueries).toHaveBeenCalledWith([
-      "learningPaths",
-      "detail",
-      path.id,
-    ])
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["learningPaths", "list"],
+    })
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["learningPaths", "detail", path.id],
+    })
   })
 })

--- a/frontends/api/src/hooks/learningPaths/index.ts
+++ b/frontends/api/src/hooks/learningPaths/index.ts
@@ -1,5 +1,4 @@
 import {
-  UseQueryOptions,
   useQuery,
   useInfiniteQuery,
   useQueryClient,
@@ -18,7 +17,7 @@ import { useUserHasPermission, Permission } from "api/hooks/user"
 
 const useLearningPathsList = (
   params: ListRequest = {},
-  opts: Pick<UseQueryOptions, "enabled"> = {},
+  opts?: { enabled?: boolean },
 ) => {
   return useQuery({
     ...learningPathQueries.list(params),
@@ -28,15 +27,11 @@ const useLearningPathsList = (
 
 const useInfiniteLearningPathItems = (
   params: ItemsListRequest,
-  options: Pick<UseQueryOptions, "enabled"> = {},
+  opts?: { enabled?: boolean },
 ) => {
   return useInfiniteQuery({
     ...learningPathQueries.infiniteItems(params.learning_resource_id, params),
-    // TODO: in v5, co-locate this with the query options via infiniteQueryOptions
-    getNextPageParam: (lastPage) => {
-      return lastPage.next ?? undefined
-    },
-    ...options,
+    ...opts,
   })
 }
 
@@ -56,7 +51,7 @@ const useLearningPathCreate = () => {
         LearningPathResourceRequest: params,
       }),
     onSettled: () => {
-      queryClient.invalidateQueries(learningPathKeys.listRoot())
+      queryClient.invalidateQueries({ queryKey: learningPathKeys.listRoot() })
     },
   })
 }
@@ -72,8 +67,10 @@ const useLearningPathUpdate = () => {
         PatchedLearningPathResourceRequest: params,
       }),
     onSettled: (data, err, vars) => {
-      queryClient.invalidateQueries(learningPathKeys.listRoot())
-      queryClient.invalidateQueries(learningPathKeys.detail(vars.id))
+      queryClient.invalidateQueries({ queryKey: learningPathKeys.listRoot() })
+      queryClient.invalidateQueries({
+        queryKey: learningPathKeys.detail(vars.id),
+      })
     },
   })
 }
@@ -84,8 +81,10 @@ const useLearningPathDestroy = () => {
     mutationFn: (params: DestroyRequest) =>
       learningPathsApi.learningpathsDestroy(params),
     onSettled: () => {
-      queryClient.invalidateQueries(learningPathKeys.listRoot())
-      queryClient.invalidateQueries(learningPathKeys.membershipList())
+      queryClient.invalidateQueries({ queryKey: learningPathKeys.listRoot() })
+      queryClient.invalidateQueries({
+        queryKey: learningPathKeys.membershipList(),
+      })
     },
   })
 }
@@ -107,9 +106,9 @@ const useLearningPathListItemMove = () => {
       })
     },
     onSettled: (_data, _err, vars) => {
-      queryClient.invalidateQueries(
-        learningPathKeys.infiniteItemsRoot(vars.parent),
-      )
+      queryClient.invalidateQueries({
+        queryKey: learningPathKeys.infiniteItemsRoot(vars.parent),
+      })
     },
   })
 }

--- a/frontends/api/src/hooks/learningPaths/queries.ts
+++ b/frontends/api/src/hooks/learningPaths/queries.ts
@@ -6,7 +6,7 @@ import type {
   PaginatedLearningPathRelationshipList,
 } from "../../generated/v1"
 import { clearListMemberships } from "../learningResources/queries"
-import { QueryOptions, UseInfiniteQueryOptions } from "@tanstack/react-query"
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query"
 
 const learningPathKeys = {
   root: ["learningPaths"],
@@ -24,21 +24,21 @@ const learningPathKeys = {
 
 const learningPathQueries = {
   list: (params: ListRequest) =>
-    ({
+    queryOptions({
       queryKey: learningPathKeys.list(params),
       queryFn: () =>
         learningPathsApi.learningpathsList(params).then((res) => res.data),
-    }) satisfies QueryOptions,
+    }),
   detail: (id: number) =>
-    ({
+    queryOptions({
       queryKey: learningPathKeys.detail(id),
       queryFn: () =>
         learningPathsApi.learningpathsRetrieve({ id }).then((res) => res.data),
-    }) satisfies QueryOptions,
+    }),
   infiniteItems: (id: number, listingParams: ItemsListRequest) =>
-    ({
+    infiniteQueryOptions({
       queryKey: learningPathKeys.infiniteItems(id, listingParams),
-      queryFn: async ({ pageParam }: { pageParam?: string } = {}) => {
+      queryFn: async ({ pageParam }) => {
         // Use generated API for first request, then use next parameter
         const request = pageParam
           ? axiosInstance.request<PaginatedLearningPathRelationshipList>({
@@ -55,13 +55,18 @@ const learningPathQueries = {
           })),
         }
       },
-    }) satisfies UseInfiniteQueryOptions,
+      // Casting is so infiniteQueryOptions can infer the correct type for initialPageParam
+      initialPageParam: null as string | null,
+      getNextPageParam: (lastPage) => {
+        return lastPage.next ?? undefined
+      },
+    }),
   membershipList: () =>
-    ({
+    queryOptions({
       queryKey: learningPathKeys.membershipList(),
       queryFn: () =>
         learningPathsApi.learningpathsMembershipList().then((res) => res.data),
-    }) satisfies QueryOptions,
+    }),
 }
 
 export { learningPathQueries, learningPathKeys }

--- a/frontends/api/src/hooks/learningResources/index.ts
+++ b/frontends/api/src/hooks/learningResources/index.ts
@@ -1,9 +1,4 @@
-import {
-  UseQueryOptions,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { learningResourcesApi } from "../../clients"
 import type {
   LearningResourcesApiLearningResourcesListRequest as LRListRequest,
@@ -30,7 +25,7 @@ import { useCallback } from "react"
 
 const useLearningResourcesList = (
   params: LRListRequest = {},
-  opts: Pick<UseQueryOptions, "enabled"> = {},
+  opts?: { enabled?: boolean },
 ) => {
   return useQuery({
     ...learningResourceQueries.list(params),
@@ -61,10 +56,7 @@ const useFeaturedLearningResourcesList = (params: FeaturedListParams = {}) => {
   return useQuery(learningResourceQueries.featured(params))
 }
 
-const useLearningResourceTopic = (
-  id: number,
-  opts: Pick<UseQueryOptions, "enabled"> = {},
-) => {
+const useLearningResourceTopic = (id: number, opts?: { enabled?: boolean }) => {
   return useQuery({
     ...topicQueries.detail(id),
     ...opts,
@@ -73,7 +65,7 @@ const useLearningResourceTopic = (
 
 const useLearningResourceTopics = (
   params: TopicsListRequest = {},
-  opts: Pick<UseQueryOptions, "enabled"> = {},
+  opts?: { enabled?: boolean },
 ) => {
   return useQuery({
     ...topicQueries.list(params),
@@ -83,7 +75,7 @@ const useLearningResourceTopics = (
 
 const useLearningResourcesSearch = (
   params: LRSearchRequest,
-  opts?: Pick<UseQueryOptions, "keepPreviousData">,
+  opts?: { keepPreviousData?: boolean; enabled?: boolean },
 ) => {
   return useQuery({
     ...learningResourceQueries.search(params),
@@ -98,7 +90,7 @@ const useLearningResourceSetUserListRelationships = () => {
       params: LearningResourcesApiLearningResourcesUserlistsPartialUpdateRequest,
     ) => learningResourcesApi.learningResourcesUserlistsPartialUpdate(params),
     onSettled: () => {
-      queryClient.invalidateQueries(userlistKeys.membershipList())
+      queryClient.invalidateQueries({ queryKey: userlistKeys.membershipList() })
     },
   })
 }
@@ -111,14 +103,16 @@ const useLearningResourceSetLearningPathRelationships = () => {
     ) =>
       learningResourcesApi.learningResourcesLearningPathsPartialUpdate(params),
     onSettled: () => {
-      queryClient.invalidateQueries(learningPathKeys.membershipList())
+      queryClient.invalidateQueries({
+        queryKey: learningPathKeys.membershipList(),
+      })
     },
   })
 }
 
 const useOfferorsList = (
   params: OfferorsApiOfferorsListRequest = {},
-  opts: Pick<UseQueryOptions, "enabled"> = {},
+  opts?: { enabled?: boolean },
 ) => {
   return useQuery({
     ...offerorQueries.list(params),
@@ -128,7 +122,7 @@ const useOfferorsList = (
 
 const usePlatformsList = (
   params: PlatformsApiPlatformsListRequest = {},
-  opts: Pick<UseQueryOptions, "enabled"> = {},
+  opts?: { enabled?: boolean },
 ) => {
   return useQuery({
     ...platformsQueries.list(params),
@@ -142,7 +136,7 @@ const useSchoolsList = () => {
 
 const useSimilarLearningResources = (
   id: number,
-  opts: Pick<UseQueryOptions, "enabled"> = {},
+  opts?: { enabled?: boolean },
 ) => {
   return useQuery({
     ...learningResourceQueries.similar(id),
@@ -152,7 +146,7 @@ const useSimilarLearningResources = (
 
 const useVectorSimilarLearningResources = (
   id: number,
-  opts: Pick<UseQueryOptions, "enabled"> = {},
+  opts?: { enabled?: boolean },
 ) => {
   return useQuery({
     ...learningResourceQueries.vectorSimilar(id),

--- a/frontends/api/src/hooks/learningResources/index.ts
+++ b/frontends/api/src/hooks/learningResources/index.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 import { learningResourcesApi } from "../../clients"
 import type {
   LearningResourcesApiLearningResourcesListRequest as LRListRequest,
@@ -75,11 +80,13 @@ const useLearningResourceTopics = (
 
 const useLearningResourcesSearch = (
   params: LRSearchRequest,
-  opts?: { keepPreviousData?: boolean; enabled?: boolean },
+  opts?: {
+    keepPreviousData?: boolean
+  },
 ) => {
   return useQuery({
     ...learningResourceQueries.search(params),
-    ...opts,
+    placeholderData: opts?.keepPreviousData ? keepPreviousData : undefined,
   })
 }
 

--- a/frontends/api/src/hooks/learningResources/queries.ts
+++ b/frontends/api/src/hooks/learningResources/queries.ts
@@ -7,7 +7,7 @@ import {
   schoolsApi,
   featuredApi,
 } from "../../clients"
-import axiosInstance from "../../axios"
+
 import type {
   LearningResource,
   LearningResourcesApiLearningResourcesListRequest as LearningResourcesListRequest,
@@ -17,9 +17,8 @@ import type {
   PlatformsApiPlatformsListRequest,
   FeaturedApiFeaturedListRequest as FeaturedListParams,
   LearningResourcesApiLearningResourcesItemsListRequest as ItemsListRequest,
-  PaginatedLearningResourceRelationshipList,
 } from "../../generated/v1"
-import type { QueryOptions } from "@tanstack/react-query"
+import { queryOptions } from "@tanstack/react-query"
 
 /* List memberships were previously determined in the learningResourcesApi
  * from user_list_parents and learning_path_parents on each resource.
@@ -29,7 +28,9 @@ import type { QueryOptions } from "@tanstack/react-query"
  * Removing here to ensure they are not depended on anywhere, though they can
  * be removed from the GET APIs TODO.
  */
-export const clearListMemberships = (resource: LearningResource) => ({
+export const clearListMemberships = (
+  resource: LearningResource,
+): LearningResource => ({
   ...resource,
   user_list_parents: [],
   learning_path_parents: [],
@@ -133,60 +134,51 @@ const offerorsKeys = {
 
 const learningResourceQueries = {
   detail: (id: number) =>
-    ({
+    queryOptions({
       queryKey: learningResourceKeys.detail(id),
       queryFn: () =>
         learningResourcesApi
           .learningResourcesRetrieve({ id })
           .then((res) => clearListMemberships(res.data)),
-    }) satisfies QueryOptions,
-  items: (id: number, params: ItemsListRequest) => {
-    return {
+    }),
+  items: (id: number, params: ItemsListRequest) =>
+    queryOptions({
       queryKey: learningResourceKeys.items(id, params),
-      queryFn: ({ pageParam }: { pageParam?: string } = {}) => {
-        // Use generated API for first request, then use next parameter
-        const request = pageParam
-          ? axiosInstance.request<PaginatedLearningResourceRelationshipList>({
-              method: "get",
-              url: pageParam,
-            })
-          : learningResourcesApi.learningResourcesItemsList(params)
-        return request.then((res) =>
-          res.data.results.map((rel) => clearListMemberships(rel.resource)),
-        )
+      queryFn: () => {
+        return learningResourcesApi
+          .learningResourcesItemsList(params)
+          .then((res) =>
+            res.data.results.map((rel) => clearListMemberships(rel.resource)),
+          )
       },
-    } satisfies QueryOptions
-  },
-  similar: (id: number) => {
-    return {
+    }),
+  similar: (id: number) =>
+    queryOptions({
       queryKey: learningResourceKeys.similar(id),
       queryFn: () =>
         learningResourcesApi
           .learningResourcesSimilarList({ id })
           .then((res) => res.data.map(clearListMemberships)),
-    } satisfies QueryOptions
-  },
-  vectorSimilar: (id: number) => {
-    return {
+    }),
+  vectorSimilar: (id: number) =>
+    queryOptions({
       queryKey: learningResourceKeys.vectorSimilar(id),
       queryFn: () =>
         learningResourcesApi
           .learningResourcesVectorSimilarList({ id })
           .then((res) => res.data.map(clearListMemberships)),
-    } satisfies QueryOptions
-  },
-  list: (params: LearningResourcesListRequest) => {
-    return {
+    }),
+  list: (params: LearningResourcesListRequest) =>
+    queryOptions({
       queryKey: learningResourceKeys.list(params),
       queryFn: () =>
         learningResourcesApi.learningResourcesList(params).then((res) => ({
           ...res.data,
           results: res.data.results.map(clearListMemberships),
         })),
-    } satisfies QueryOptions
-  },
-  featured: (params: FeaturedListParams = {}) => {
-    return {
+    }),
+  featured: (params: FeaturedListParams = {}) =>
+    queryOptions({
       queryKey: learningResourceKeys.featured(params),
       queryFn: () =>
         featuredApi.featuredList(params).then((res) => {
@@ -197,10 +189,9 @@ const learningResourceQueries = {
             ),
           }
         }),
-    } satisfies QueryOptions
-  },
-  search: (params: LearningResourcesSearchRetrieveRequest) => {
-    return {
+    }),
+  search: (params: LearningResourcesSearchRetrieveRequest) =>
+    queryOptions({
       queryKey: learningResourceKeys.search(params),
       queryFn: () =>
         learningResourcesSearchApi
@@ -209,50 +200,43 @@ const learningResourceQueries = {
             ...res.data,
             results: res.data.results.map(clearListMemberships),
           })),
-    } satisfies QueryOptions
-  },
+    }),
 }
 
 const topicQueries = {
-  list: (params: TopicsListRequest) => {
-    return {
+  list: (params: TopicsListRequest) =>
+    queryOptions({
       queryKey: topicsKeys.list(params),
       queryFn: () => topicsApi.topicsList(params).then((res) => res.data),
-    } satisfies QueryOptions
-  },
-  detail: (id: number) => {
-    return {
+    }),
+  detail: (id: number) =>
+    queryOptions({
       queryKey: topicsKeys.detail(id),
       queryFn: () => topicsApi.topicsRetrieve({ id }).then((res) => res.data),
-    } satisfies QueryOptions
-  },
+    }),
 }
 
 const platformsQueries = {
-  list: (params: PlatformsApiPlatformsListRequest) => {
-    return {
-      queryKey: platformsKeys.list(params),
-      queryFn: () => platformsApi.platformsList(params).then((res) => res.data),
-    } satisfies QueryOptions
-  },
+  list: (params: PlatformsApiPlatformsListRequest) => ({
+    queryKey: platformsKeys.list(params),
+    queryFn: () => platformsApi.platformsList(params).then((res) => res.data),
+  }),
 }
 
 const schoolQueries = {
-  list: () => {
-    return {
+  list: () =>
+    queryOptions({
       queryKey: schoolKeys.list(),
       queryFn: () => schoolsApi.schoolsList().then((res) => res.data),
-    } satisfies QueryOptions
-  },
+    }),
 }
 
 const offerorQueries = {
-  list: (params: OfferorsApiOfferorsListRequest) => {
-    return {
+  list: (params: OfferorsApiOfferorsListRequest) =>
+    queryOptions({
       queryKey: offerorsKeys.list(params),
       queryFn: () => offerorsApi.offerorsList(params).then((res) => res.data),
-    } satisfies QueryOptions
-  },
+    }),
 }
 
 export {

--- a/frontends/api/src/hooks/learningResources/queries.ts
+++ b/frontends/api/src/hooks/learningResources/queries.ts
@@ -17,6 +17,7 @@ import type {
   PlatformsApiPlatformsListRequest,
   FeaturedApiFeaturedListRequest as FeaturedListParams,
   LearningResourcesApiLearningResourcesItemsListRequest as ItemsListRequest,
+  LearningResourcesSearchResponse,
 } from "../../generated/v1"
 import { queryOptions } from "@tanstack/react-query"
 
@@ -194,12 +195,13 @@ const learningResourceQueries = {
     queryOptions({
       queryKey: learningResourceKeys.search(params),
       queryFn: () =>
-        learningResourcesSearchApi
-          .learningResourcesSearchRetrieve(params)
-          .then((res) => ({
-            ...res.data,
-            results: res.data.results.map(clearListMemberships),
-          })),
+        learningResourcesSearchApi.learningResourcesSearchRetrieve(params).then(
+          (res) =>
+            ({
+              ...res.data,
+              results: res.data.results.map(clearListMemberships),
+            }) as LearningResourcesSearchResponse,
+        ),
     }),
 }
 

--- a/frontends/api/src/hooks/newsEvents/queries.ts
+++ b/frontends/api/src/hooks/newsEvents/queries.ts
@@ -1,4 +1,4 @@
-import { QueryOptions } from "@tanstack/react-query"
+import { queryOptions } from "@tanstack/react-query"
 import { newsEventsApi } from "../../clients"
 import type { NewsEventsApiNewsEventsListRequest } from "../../generated/v0"
 
@@ -15,17 +15,17 @@ const newsEventsKeys = {
 
 const newsEventsQueries = {
   list: (params: NewsEventsApiNewsEventsListRequest) =>
-    ({
+    queryOptions({
       queryKey: newsEventsKeys.list(params),
       queryFn: () =>
         newsEventsApi.newsEventsList(params).then((res) => res.data),
-    }) satisfies QueryOptions,
+    }),
   detail: (id: number) =>
-    ({
+    queryOptions({
       queryKey: newsEventsKeys.detail(id),
       queryFn: () =>
         newsEventsApi.newsEventsRetrieve({ id }).then((res) => res.data),
-    }) satisfies QueryOptions,
+    }),
 }
 
 export { newsEventsQueries, newsEventsKeys }

--- a/frontends/api/src/hooks/programLetters/queries.ts
+++ b/frontends/api/src/hooks/programLetters/queries.ts
@@ -1,4 +1,4 @@
-import { QueryOptions } from "@tanstack/react-query"
+import { queryOptions } from "@tanstack/react-query"
 import { programLettersApi } from "../../clients"
 
 const programLetterKeys = {
@@ -8,13 +8,13 @@ const programLetterKeys = {
 }
 const programLetterQueries = {
   detail: (id: string) =>
-    ({
+    queryOptions({
       queryKey: programLetterKeys.detail(id),
       queryFn: () =>
         programLettersApi
           .programLettersRetrieve({ id })
           .then((res) => res.data),
-    }) satisfies QueryOptions,
+    }),
 }
 
 export { programLetterQueries, programLetterKeys }

--- a/frontends/api/src/hooks/searchSubscription/index.ts
+++ b/frontends/api/src/hooks/searchSubscription/index.ts
@@ -1,9 +1,4 @@
-import {
-  useMutation,
-  UseQueryOptions,
-  useQueryClient,
-  useQuery,
-} from "@tanstack/react-query"
+import { useMutation, useQueryClient, useQuery } from "@tanstack/react-query"
 import { searchSubscriptionQueries, searchSubscriptionKeys } from "./keyFactory"
 import type { LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreateRequest as subscriptionCreateRequest } from "../../generated/v1"
 import { searchSubscriptionApi } from "../../clients"
@@ -17,14 +12,14 @@ const useSearchSubscriptionCreate = () => {
         .learningResourcesUserSubscriptionSubscribeCreate(params)
         .then((res) => res.data),
     onSuccess: (_data) => {
-      queryClient.invalidateQueries(searchSubscriptionKeys.root)
+      queryClient.invalidateQueries({ queryKey: searchSubscriptionKeys.root })
     },
   })
 }
 
 const useSearchSubscriptionList = (
   params = {},
-  opts: Pick<UseQueryOptions, "enabled"> = {},
+  opts?: { enabled?: boolean },
 ) => {
   return useQuery({
     ...searchSubscriptionQueries.list(params),
@@ -42,7 +37,7 @@ const useSearchSubscriptionDelete = () => {
         .then((res) => res.data)
     },
     onSuccess: (_data) => {
-      queryClient.invalidateQueries(searchSubscriptionKeys.root)
+      queryClient.invalidateQueries({ queryKey: searchSubscriptionKeys.root })
     },
   })
 }

--- a/frontends/api/src/hooks/searchSubscription/keyFactory.ts
+++ b/frontends/api/src/hooks/searchSubscription/keyFactory.ts
@@ -1,6 +1,6 @@
 import { searchSubscriptionApi } from "../../clients"
 import type { LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckListRequest as subscriptionCheckListRequest } from "../../generated/v1"
-import { QueryOptions } from "@tanstack/react-query"
+import { queryOptions } from "@tanstack/react-query"
 
 const searchSubscriptionKeys = {
   root: ["searchSubscriptions"],
@@ -13,13 +13,13 @@ const searchSubscriptionKeys = {
 
 const searchSubscriptionQueries = {
   list: (params: subscriptionCheckListRequest) =>
-    ({
+    queryOptions({
       queryKey: searchSubscriptionKeys.list(params),
       queryFn: () =>
         searchSubscriptionApi
           .learningResourcesUserSubscriptionCheckList(params)
           .then((res) => res.data),
-    }) satisfies QueryOptions,
+    }),
 }
 
 export { searchSubscriptionQueries, searchSubscriptionKeys }

--- a/frontends/api/src/hooks/testimonials/index.ts
+++ b/frontends/api/src/hooks/testimonials/index.ts
@@ -1,11 +1,11 @@
-import { UseQueryOptions, useQuery } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
 
 import type { TestimonialsApiTestimonialsListRequest } from "../../generated/v0"
 import { testimonialsQueries } from "./queries"
 
 const useTestimonialList = (
   params: TestimonialsApiTestimonialsListRequest = {},
-  opts: Pick<UseQueryOptions, "enabled"> = {},
+  opts?: { enabled?: boolean },
 ) => {
   return useQuery({
     ...testimonialsQueries.list(params),

--- a/frontends/api/src/hooks/testimonials/queries.ts
+++ b/frontends/api/src/hooks/testimonials/queries.ts
@@ -1,4 +1,4 @@
-import { QueryOptions } from "@tanstack/react-query"
+import { queryOptions } from "@tanstack/react-query"
 import { testimonialsApi } from "../../clients"
 import type { TestimonialsApiTestimonialsListRequest as TestimonialsListRequest } from "../../generated/v0"
 
@@ -15,17 +15,17 @@ const testimonialKeys = {
 
 const testimonialsQueries = {
   list: (params: TestimonialsListRequest) =>
-    ({
+    queryOptions({
       queryKey: testimonialKeys.list(params),
       queryFn: () =>
         testimonialsApi.testimonialsList(params).then((res) => res.data),
-    }) satisfies QueryOptions,
+    }),
   detail: (id: number) =>
-    ({
+    queryOptions({
       queryKey: testimonialKeys.detail(id),
       queryFn: () =>
         testimonialsApi.testimonialsRetrieve({ id }).then((res) => res.data),
-    }) satisfies QueryOptions,
+    }),
 }
 
 export { testimonialsQueries, testimonialKeys }

--- a/frontends/api/src/hooks/userLists/index.ts
+++ b/frontends/api/src/hooks/userLists/index.ts
@@ -1,5 +1,4 @@
 import {
-  UseQueryOptions,
   useInfiniteQuery,
   useMutation,
   useQuery,
@@ -18,7 +17,7 @@ import { useUserIsAuthenticated } from "api/hooks/user"
 
 const useUserListList = (
   params: ListRequest = {},
-  opts: Pick<UseQueryOptions, "enabled"> = {},
+  opts?: { enabled?: boolean },
 ) => {
   return useQuery({
     ...userlistQueries.list(params),
@@ -38,7 +37,7 @@ const useUserListCreate = () => {
         UserListRequest: params,
       }),
     onSettled: () => {
-      queryClient.invalidateQueries(userlistKeys.listRoot())
+      queryClient.invalidateQueries({ queryKey: userlistKeys.listRoot() })
     },
   })
 }
@@ -51,8 +50,8 @@ const useUserListUpdate = () => {
         PatchedUserListRequest: params,
       }),
     onSettled: (_data, _err, vars) => {
-      queryClient.invalidateQueries(userlistKeys.listRoot())
-      queryClient.invalidateQueries(userlistKeys.detail(vars.id))
+      queryClient.invalidateQueries({ queryKey: userlistKeys.listRoot() })
+      queryClient.invalidateQueries({ queryKey: userlistKeys.detail(vars.id) })
     },
   })
 }
@@ -63,22 +62,19 @@ const useUserListDestroy = () => {
     mutationFn: (params: DestroyRequest) =>
       userListsApi.userlistsDestroy(params),
     onSettled: () => {
-      queryClient.invalidateQueries(userlistKeys.listRoot())
-      queryClient.invalidateQueries(userlistKeys.membershipList())
+      queryClient.invalidateQueries({ queryKey: userlistKeys.listRoot() })
+      queryClient.invalidateQueries({ queryKey: userlistKeys.membershipList() })
     },
   })
 }
 
 const useInfiniteUserListItems = (
   params: ItemsListRequest,
-  options: Pick<UseQueryOptions, "enabled"> = {},
+  opts?: { enabled?: boolean },
 ) => {
   return useInfiniteQuery({
     ...userlistQueries.infiniteItems(params.userlist_id, params),
-    getNextPageParam: (lastPage) => {
-      return lastPage.next ?? undefined
-    },
-    ...options,
+    ...opts,
   })
 }
 
@@ -98,7 +94,9 @@ const useUserListListItemMove = () => {
       })
     },
     onSettled: (_data, _err, vars) => {
-      queryClient.invalidateQueries(userlistKeys.infiniteItemsRoot(vars.parent))
+      queryClient.invalidateQueries({
+        queryKey: userlistKeys.infiniteItemsRoot(vars.parent),
+      })
     },
   })
 }

--- a/frontends/api/src/hooks/widget_lists/index.ts
+++ b/frontends/api/src/hooks/widget_lists/index.ts
@@ -26,7 +26,7 @@ const useMutateWidgetsList = (id: number) => {
         .then((response) => response.data),
 
     onSuccess: (_data) => {
-      client.invalidateQueries(widgetListKeys.root)
+      client.invalidateQueries({ queryKey: widgetListKeys.root })
     },
   })
 }

--- a/frontends/api/src/hooks/widget_lists/queries.ts
+++ b/frontends/api/src/hooks/widget_lists/queries.ts
@@ -1,4 +1,4 @@
-import { QueryOptions } from "@tanstack/react-query"
+import { queryOptions } from "@tanstack/react-query"
 import { widgetListsApi } from "../../clients"
 
 const widgetListKeys = {
@@ -9,11 +9,11 @@ const widgetListKeys = {
 
 const widgetListQueries = {
   detail: (id: number) =>
-    ({
+    queryOptions({
       queryKey: widgetListKeys.detail(id),
       queryFn: () =>
         widgetListsApi.widgetListsRetrieve({ id }).then((res) => res.data),
-    }) satisfies QueryOptions,
+    }),
 }
 
 export { widgetListQueries, widgetListKeys }

--- a/frontends/api/src/ssr/usePrefetchWarnings.test.ts
+++ b/frontends/api/src/ssr/usePrefetchWarnings.test.ts
@@ -44,12 +44,12 @@ describe("SSR prefetch warnings", () => {
       [
         expect.objectContaining({
           disabled: false,
-          initialStatus: "loading",
+          status: "pending",
           key: learningResourceQueries.detail(1).queryKey,
           observerCount: 1,
         }),
       ],
-      ["hash", "initialStatus", "status", "observerCount", "disabled"],
+      ["hash", "status", "observerCount", "disabled"],
     )
   })
 
@@ -104,15 +104,14 @@ describe("SSR prefetch warnings", () => {
     expect(console.table).toHaveBeenCalledWith(
       [
         {
-          disabled: false,
+          disabled: true,
           hash: JSON.stringify(learningResourceQueries.detail(1).queryKey),
-          initialStatus: "success",
           key: learningResourceQueries.detail(1).queryKey,
           observerCount: 0,
           status: "success",
         },
       ],
-      ["hash", "initialStatus", "status", "observerCount", "disabled"],
+      ["hash", "status", "observerCount", "disabled"],
     )
   })
 })

--- a/frontends/api/src/ssr/usePrefetchWarnings.ts
+++ b/frontends/api/src/ssr/usePrefetchWarnings.ts
@@ -9,7 +9,6 @@ const logQueries = (...args: [...string[], Query[]]) => {
       key: query.queryKey,
       hash: query.queryHash,
       disabled: query.isDisabled(),
-      initialStatus: query.initialState.status,
       status: query.state.status,
       observerCount: query.getObserversCount(),
     })),
@@ -52,14 +51,14 @@ export const usePrefetchWarnings = ({
       const cache = queryClient.getQueryCache()
       const queries = cache.getAll()
 
-      const exempted = [...exemptions, ...PREFETCH_EXEMPT_QUERIES].map((key) =>
-        cache.find(key),
+      const exempted = [...exemptions, ...PREFETCH_EXEMPT_QUERIES].map(
+        (queryKey) => cache.find({ queryKey }),
       )
 
       const potentialPrefetches = queries.filter(
         (query) =>
           !exempted.includes(query) &&
-          query.initialState.status !== "success" &&
+          query.state.status !== "success" &&
           !query.isDisabled(),
       )
 
@@ -75,7 +74,7 @@ export const usePrefetchWarnings = ({
       const unusedPrefetches = queries.filter(
         (query) =>
           !exempted.includes(query) &&
-          query.initialState.status === "success" &&
+          query.state.status === "success" &&
           query.getObserversCount() === 0 &&
           !query.isDisabled(),
       )

--- a/frontends/api/src/ssr/usePrefetchWarnings.ts
+++ b/frontends/api/src/ssr/usePrefetchWarnings.ts
@@ -12,7 +12,7 @@ const logQueries = (...args: [...string[], Query[]]) => {
       status: query.state.status,
       observerCount: query.getObserversCount(),
     })),
-    ["hash", "initialStatus", "status", "observerCount", "disabled"],
+    ["hash", "status", "observerCount", "disabled"],
   )
 }
 
@@ -75,8 +75,7 @@ export const usePrefetchWarnings = ({
         (query) =>
           !exempted.includes(query) &&
           query.state.status === "success" &&
-          query.getObserversCount() === 0 &&
-          !query.isDisabled(),
+          query.getObserversCount() === 0,
       )
 
       if (unusedPrefetches.length > 0) {

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -20,7 +20,7 @@
     "@nlux/themes": "^2.17.1",
     "@remixicon/react": "^4.2.0",
     "@sentry/nextjs": "^8.36.0",
-    "@tanstack/react-query": "^4.36.1",
+    "@tanstack/react-query": "^5.66",
     "api": "workspace:*",
     "classnames": "^2.5.1",
     "formik": "^2.4.6",

--- a/frontends/main/src/app-pages/DashboardPage/ProfileEditForm.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ProfileEditForm.tsx
@@ -75,7 +75,7 @@ const ProfileEditForm: React.FC<Props> = ({ profile }) => {
     }
   }, [profile])
   const { data: user } = useUserMe()
-  const { isLoading: isSaving, mutateAsync } = useProfileMeMutation()
+  const { isPending: isSaving, mutateAsync } = useProfileMeMutation()
   const { data: topics } = useLearningResourceTopics({ is_toplevel: true })
   const topicChoices =
     topics?.results?.map((topic) => ({

--- a/frontends/main/src/app-pages/OnboardingPage/OnboardingPage.tsx
+++ b/frontends/main/src/app-pages/OnboardingPage/OnboardingPage.tsx
@@ -152,7 +152,7 @@ const OnboardingPage: React.FC = () => {
         profile?.topic_interests?.map((topic) => String(topic.id)) || [],
     }
   }, [profile])
-  const { isLoading: isSaving, mutateAsync } = useProfileMeMutation()
+  const { isPending: isSaving, mutateAsync } = useProfileMeMutation()
   const { isLoading: userLoading, data: user } = useUserMe()
   const [activeStep, setActiveStep] = React.useState<number>(0)
   const router = useRouter()

--- a/frontends/main/src/app/c/[channelType]/[name]/page.tsx
+++ b/frontends/main/src/app/c/[channelType]/[name]/page.tsx
@@ -9,7 +9,7 @@ import {
   LearningResourceOfferorDetail,
 } from "api"
 import { getMetadataAsync } from "@/common/metadata"
-import { Hydrate } from "@tanstack/react-query"
+import { HydrationBoundary } from "@tanstack/react-query"
 import { prefetch } from "api/ssr/prefetch"
 import {
   learningResourceQueries,
@@ -104,9 +104,9 @@ const Page: React.FC = async ({
     queryClient,
   )
   return (
-    <Hydrate state={dehydratedState}>
+    <HydrationBoundary state={dehydratedState}>
       <ChannelPage />
-    </Hydrate>
+    </HydrationBoundary>
   )
 }
 

--- a/frontends/main/src/app/departments/page.tsx
+++ b/frontends/main/src/app/departments/page.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Metadata } from "next"
-import { Hydrate } from "@tanstack/react-query"
+import { HydrationBoundary } from "@tanstack/react-query"
 import { standardizeMetadata } from "@/common/metadata"
 import { schoolQueries } from "api/hooks/learningResources"
 import { channelQueries } from "api/hooks/channels"
@@ -18,9 +18,9 @@ const Page: React.FC = async () => {
   ])
 
   return (
-    <Hydrate state={dehydratedState}>
+    <HydrationBoundary state={dehydratedState}>
       <DepartmentListingPage />
-    </Hydrate>
+    </HydrationBoundary>
   )
 }
 

--- a/frontends/main/src/app/getQueryClient.test.tsx
+++ b/frontends/main/src/app/getQueryClient.test.tsx
@@ -26,7 +26,8 @@ test.each([
     const queryFn = jest.fn().mockRejectedValue({ response: { status } })
     const { result } = renderHook(
       () =>
-        useQuery(["test"], {
+        useQuery({
+          queryKey: ["test"],
           queryFn,
           retryDelay: 0,
         }),

--- a/frontends/main/src/app/getQueryClient.ts
+++ b/frontends/main/src/app/getQueryClient.ts
@@ -22,7 +22,7 @@ const makeQueryClient = (): QueryClient => {
         // The runtime error will be caught by an error boundary.
         // For now, only do this for 404s, 403s, and 401s. Other errors should
         // be handled locally by components.
-        useErrorBoundary: (error) => {
+        throwOnError: (error) => {
           const status = (error as MaybeHasStatus)?.response?.status
           return THROW_ERROR_CODES.includes(status)
         },

--- a/frontends/main/src/app/page.tsx
+++ b/frontends/main/src/app/page.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import type { Metadata } from "next"
 import HomePage from "@/app-pages/HomePage/HomePage"
 import { getMetadataAsync } from "@/common/metadata"
-import { Hydrate } from "@tanstack/react-query"
+import { HydrationBoundary } from "@tanstack/react-query"
 import {
   learningResourceQueries,
   topicQueries,
@@ -86,9 +86,9 @@ const Page: React.FC = async () => {
   ])
 
   return (
-    <Hydrate state={dehydratedState}>
+    <HydrationBoundary state={dehydratedState}>
       <HomePage heroImageIndex={Math.floor(Math.random() * 5) + 1} />
-    </Hydrate>
+    </HydrationBoundary>
   )
 }
 

--- a/frontends/main/src/app/search/page.tsx
+++ b/frontends/main/src/app/search/page.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Hydrate } from "@tanstack/react-query"
+import { HydrationBoundary } from "@tanstack/react-query"
 import { prefetch } from "api/ssr/prefetch"
 import {
   learningResourceQueries,
@@ -51,9 +51,9 @@ const Page: React.FC = async ({
   ])
 
   return (
-    <Hydrate state={dehydratedState}>
+    <HydrationBoundary state={dehydratedState}>
       <SearchPage />
-    </Hydrate>
+    </HydrationBoundary>
   )
 }
 

--- a/frontends/main/src/app/topics/page.tsx
+++ b/frontends/main/src/app/topics/page.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Metadata } from "next"
-import { Hydrate } from "@tanstack/react-query"
+import { HydrationBoundary } from "@tanstack/react-query"
 import { prefetch } from "api/ssr/prefetch"
 import { topicQueries } from "api/hooks/learningResources"
 import { channelQueries } from "api/hooks/channels"
@@ -18,9 +18,9 @@ const Page: React.FC = async () => {
   ])
 
   return (
-    <Hydrate state={dehydratedState}>
+    <HydrationBoundary state={dehydratedState}>
       <TopicsListingPage />
-    </Hydrate>
+    </HydrationBoundary>
   )
 }
 

--- a/frontends/main/src/app/units/page.tsx
+++ b/frontends/main/src/app/units/page.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Metadata } from "next"
-import { Hydrate } from "@tanstack/react-query"
+import { HydrationBoundary } from "@tanstack/react-query"
 import { prefetch } from "api/ssr/prefetch"
 import { standardizeMetadata } from "@/common/metadata"
 import { channelQueries } from "api/hooks/channels"
@@ -17,9 +17,9 @@ const Page: React.FC = async () => {
   ])
 
   return (
-    <Hydrate state={dehydratedState}>
+    <HydrationBoundary state={dehydratedState}>
       <UnitsListingPage />
-    </Hydrate>
+    </HydrationBoundary>
   )
 }
 

--- a/frontends/main/src/page-components/Dialogs/AddToListDialog.tsx
+++ b/frontends/main/src/page-components/Dialogs/AddToListDialog.tsx
@@ -68,11 +68,11 @@ const AddToListDialogInner: React.FC<AddToListDialogInnerProps> = ({
     useLearningPathMemberList(resource?.id)
 
   const {
-    isLoading: isSavingUserListRelationships,
+    isPending: isSavingUserListRelationships,
     mutateAsync: setUserListRelationships,
   } = useLearningResourceSetUserListRelationships()
   const {
-    isLoading: isSavingLearningPathRelationships,
+    isPending: isSavingLearningPathRelationships,
     mutateAsync: setLearningPathRelationships,
   } = useLearningResourceSetLearningPathRelationships()
 

--- a/frontends/main/src/page-components/ItemsListing/ItemsListing.tsx
+++ b/frontends/main/src/page-components/ItemsListing/ItemsListing.tsx
@@ -108,8 +108,8 @@ const ItemsListingSortable: React.FC<{
 
   const disabled =
     isRefetching ||
-    moveLearningPathListItem.isLoading ||
-    moveUserListListItem.isLoading
+    moveLearningPathListItem.isPending ||
+    moveUserListListItem.isPending
 
   return (
     <StyledPlainList disabled={disabled} itemSpacing={condensed ? 1 : 2}>

--- a/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
+++ b/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
@@ -53,7 +53,7 @@ describe("ResourceCarousel", () => {
     if (autoResolve) {
       resolve()
     }
-    return { resources, resolve }
+    return { resources, resolve, searchResponse }
   }
 
   it.each([
@@ -123,11 +123,12 @@ describe("ResourceCarousel", () => {
       const config: ResourceCarouselProps["config"] = labels.map((label) => {
         return {
           label,
-          data: { type: "resources", params: {} },
+          data: { type: "lr_search", params: { q: label } },
         }
       })
 
       const { resources } = setupApis()
+
       renderWithProviders(
         <ResourceCarousel
           titleComponent="h1"
@@ -144,9 +145,9 @@ describe("ResourceCarousel", () => {
         expect(tabs).toHaveLength(0)
       }
 
-      await screen.findByText(resources.list.results[1].title)
-      await screen.findByText(resources.list.results[0].title)
-      await screen.findByText(resources.list.results[2].title)
+      await screen.findByText(resources.search.results[1].title)
+      await screen.findByText(resources.search.results[0].title)
+      await screen.findByText(resources.search.results[2].title)
     },
   )
 

--- a/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.tsx
+++ b/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.tsx
@@ -179,6 +179,11 @@ type ResourceCarouselProps = {
   titleVariant?: TypographyProps["variant"]
   excludeResourceId?: number
 }
+
+type CarouselQuery = UseQueryOptions<
+  LearningResource[] | PaginatedLearningResourceList
+>
+
 /**
  * A tabbed carousel that fetches resources based on the configuration provided.
  *  - each TabConfig generates a tab + tabpanel that pulls data from an API based
@@ -204,38 +209,33 @@ const ResourceCarousel: React.FC<ResourceCarouselProps> = ({
   const [ref, setRef] = React.useState<HTMLDivElement | null>(null)
 
   const queries = useQueries({
-    queries: config.map(
-      (
-        tab,
-      ): UseQueryOptions<
-        PaginatedLearningResourceList | LearningResource[],
-        unknown,
-        unknown,
-        // The factory-generated types for queryKeys are very specific (tuples not arrays)
-        // and assignable to the loose QueryKey (readonly unknown[]) on the UseQueryOptions generic.
-        // But! as a queryFn arg the more specific QueryKey cannot be assigned to the looser QueryKey.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        any
-      > => {
-        switch (tab.data.type) {
-          case "resources":
-            return learningResourceQueries.list(tab.data.params)
-          case "resource_items":
-            return learningResourceQueries.items(
-              tab.data.params.learning_resource_id,
-              tab.data.params,
-            )
-          case "lr_search":
-            return learningResourceQueries.search(tab.data.params)
-          case "lr_featured":
-            return learningResourceQueries.featured(tab.data.params)
-          case "lr_similar":
-            return learningResourceQueries.similar(tab.data.params.id)
-          case "lr_vector_similar":
-            return learningResourceQueries.vectorSimilar(tab.data.params.id)
-        }
-      },
-    ),
+    queries: config.map((tab) => {
+      switch (tab.data.type) {
+        case "resources":
+          return learningResourceQueries.list(tab.data.params) as CarouselQuery
+        case "resource_items":
+          return learningResourceQueries.items(
+            tab.data.params.learning_resource_id,
+            tab.data.params,
+          ) as CarouselQuery
+        case "lr_search":
+          return learningResourceQueries.search(
+            tab.data.params,
+          ) as CarouselQuery
+        case "lr_featured":
+          return learningResourceQueries.featured(
+            tab.data.params,
+          ) as CarouselQuery
+        case "lr_similar":
+          return learningResourceQueries.similar(
+            tab.data.params.id,
+          ) as CarouselQuery
+        case "lr_vector_similar":
+          return learningResourceQueries.vectorSimilar(
+            tab.data.params.id,
+          ) as CarouselQuery
+      }
+    }),
   })
 
   const getCount = (

--- a/frontends/main/src/page-components/SearchSubscriptionToggle/SearchSubscriptionToggle.tsx
+++ b/frontends/main/src/page-components/SearchSubscriptionToggle/SearchSubscriptionToggle.tsx
@@ -91,7 +91,7 @@ const SearchSubscriptionToggle: React.FC<SearchSubscriptionToggleProps> = ({
     <>
       <StyledButton
         variant="primary"
-        disabled={subscriptionCreate.isLoading}
+        disabled={subscriptionCreate.isPending}
         startIcon={<RiMailLine />}
         onClick={onFollowClick}
       >

--- a/yarn.lock
+++ b/yarn.lock
@@ -4938,29 +4938,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/query-core@npm:4.36.1":
-  version: 4.36.1
-  resolution: "@tanstack/query-core@npm:4.36.1"
-  checksum: 10/7c648872cd491bcab2aa4c18e0b7ca130c072f05c277a5876977fa3bfa87634bbfde46e9d249236587d78c39866889a02e4e202b478dc6074ff96093732ae56d
+"@tanstack/query-core@npm:5.66.0":
+  version: 5.66.0
+  resolution: "@tanstack/query-core@npm:5.66.0"
+  checksum: 10/ba8623c0272e36d3ce616afa024d43e07e6b69170219b32eb4f60156fee9ac4ffa74d2fbb999739b6dea757b75966e76129271f4224f06c59deee24a72944da4
   languageName: node
   linkType: hard
 
-"@tanstack/react-query@npm:^4.36.1":
-  version: 4.36.1
-  resolution: "@tanstack/react-query@npm:4.36.1"
+"@tanstack/react-query@npm:^5.66.0":
+  version: 5.66.0
+  resolution: "@tanstack/react-query@npm:5.66.0"
   dependencies:
-    "@tanstack/query-core": "npm:4.36.1"
-    use-sync-external-store: "npm:^1.2.0"
+    "@tanstack/query-core": "npm:5.66.0"
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-native: "*"
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-    react-native:
-      optional: true
-  checksum: 10/764b860c3ac8d254fc6b07e01054a0f58058644d59626c724b213293fbf1e31c198cbb26e4c32c0d16dcaec0353c0ae19147d9c667675b31f8cea1d64f1ff4ac
+    react: ^18 || ^19
+  checksum: 10/482decc02664e756c66c9ff46279b5eb3f0fb29fcdcb51b96319e8487a2b2e8b151319d6a5d9ef1180523a1792d6449cec2e9bfa87f37a4f755fc9d95534585d
   languageName: node
   linkType: hard
 
@@ -6596,7 +6588,7 @@ __metadata:
   resolution: "api@workspace:frontends/api"
   dependencies:
     "@faker-js/faker": "npm:^9.0.0"
-    "@tanstack/react-query": "npm:^4.36.1"
+    "@tanstack/react-query": "npm:^5.66.0"
     "@testing-library/react": "npm:^16.1.0"
     axios: "npm:^1.6.3"
     enforce-unique: "npm:^1.3.0"
@@ -12782,7 +12774,7 @@ __metadata:
     "@nlux/themes": "npm:^2.17.1"
     "@remixicon/react": "npm:^4.2.0"
     "@sentry/nextjs": "npm:^8.36.0"
-    "@tanstack/react-query": "npm:^4.36.1"
+    "@tanstack/react-query": "npm:^5.66.0"
     "@testing-library/jest-dom": "npm:^6.4.8"
     "@testing-library/react": "npm:^16.1.0"
     "@testing-library/user-event": "npm:^14.5.2"
@@ -18383,15 +18375,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/fd3787ed19f6cfbf70e2c5822d01bebbf96b00968195840d5ad61082b8e6ca7a8e2e46270c4096537d18a38ea57f4e4e9668cce5eec36fa4697ddba2ef1203fd
-  languageName: node
-  linkType: hard
-
-"use-sync-external-store@npm:^1.2.0":
-  version: 1.2.2
-  resolution: "use-sync-external-store@npm:1.2.2"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 10/671e9c190aab9a8374a5d468c6ba17f52c38b6fae970110bc196fc1e2b57204149aea9619be49a1bb5207fb6e51d8afd19c3bcb94afe61813fed039821461dc0
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4945,7 +4945,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-query@npm:^5.66.0":
+"@tanstack/react-query@npm:^5.66, @tanstack/react-query@npm:^5.66.0":
   version: 5.66.0
   resolution: "@tanstack/react-query@npm:5.66.0"
   dependencies:
@@ -12774,7 +12774,7 @@ __metadata:
     "@nlux/themes": "npm:^2.17.1"
     "@remixicon/react": "npm:^4.2.0"
     "@sentry/nextjs": "npm:^8.36.0"
-    "@tanstack/react-query": "npm:^5.66.0"
+    "@tanstack/react-query": "npm:^5.66"
     "@testing-library/jest-dom": "npm:^6.4.8"
     "@testing-library/react": "npm:^16.1.0"
     "@testing-library/user-event": "npm:^14.5.2"


### PR DESCRIPTION
### What are the relevant tickets?
Closes #1940 

### Description (What does it do?)
Updates react query to v5

### How can this be tested?

- There should be no functional changes. Good to check basic functionality.
- Could also check that server-side request warnings still work, though we have tests for this. For example:
    - In `frontends/main/src/app/page.tsx`, comment out one of the requests inside `prefetch`. When you reload the page, you should see a warning in JS console.
    - In  `frontends/main/src/app/page.tsx`, add an extra useless request inside prefetch. (E.g.,     `learningResourceQueries.featured({ limit: 1 })`. You should see a warning in JS console that a useless prefetch was made.
