### PR TITLE
Update README to point to separate keycloak readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,26 +211,10 @@ This repo includes a config for running a [Jupyter notebook](https://jupyter.org
 
 From there, you should be able to run code snippets with a live Django app just like you would in a Django shell.
 
-### Connecting with an OpenID Connect provider for authentication
+### Connecting with Keycloak for authentication
 
-The MIT Learn application relies on an OpenID Connect client provided by Keycloak for authentication.
-
-The following environment variables must be defined using values from a Keycloak instance:
-
-- SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT - The base URI for OpenID Connect discovery, https://<OIDC_ENDPOINT>/ without .well-known/openid-configuration.
-- OIDC_ENDPOINT - The base URI for OpenID Connect discovery, https://<OIDC_ENDPOINT>/ without .well-known/openid-configuration.
-
-- SOCIAL_AUTH_OL_OIDC_KEY - The client ID provided by the OpenID Connect provider.
-- SOCIAL_AUTH_OL_OIDC_SECRET - The client secret provided by the OpenID Connect provider.
-- AUTHORIZATION_URL - Provider endpoint where the user is asked to authenticate.
-- ACCESS_TOKEN_URL - Provider endpoint where client exchanges the authorization code for tokens.
-- USERINFO_URL - Provder endpoint where client sends requests for identity claims.
-- KEYCLOAK_BASE_URL - The base URL of the Keycloak instance. Used for generating the
-- KEYCLOAK_REALM_NAME - The Keycloak realm that the OpenID Connect client exists in.
-
-To login via the Keycloak client, open http://od.odl.local:8063/login/ol-oidc in your browser.
-
-Additional details can be found at https://docs.google.com/document/d/17tJ-C2EwWoSpJWZKjuhMVgsqGtyPH0IN9KakXvSKU0M/edit
+Please read [the Keycloak README](README-keycloak.md) for instructions on authenticating via
+local Keycloak and APISIX containers.
 
 ### Configuring PostHog Support
 


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/mit-learn/pull/2061

### Description (What does it do?)
Updates the keycloak section in the main README to link to the separate Keycloak README

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Click the new link the in Keycloak section of the main README, it should send you to the keycloak README


