### PR TITLE
Fix the SCIM user search URL

### DIFF
--- a/scim/urls.py
+++ b/scim/urls.py
@@ -7,7 +7,7 @@ from scim import views
 ol_scim_urls = (
     [
         re_path(r"^Bulk$", views.BulkView.as_view(), name="bulk"),
-        re_path(r"^\.search$", views.SearchView.as_view(), name="users-search"),
+        re_path(r"^Users/\.search$", views.SearchView.as_view(), name="users-search"),
     ],
     "ol-scim",
 )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
The endpoint was supposed to be overriding the search endpoint for `/Users/.search` but somehow that got lost in the previous PR. Example request from the plugin:
```
2025-02-28 14:47:45,055 TRACE [de.captaingoldfish.scim.sdk.client.http.ScimHttpClient] (executor-thread-716) Sending http request:
	method: POST
	uri: https://api.learn.odl.local/scim/v2/Users/.search
```

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
You can run this locally, but the difference isn't obvious unless you have 500 or so users locally. I'd suggest just doing a smoke test and verifying the code looks correct / tests pass.
