### PR TITLE
add option to skip onboarding with query string arg during account creation

### DIFF
--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -1,5 +1,7 @@
 """Tests of user pipeline actions"""
 
+from urllib.parse import urlparse
+
 import pytest
 
 from authentication.pipeline import user as user_actions
@@ -82,7 +84,7 @@ def test_user_onboarding_actions(
         "details": {},
         "backend": mock_backend,
     }
-    netloc = next_qs.split("/")[2]
+    netloc = urlparse(next_qs).netloc if next_qs else None
     expected_allowed_hosts = (
         [*social_auth_allowed_redirect_hosts, "example.com"]
         if social_auth_allowed_redirect_hosts

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -43,3 +43,59 @@ def test_user_created_actions(mocker, is_new):
 
     user_actions.user_created_actions(**kwargs)
     assert user.user_lists.count() == (1 if is_new else 0)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("is_new", [True, False])
+@pytest.mark.parametrize("skip_onboarding", [True, False])
+@pytest.mark.parametrize("next_qs", ["http://example1.com", None])
+@pytest.mark.parametrize("social_auth_allowed_redirect_hosts", [["example1.com"], None])
+def test_user_onboarding_actions(
+    mocker, is_new, skip_onboarding, next_qs, social_auth_allowed_redirect_hosts
+):
+    """
+    Tests that user_created_actions creates a favorites list for new users only
+    """
+
+    def setting_side_effect(name, default=None):
+        if name == "NEW_USER_LOGIN_REDIRECT_URL":
+            return "http://example.com"
+        if name == "SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS":
+            return social_auth_allowed_redirect_hosts
+        return None
+
+    def session_get_side_effect(name):
+        if name == "skip_onboarding":
+            return skip_onboarding
+        if name == "next":
+            return next_qs
+        return None
+
+    mock_backend = mocker.Mock(name="email")
+    mock_backend.setting.side_effect = setting_side_effect
+    mock_backend.strategy.session_get.side_effect = session_get_side_effect
+    mock_backend.strategy.request_host = mocker.Mock(return_value="example.com")
+    user = UserFactory.create()
+    kwargs = {
+        "user": user,
+        "is_new": is_new,
+        "details": {},
+        "backend": mock_backend,
+    }
+    netloc = next_qs.split("/")[2]
+    expected_allowed_hosts = (
+        [*social_auth_allowed_redirect_hosts, "example.com"]
+        if social_auth_allowed_redirect_hosts
+        else ["example.com"]
+    )
+    expected_next = None
+    if is_new and not skip_onboarding:
+        expected_next = "http://example.com"
+    elif next_qs and netloc in expected_allowed_hosts:
+        expected_next = next_qs
+
+    user_actions.user_onboarding(**kwargs)
+    if expected_next:
+        mock_backend.strategy.session_set.assert_called_once_with("next", expected_next)
+    else:
+        mock_backend.strategy.session_set.assert_not_called()

--- a/main/settings.py
+++ b/main/settings.py
@@ -309,6 +309,7 @@ SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS = [
 SOCIAL_AUTH_PROTECTED_USER_FIELDS = [
     "profile",  # this avoids an error because profile is a related model
 ]
+SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = ["skip_onboarding", "next"]
 
 SOCIAL_AUTH_PIPELINE = (
     # Checks if an admin user attempts to login/register while hijacking another user.


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6790

### Description (What does it do?)
This PR adds the ability to skip onboarding when creating a new user, instead redirecting to the sanitized `next` query string param if available.

### How can this be tested?
- In your `.env` file, set `SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS=["google.com"]
- Make sure you have Keycloak configured, and you have an email address not currently in use on the Keycloak instance you are using (If you have a GMail account, you can follow these instructions: https://github.com/mitodl/hq/issues/6790#issuecomment-2674795563)
- Spin up `mit-learn` on this branch
- Open an incognito window and browse to http://localhost:8062/login/ol-oidc?skip_onboarding=true&next=https://google.com/
- Click on "Sign Up"
- Fill out the details and click "Sign Up"
- Check the email address you typed in, and there should be a link there to verify your email, click it
- After clicking the link, you should be redirected to Google
