### PR TITLE
Fix stale rendering on Syllabus chat

### DIFF
--- a/frontends/main/src/page-components/AiChat/AiChatWithEntryScreen.tsx
+++ b/frontends/main/src/page-components/AiChat/AiChatWithEntryScreen.tsx
@@ -121,6 +121,7 @@ const AiChatWithEntryScreen = ({
   onClose,
   chatScreenClassName,
   className,
+  chatId,
 }: {
   entryTitle: string
   starters: AiChatProps["conversationStarters"]
@@ -130,6 +131,7 @@ const AiChatWithEntryScreen = ({
   onClose?: () => void
   className?: string
   chatScreenClassName?: string
+  chatId?: string
 }) => {
   const [initialPrompt, setInitialPrompt] = useState("")
   const [showEntryScreen, setShowEntryScreen] = useState(true)
@@ -221,6 +223,7 @@ const AiChatWithEntryScreen = ({
             onClose={onClose}
             requestOpts={requestOpts}
             ref={aiChatRef}
+            chatId={chatId}
           />
         </ChatScreen>
       )}

--- a/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx
@@ -145,6 +145,7 @@ const AiChatSyllabusSlideDown = ({
       </Opener>
       <SlideDown open={open} inert={!open}>
         <StyledAiChatWithEntryScreen
+          key={resource.readable_id}
           entryTitle="What do you want to know about this course?"
           starters={STARTERS}
           initialMessages={getInitialMessage(resource, user.data)}

--- a/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx
@@ -145,7 +145,7 @@ const AiChatSyllabusSlideDown = ({
       </Opener>
       <SlideDown open={open} inert={!open}>
         <StyledAiChatWithEntryScreen
-          key={resource.readable_id}
+          chatId={resource.readable_id}
           entryTitle="What do you want to know about this course?"
           starters={STARTERS}
           initialMessages={getInitialMessage(resource, user.data)}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Closes https://github.com/mitodl/hq/issues/6836

### Description (What does it do?)
<!--- Describe your changes in detail -->

Passes the readable resource ID as chat ID to the AiChat component to re-render initial message with selected course name.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Open the resource drawer.
- Open the chat ("AskTIM about this course") and enter a prompt.
- Note the "Hello and welcome to <name>" assistant text.
- Close the chat. Do not close the drawer,
- Select another course from the drawer carousels.
- Open the chat.
- Confirm that "Hello and welcome to <name>" reflects the current course.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

This does not restore the previous chat history as expected. When navigating between courses within the drawer, the chat will open at the chat screen with the current course.

The other option ([previous commit](https://github.com/mitodl/mit-learn/commit/40ae1647bf09305614828f9e3b69bf1e1a7a2e80)) was just to key the component with the resource ID. This also produces a new render, however with this option each new chat returns to the entry screen.
