### PR TITLE
Fix the casing of the sort field for SCIM search

### DIFF
--- a/scim/constants.py
+++ b/scim/constants.py
@@ -5,3 +5,12 @@ class SchemaURI:
     BULK_REQUEST = "urn:ietf:params:scim:api:messages:2.0:BulkRequest"
 
     BULK_RESPONSE = "urn:ietf:params:scim:api:messages:2.0:BulkResponse"
+
+
+SORT_MAPPING = {
+    "id": "id",
+    "userName": "username",
+    "email": "email",
+}
+
+VALID_SORTS = SORT_MAPPING.keys()

--- a/scim/views.py
+++ b/scim/views.py
@@ -178,11 +178,13 @@ class SearchView(djs_views.UserSearchView):
         sort_order = body.get("sortOrder", "ascending")
         query = body.get("filter", None)
 
-        if sort_by is not None and sort_by not in ("id", "email", "username"):
-            msg = "Sorting only supports email or username"
+        if sort_by not in constants.VALID_SORTS:
+            msg = f"Sorting only supports: {', '.join(constants.VALID_SORTS)}"
             raise exceptions.BadRequestError(msg)
+        else:
+            sort_by = constants.SORT_MAPPING[sort_by]
 
-        if sort_order is not None and sort_order not in ("ascending", "descending"):
+        if sort_order not in ("ascending", "descending"):
             msg = "Sorting only supports ascending or descending"
             raise exceptions.BadRequestError(msg)
 

--- a/scim/views_test.py
+++ b/scim/views_test.py
@@ -433,9 +433,9 @@ def test_bulk_post(scim_client, bulk_test_data):
         ("email", None),
         ("email", "ascending"),
         ("email", "descending"),
-        ("username", None),
-        ("username", "ascending"),
-        ("username", "descending"),
+        ("userName", None),
+        ("userName", "ascending"),
+        ("userName", "descending"),
     ],
 )
 @pytest.mark.parametrize("count", [None, 100, 500])
@@ -447,7 +447,7 @@ def test_user_search(large_user_set, scim_client, sort_by, sort_order, count):
     expected = search_users
 
     effective_count = count or 50
-    effective_sort_by = sort_by or "id"
+    effective_sort_by = constants.SORT_MAPPING[sort_by or "id"]
     effective_sort_order = sort_order or "ascending"
 
     def _sort(user):


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Requests come in this format:
```
{'schemas': ['urn:ietf:params:scim:api:messages:2.0:SearchRequest'], 'filter': 'emails.value EQ "jackson@example.com"', 'sortBy': 'userName', 'excludedAttributes': 'groups.value,groups.$ref,groups.display,groups,emails.display,manager.displayName'}`
```

The view code that was handling the sorting was expecting `username` but it is actually `userName`.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Tests should pass.