### PR TITLE
Make embedding generation task use correct run

### DIFF
--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -104,7 +104,11 @@ def start_embed_resources(self, indexes, skip_content_files, overwrite):
                     .exclude(readable_id=blocklisted_ids)
                     .order_by("id")
                 ):
-                    run = course.next_run
+                    run = (
+                        course.next_run
+                        if course.next_run
+                        else course.runs.order_by("-start_date").first()
+                    )
                     run_contentfiles = (
                         ContentFile.objects.filter(
                             run=run,
@@ -188,7 +192,11 @@ def embed_learning_resources_by_id(self, ids, skip_content_files, overwrite):
                 for course in embed_resources.filter(
                     etl_source__in=RESOURCE_FILE_ETL_SOURCES
                 ).order_by("id"):
-                    run = course.next_run
+                    run = (
+                        course.next_run
+                        if course.next_run
+                        else course.runs.order_by("-start_date").first()
+                    )
                     run_contentfiles = ContentFile.objects.filter(
                         run=run,
                         published=True,

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -104,11 +104,7 @@ def start_embed_resources(self, indexes, skip_content_files, overwrite):
                     .exclude(readable_id=blocklisted_ids)
                     .order_by("id")
                 ):
-                    run = (
-                        course.runs.filter(published=True)
-                        .order_by("-start_date")
-                        .first()
-                    )
+                    run = course.next_run
                     run_contentfiles = (
                         ContentFile.objects.filter(
                             run=run,
@@ -192,11 +188,7 @@ def embed_learning_resources_by_id(self, ids, skip_content_files, overwrite):
                 for course in embed_resources.filter(
                     etl_source__in=RESOURCE_FILE_ETL_SOURCES
                 ).order_by("id"):
-                    run = (
-                        course.runs.filter(published=True)
-                        .order_by("-start_date")
-                        .first()
-                    )
+                    run = course.next_run
                     run_contentfiles = ContentFile.objects.filter(
                         run=run,
                         published=True,

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -107,7 +107,9 @@ def start_embed_resources(self, indexes, skip_content_files, overwrite):
                     run = (
                         course.next_run
                         if course.next_run
-                        else course.runs.order_by("-start_date").first()
+                        else course.runs.filter(published=True)
+                        .order_by("-start_date")
+                        .first()
                     )
                     run_contentfiles = (
                         ContentFile.objects.filter(
@@ -195,7 +197,9 @@ def embed_learning_resources_by_id(self, ids, skip_content_files, overwrite):
                     run = (
                         course.next_run
                         if course.next_run
-                        else course.runs.order_by("-start_date").first()
+                        else course.runs.filter(published=True)
+                        .order_by("-start_date")
+                        .first()
                     )
                     run_contentfiles = ContentFile.objects.filter(
                         run=run,

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -221,3 +221,41 @@ def test_embed_learning_resources_by_id(mocker, mocked_celery):
         assert mock_call.args[1] == "content_file"
     embedded_resource_ids = generate_embeddings_mock.si.mock_calls[0].args[0]
     assert sorted(resource_ids) == sorted(embedded_resource_ids)
+
+
+def test_embedded_content_from_next_run(mocker, mocked_celery):
+    """
+    Content files to embed should come from next course run
+    """
+
+    mocker.patch("vector_search.tasks.load_course_blocklist", return_value=[])
+
+    course = CourseFactory.create(etl_source=ETLSource.ocw.value)
+
+    latest_run = LearningResourceRunFactory.create(
+        learning_resource=course.learning_resource,
+        created_on=datetime.datetime.now(tz=datetime.UTC),
+    )
+    # create contentfiles using the latest run
+    ContentFileFactory.create_batch(3, run=latest_run)
+    next_run_contentfiles = [
+        cf.id
+        for cf in ContentFileFactory.create_batch(
+            3, run=course.learning_resource.next_run
+        )
+    ]
+
+    generate_embeddings_mock = mocker.patch(
+        "vector_search.tasks.generate_embeddings", autospec=True
+    )
+
+    with pytest.raises(mocked_celery.replace_exception_class):
+        start_embed_resources.delay(
+            ["course"], skip_content_files=False, overwrite=True
+        )
+
+    generate_embeddings_mock.si.assert_called_with(
+        next_run_contentfiles,
+        "content_file",
+        True,  # noqa: FBT003
+    )

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -259,3 +259,35 @@ def test_embedded_content_from_next_run(mocker, mocked_celery):
         "content_file",
         True,  # noqa: FBT003
     )
+
+
+def test_embedded_content_from_latest_run_if_next_missing(mocker, mocked_celery):
+    """
+    Content files to embed should come from latest run if the next run is missing
+    """
+
+    mocker.patch("vector_search.tasks.load_course_blocklist", return_value=[])
+
+    course = CourseFactory.create(etl_source=ETLSource.ocw.value)
+    course.runs.all().delete()
+    latest_run = LearningResourceRunFactory.create(
+        learning_resource=course.learning_resource,
+        created_on=datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(hours=1),
+    )
+    latest_run_contentfiles = [
+        cf.id for cf in ContentFileFactory.create_batch(3, run=latest_run)
+    ]
+    generate_embeddings_mock = mocker.patch(
+        "vector_search.tasks.generate_embeddings", autospec=True
+    )
+
+    with pytest.raises(mocked_celery.replace_exception_class):
+        start_embed_resources.delay(
+            ["course"], skip_content_files=False, overwrite=True
+        )
+
+    generate_embeddings_mock.si.assert_called_with(
+        latest_run_contentfiles,
+        "content_file",
+        True,  # noqa: FBT003
+    )

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -232,18 +232,23 @@ def test_embedded_content_from_next_run(mocker, mocked_celery):
 
     course = CourseFactory.create(etl_source=ETLSource.ocw.value)
 
-    latest_run = LearningResourceRunFactory.create(
+    other_run = LearningResourceRunFactory.create(
+        learning_resource=course.learning_resource,
+        created_on=datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=2),
+    )
+    LearningResourceRunFactory.create(
         learning_resource=course.learning_resource,
         created_on=datetime.datetime.now(tz=datetime.UTC),
     )
-    # create contentfiles using the latest run
-    ContentFileFactory.create_batch(3, run=latest_run)
+
     next_run_contentfiles = [
         cf.id
         for cf in ContentFileFactory.create_batch(
             3, run=course.learning_resource.next_run
         )
     ]
+    # create contentfiles using the other run
+    ContentFileFactory.create_batch(3, run=other_run)
 
     generate_embeddings_mock = mocker.patch(
         "vector_search.tasks.generate_embeddings", autospec=True


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/6832
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This Pr makes it so that the embedding process for contentfiles pulls the contentfiles from the "next run" of the learning resource rather than the latest run.

### How can this be tested?
1. Checkout this branch.
2. embedding contentfiles should work as expected ```python manage.py generate_embeddings --all```
