### PR TITLE
removing school from departments display

### DIFF
--- a/vector_search/serializers.py
+++ b/vector_search/serializers.py
@@ -55,13 +55,20 @@ class LearningResourceMetadataDisplaySerializer(serializers.Serializer):
     platform_display = serializers.SerializerMethodField()
 
     def get_departments_display(self, serialized_resource):
-        return ", ".join(
-            f"{department['name']}"
-            for department in serialized_resource.get("departments", [])
-        )
+        department_vals = []
+        for department in serialized_resource.get("departments", []):
+            school_display = (
+                f" ({department['school']['name']})" if department.get("school") else ""
+            )
+            department_vals.append(f"{department['name']}{school_display}")
+        return ", ".join(department_vals)
 
     def get_platform_display(self, serialized_resource):
-        return serialized_resource["platform"]["name"]
+        return (
+            serialized_resource["platform"].get("name")
+            if serialized_resource.get("platform")
+            else ""
+        )
 
     def get_levels_display(self, serialized_resource):
         levels = []
@@ -121,7 +128,11 @@ class LearningResourceMetadataDisplaySerializer(serializers.Serializer):
         )
 
     def get_certification_display(self, serialized_resource):
-        return serialized_resource.get("certification_type", {}).get("name")
+        return (
+            serialized_resource["certification_type"].get("name")
+            if serialized_resource.get("certification_type")
+            else ""
+        )
 
     def get_price_display(self, serialized_resource):
         return (

--- a/vector_search/serializers.py
+++ b/vector_search/serializers.py
@@ -78,7 +78,11 @@ class LearningResourceMetadataDisplaySerializer(serializers.Serializer):
         return ", ".join(set(languages))
 
     def get_offered_by_display(self, serialized_resource):
-        return serialized_resource.get("offered_by", {}).get("name")
+        return (
+            serialized_resource["offered_by"].get("name")
+            if serialized_resource.get("offered_by")
+            else ""
+        )
 
     def get_runs_display(self, serialized_resource):
         runs = []

--- a/vector_search/serializers.py
+++ b/vector_search/serializers.py
@@ -56,7 +56,7 @@ class LearningResourceMetadataDisplaySerializer(serializers.Serializer):
 
     def get_departments_display(self, serialized_resource):
         return ", ".join(
-            f"{department['name']} ({department['school']['name']})"
+            f"{department['name']}"
             for department in serialized_resource.get("departments", [])
         )
 

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -234,11 +234,11 @@ def test_embedded_content_from_next_run(mocker, mocked_celery):
     course.runs.all().delete()
     other_run = LearningResourceRunFactory.create(
         learning_resource=course.learning_resource,
-        created_on=datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=2),
+        start_date=datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=2),
     )
     LearningResourceRunFactory.create(
         learning_resource=course.learning_resource,
-        created_on=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=2),
+        start_date=datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=2),
     )
 
     next_run_contentfiles = [
@@ -277,7 +277,7 @@ def test_embedded_content_from_latest_run_if_next_missing(mocker, mocked_celery)
     course.runs.all().delete()
     latest_run = LearningResourceRunFactory.create(
         learning_resource=course.learning_resource,
-        created_on=datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(hours=1),
+        start_date=datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(hours=1),
     )
     latest_run_contentfiles = [
         cf.id for cf in ContentFileFactory.create_batch(3, run=latest_run)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/6881
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This Pr removes the department.school from the departments display attribute in the LearningResourceMetadataDisplaySerializer. It was causing an exception while running embeddings since not every department has that defined. Removing it for now since it doesnt add much to the departments display and so i can re-run the contentfile embeddings.

### How can this be tested?
1. checkout this branch.
2. restart celery
3. running the following to set some learning resource's department to a department with no school. make note of the resource id
```
from learning_resources.models import ContentFile,LearningResource, LearningResourceDepartment
dept = LearningResourceDepartment.objects.filter(school__isnull=True).first()
lr = LearningResource.objects.first()
lr.dept = dept
lr.save()
print(lr.id)
```
4. run embeddings for that one resource. it should not error out ```python manage.py generate_embeddings --resource-ids <resource id> --overwrite```

# Additional context
This PR also has a fix for a flakey test that surfaced