### PR TITLE
Handle "next" query string param in CustomLogoutView

### DIFF
--- a/authentication/views.py
+++ b/authentication/views.py
@@ -5,6 +5,7 @@ from urllib.parse import urlencode
 from django.conf import settings
 from django.contrib.auth import views
 from django.shortcuts import redirect
+from social_core.utils import sanitize_redirect
 from social_django.utils import load_strategy
 
 from authentication.backends.ol_open_id_connect import OlOpenIdConnectAuth
@@ -34,6 +35,9 @@ class CustomLogoutView(views.LogoutView):
         ).first()
         id_token = user_social_auth_record.extra_data.get("id_token")
         qs_next = self.request.GET.get("next")
+        if qs_next:
+            allowed_hosts = settings.SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS or []
+            qs_next = sanitize_redirect(allowed_hosts, qs_next)
         qs = urlencode(
             {
                 "id_token_hint": id_token,

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -33,12 +33,13 @@ class CustomLogoutView(views.LogoutView):
             user, provider=OlOpenIdConnectAuth.name
         ).first()
         id_token = user_social_auth_record.extra_data.get("id_token")
+        qs_next = self.request.GET.get("next")
         qs = urlencode(
             {
                 "id_token_hint": id_token,
-                "post_logout_redirect_uri": self.request.build_absolute_uri(
-                    settings.LOGOUT_REDIRECT_URL
-                ),
+                "post_logout_redirect_uri": qs_next
+                if qs_next
+                else self.request.build_absolute_uri(settings.LOGOUT_REDIRECT_URL),
             }
         )
 
@@ -55,7 +56,7 @@ class CustomLogoutView(views.LogoutView):
         **kwargs,  # noqa: ARG002
     ):
         """
-        GET endpoint for loggin a user out.
+        GET endpoint for logging a user out.
 
         The logout redirect path the user follows is:
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6789

### Description (What does it do?)
This PR sets up the `CustomLogoutView`'s `_keycloak_logout_url` function to properly pass the `next` query string param to Keycloak as `post_logout_redirect_uri` if it is passed along in the initial request to `/logout`. In this case, it would be sent instead of the value of `settings.LOGOUT_REDIRECT_URL`.

### How can this be tested?
 - Spin up `mit-learn` locally on this branch
 - Log in to the site at http://localhost:8062/ in your usual way
 - Click the User Menu in the upper right, then right click on "Log Out" and click "Copy link address"
 - Open a new tab and paste in the URL, but don't go to it yet
 - At the end of the URL, add: `?next=https://www.google.com
 - Verify that when you hit enter, you are brought to Google
 - Navigate back to your instance of MIT Learn and verify that you are logged out
