### PR TITLE
Fix SCIM search API sort and pagination

### DIFF
--- a/scim/urls.py
+++ b/scim/urls.py
@@ -6,12 +6,13 @@ from scim import views
 
 ol_scim_urls = (
     [
-        re_path("^Bulk$", views.BulkView.as_view(), name="bulk"),
+        re_path(r"^Bulk$", views.BulkView.as_view(), name="bulk"),
+        re_path(r"^\.search$", views.SearchView.as_view(), name="users-search"),
     ],
     "ol-scim",
 )
 
 urlpatterns = [
-    re_path("^scim/v2/", include(ol_scim_urls)),
-    re_path("^scim/v2/", include("django_scim.urls", namespace="scim")),
+    re_path(r"^scim/v2/", include(ol_scim_urls)),
+    re_path(r"^scim/v2/", include("django_scim.urls", namespace="scim")),
 ]

--- a/scim/views_test.py
+++ b/scim/views_test.py
@@ -415,28 +415,86 @@ def test_bulk_post(scim_client, bulk_test_data):
                     assert actual_value == expected_value
 
 
-def test_user_search(scim_client):
+@pytest.mark.parametrize(
+    ("sort_by", "sort_order"),
+    [
+        (None, None),
+        ("email", None),
+        ("email", "ascending"),
+        ("email", "descending"),
+        ("username", None),
+        ("username", "ascending"),
+        ("username", "descending"),
+    ],
+)
+@pytest.mark.parametrize("count", [None, 100, 500])
+def test_user_search(scim_client, sort_by, sort_order, count):
     """Test the user search endpoint"""
-    users = UserFactory.create_batch(1500)
-    emails = [user.email for user in users[:1000]]
+    large_user_set = UserFactory.create_batch(1100)
+    search_users = large_user_set[:1000]
+    emails = [user.email for user in search_users]
 
-    resp = scim_client.post(
-        f"{reverse('scim:users-search')}?count={len(emails)}",
-        content_type="application/scim+json",
-        data=json.dumps(
-            {
-                "schemas": [djs_constants.SchemaURI.SERACH_REQUEST],
-                "filter": " OR ".join([f'email EQ "{email}"' for email in emails]),
-            }
-        ),
-    )
+    expected = search_users
 
-    assert resp.status_code == 200
+    effective_count = count or 50
+    effective_sort_order = sort_order or "ascending"
 
-    data = resp.json()
+    if sort_by is not None:
+        expected = sorted(
+            expected,
+            # postgres sort is case-insensitive
+            key=lambda user: getattr(user, sort_by).lower(),
+            reverse=effective_sort_order == "descending",
+        )
 
-    assert data["totalResults"] == len(emails)
-    assert len(data["Resources"]) == len(emails)
+    for page in range(int(len(emails) / effective_count)):
+        start_index = page * effective_count  # zero based index
+        resp = scim_client.post(
+            reverse("ol-scim:users-search"),
+            content_type="application/scim+json",
+            data=json.dumps(
+                {
+                    "schemas": [djs_constants.SchemaURI.SERACH_REQUEST],
+                    "filter": " OR ".join([f'email EQ "{email}"' for email in emails]),
+                    "startIndex": start_index + 1,  # SCIM API is 1-based index
+                    **({"sortBy": sort_by} if sort_by is not None else {}),
+                    **({"sortOrder": sort_order} if sort_order is not None else {}),
+                    **({"count": count} if count is not None else {}),
+                }
+            ),
+        )
 
-    for resource in data["Resources"]:
-        assert resource["emails"][0]["value"] in emails
+        expected_in_resp = expected[start_index : start_index + effective_count]
+
+        assert resp.status_code == 200, f"Got error: {resp.content}"
+        assert resp.json() == {
+            "totalResults": len(emails),
+            "itemsPerPage": effective_count,
+            "startIndex": start_index + 1,
+            "schemas": [djs_constants.SchemaURI.LIST_RESPONSE],
+            "Resources": [
+                {
+                    "id": user.profile.scim_id,
+                    "active": user.is_active,
+                    "userName": user.username,
+                    "displayName": user.profile.name,
+                    "emails": [{"value": user.email, "primary": True}],
+                    "externalId": str(user.profile.scim_external_id),
+                    "name": {
+                        "givenName": user.first_name,
+                        "familyName": user.last_name,
+                    },
+                    "meta": {
+                        "resourceType": "User",
+                        "location": f"https://localhost/scim/v2/Users/{user.profile.scim_id}",
+                        "lastModified": user.profile.updated_at.isoformat(
+                            timespec="milliseconds"
+                        ),
+                        "created": user.date_joined.isoformat(timespec="milliseconds"),
+                    },
+                    "groups": [],
+                    "schemas": [djs_constants.SchemaURI.USER],
+                }
+                for user in expected_in_resp
+            ],
+        }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/6805

### Description (What does it do?)
<!--- Describe your changes in detail -->
This overrides the implementation for the SCIM user search API to:
- Correctly take the pagination information from the POST body instead of query string per spec
- Apply sorting to the queryset (this broke when we implemented improved query filtering

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
The tests cover pagination of larger data sets, you probably don't have enough local users to test the actual situation we hit in deployed environments, but the integration tests + running a SCIM sync locally should be enough to very you don't hit any errors. Setup instructions are in `scim/README.md` if you haven't yet.
