### PR TITLE
Fix SCIM startIndex parsing

### DIFF
--- a/scim/views.py
+++ b/scim/views.py
@@ -172,8 +172,9 @@ class SearchView(djs_views.UserSearchView):
             msg = "Invalid schema uri. Must be SearchRequest."
             raise exceptions.BadRequestError(msg)
 
-        start = body.get("startIndex", 1)
-        count = body.get("count", 50)
+        # cast to ints because scim-for-keycloak sends strings
+        start = int(body.get("startIndex", 1))
+        count = int(body.get("count", 50))
         sort_by = body.get("sortBy", "id")
         sort_order = body.get("sortOrder", "ascending")
         query = body.get("filter", None)

--- a/scim/views_test.py
+++ b/scim/views_test.py
@@ -471,10 +471,12 @@ def test_user_search(large_user_set, scim_client, sort_by, sort_order, count):
                 {
                     "schemas": [djs_constants.SchemaURI.SERACH_REQUEST],
                     "filter": " OR ".join([f'email EQ "{email}"' for email in emails]),
-                    "startIndex": start_index + 1,  # SCIM API is 1-based index
+                    # SCIM API is 1-based index
+                    # Additionally, scim-for-keycloak sends this as a string, but spec examples have ints
+                    "startIndex": str(start_index + 1),
                     **({"sortBy": sort_by} if sort_by is not None else {}),
                     **({"sortOrder": sort_order} if sort_order is not None else {}),
-                    **({"count": count} if count is not None else {}),
+                    **({"count": str(count)} if count is not None else {}),
                 }
             ),
         )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/6852

### Description (What does it do?)
<!--- Describe your changes in detail -->
This parses `count` and `startIndex`  in the SCIM user search API as strings.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
This is hard to functionally test unless you have 100s of keycloak users. The tests passing should be enough as they explicitly cast the inputs to strings.