### PR TITLE
fix asset ids

### DIFF
--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -356,13 +356,14 @@ def get_edx_module_id(path: str, run: LearningResourceRun) -> str:
     Returns:
         str: The XBlock ID
     """
-    name = Path(path).stem
     folder = path.split("/")[-2]
 
     if folder == "static":
+        name = Path(path).name
         key_type = "asset-v1"
         module_type = "asset"
     else:
+        name = Path(path).stem
         key_type = "block-v1"
         module_type = folder
 

--- a/learning_resources/etl/utils_test.py
+++ b/learning_resources/etl/utils_test.py
@@ -180,7 +180,7 @@ def test_transform_content_files(  # noqa: PLR0913
     """transform_content_files"""
     run = LearningResourceRunFactory.create(published=True)
     document = "some text in the document"
-    file_extension = ".html"
+    file_extension = ".pdf" if folder == "static" else ".html"
     key = f"key{file_extension}"
     content_type = "course"
     checksum = "7s35721d1647f962d59b8120a52210a7"
@@ -228,7 +228,7 @@ def test_transform_content_files(  # noqa: PLR0913
 
     if folder == "static":
         edx_module_id = (
-            f"asset-v1:{run.run_id.replace('course-v1:', '')}+type@asset+block@key"
+            f"asset-v1:{run.run_id.replace('course-v1:', '')}+type@asset+block@key.pdf"
         )
     else:
         edx_module_id = (
@@ -240,14 +240,10 @@ def test_transform_content_files(  # noqa: PLR0913
             {
                 "content": "existing content"
                 if (matching_checksum and not overwrite)
-                else tika_output["content"]
-                if file_extension == ".html" or matching_checksum
-                else "",
+                else tika_output["content"],
                 "key": key,
                 "published": True,
-                "content_title": metadata["title"]
-                if has_metadata and file_extension == ".html"
-                else "",
+                "content_title": metadata["title"] if has_metadata else "",
                 "content_type": content_type,
                 "checksum": checksum,
                 "file_extension": file_extension,


### PR DESCRIPTION
### What are the relevant tickets?
NA

### Description (What does it do?)
edx_module_ids for files in the static folder which have edx_module_id starting with asset-v1 should have the file extension as part of the id. For example, sset-v1:xPRO+LASERx1+R18+type@asset+block@c2026f0d-30bd-4da6-adab-8679c3656dcf-en should be sset-v1:xPRO+LASERx1+R18+type@asset+block@c2026f0d-30bd-4da6-adab-8679c3656dcf-en.srt

### How can this be tested?
Run `docker-compose run web ./manage.py backpopulate_xpro_files --overwrite`
verify that http://api.open.odl.local:8063/api/v1/contentfiles/?edx_module_id=asset-v1%3AxPRO%2BLASERx1%2BR18%2Btype%40asset%2Bblock%40c2026f0d-30bd-4da6-adab-8679c3656dcf-en.srt returns a content file