### PR TITLE
Celery task to embed new contentfiles

### DIFF
--- a/main/settings_celery.py
+++ b/main/settings_celery.py
@@ -131,12 +131,6 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(minute=30, hour=18),  # 2:30pm EST
         "kwargs": {"period": "daily", "subscription_type": "channel_subscription_type"},
     },
-    "daily_embed_new_learning_resources": {
-        "task": "vector_search.tasks.embed_new_learning_resources",
-        "schedule": get_int(
-            "EMBED_NEW_RESOURCES_SCHEDULE_SECONDS", 60 * 30
-        ),  # default is every 30 minutes
-    },
     "send-search-subscription-emails-every-1-days": {
         "task": "learning_resources_search.tasks.send_subscription_emails",
         "schedule": crontab(minute=0, hour=19),  # 3:00pm EST
@@ -156,6 +150,13 @@ if not DEV_ENV:
             "EMBED_NEW_RESOURCES_SCHEDULE_SECONDS", 60 * 30
         ),  # default is every 30 minutes
     }
+    CELERY_BEAT_SCHEDULE["daily_embed_new_content_files"] = {
+        "task": "vector_search.tasks.embed_new_content_files",
+        "schedule": get_int(
+            "EMBED_NEW_CONTENT_FILES_SCHEDULE_SECONDS", 60 * 30
+        ),  # default is every 30 minutes
+    }
+
 
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/6705

### Description (What does it do?)
This PR introduces a periodic celery task to pickup contentfiles added within the last day and generate embeddings for them 

### How can this be tested?
To manually test this:
1. checkout this branch
2. restart the celery container
3. go to your [local qdrant dashboard](http://localhost:6333/dashboard#/collections) and delete the existing contentfiles collection
4. in django shell - we will run a script that makes sure only one ContentFile object has a created_on date of within the last day and then runs the daily embed task:
```python
from learning_resources.models import (
        ContentFile,
    )
import datetime
import random
from vector_search.utils import vector_point_id
from vector_search.tasks import embed_new_content_files

ContentFile.objects.all().update(created_on=datetime.datetime.now() - datetime.timedelta(days=2))
cfids = list(ContentFile.objects.values_list('id',flat=True))
cfid = random.choice(cfids)
cf = ContentFile.objects.get(id=cfid)
cf.created_on = datetime.datetime.now()
cf.save()
embed_new_content_files.run()
print(f"point id for embedding - {vector_point_id(f"{cf.run.learning_resource.readable_id}.{cf.run.run_id}.{cf.key}.0")}")
```
5. run ```print(f"point id for embedding - {vector_point_id(f"{cf.run.learning_resource.readable_id}.{cf.run.run_id}.{cf.key}.0")}")``` to print the qdrant point ID of one of the chunks that we can check for in the collection. copy this ID
6. go to the [content files collection](http://localhost:6333/dashboard#/collections/resource_embeddings.content_files) in qdrant
7. search for the ID you just copied in the collection `id:<your point id>` and confirm the record shows up.

