### PR TITLE
Fix contentfile embeddings

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -681,10 +681,10 @@ export interface ContentFile {
   image_src?: string | null
   /**
    *
-   * @type {string}
+   * @type {number}
    * @memberof ContentFile
    */
-  resource_id: string
+  resource_id: number
   /**
    *
    * @type {string}

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -570,19 +570,19 @@ export interface ContentFile {
    * @type {number}
    * @memberof ContentFile
    */
-  run_id: number
+  run_id?: number
   /**
    *
    * @type {string}
    * @memberof ContentFile
    */
-  run_title: string
+  run_title?: string
   /**
    *
    * @type {string}
    * @memberof ContentFile
    */
-  run_slug: string
+  run_slug?: string
   /**
    *
    * @type {Array<LearningResourceDepartment>}
@@ -594,13 +594,13 @@ export interface ContentFile {
    * @type {string}
    * @memberof ContentFile
    */
-  semester: string
+  semester?: string
   /**
    *
    * @type {number}
    * @memberof ContentFile
    */
-  year: number
+  year?: number
   /**
    *
    * @type {Array<LearningResourceTopic>}
@@ -726,7 +726,7 @@ export interface ContentFile {
    * @type {string}
    * @memberof ContentFile
    */
-  run_readable_id: string
+  run_readable_id?: string
   /**
    *
    * @type {string}

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -681,10 +681,10 @@ export interface ContentFile {
   image_src?: string | null
   /**
    *
-   * @type {number}
+   * @type {string}
    * @memberof ContentFile
    */
-  resource_id: number
+  resource_id: string
   /**
    *
    * @type {string}

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -351,10 +351,10 @@ export interface ContentFile {
   image_src?: string | null
   /**
    *
-   * @type {string}
+   * @type {number}
    * @memberof ContentFile
    */
-  resource_id: string
+  resource_id: number
   /**
    *
    * @type {string}

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -240,19 +240,19 @@ export interface ContentFile {
    * @type {number}
    * @memberof ContentFile
    */
-  run_id: number
+  run_id?: number
   /**
    *
    * @type {string}
    * @memberof ContentFile
    */
-  run_title: string
+  run_title?: string
   /**
    *
    * @type {string}
    * @memberof ContentFile
    */
-  run_slug: string
+  run_slug?: string
   /**
    *
    * @type {Array<LearningResourceDepartment>}
@@ -264,13 +264,13 @@ export interface ContentFile {
    * @type {string}
    * @memberof ContentFile
    */
-  semester: string
+  semester?: string
   /**
    *
    * @type {number}
    * @memberof ContentFile
    */
-  year: number
+  year?: number
   /**
    *
    * @type {Array<LearningResourceTopic>}
@@ -396,7 +396,7 @@ export interface ContentFile {
    * @type {string}
    * @memberof ContentFile
    */
-  run_readable_id: string
+  run_readable_id?: string
   /**
    *
    * @type {string}

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -351,10 +351,10 @@ export interface ContentFile {
   image_src?: string | null
   /**
    *
-   * @type {number}
+   * @type {string}
    * @memberof ContentFile
    */
-  resource_id: number
+  resource_id: string
   /**
    *
    * @type {string}

--- a/learning_resources/factories.py
+++ b/learning_resources/factories.py
@@ -704,7 +704,8 @@ class LearningPathRelationshipFactory(DjangoModelFactory):
 class ContentFileFactory(DjangoModelFactory):
     """Factory for ContentFiles"""
 
-    run = factory.SubFactory(LearningResourceRunFactory)
+    run = None
+    learning_resource = None
     key = factory.Faker("file_path")
     title = factory.Faker("sentence")
     description = factory.Faker("sentence")
@@ -717,6 +718,26 @@ class ContentFileFactory(DjangoModelFactory):
     file_type = FuzzyChoice(("application/pdf", "video/mp4", "text"))
     published = True
     content_tags = factory.PostGeneration(_post_gen_tags)
+
+    @classmethod
+    def _build(cls, model_class, *args, **kwargs):
+        # make sure that run or learning_resource is defined but not both
+        run = kwargs.pop("run", None)
+        learning_resource = kwargs.pop("learning_resource", None)
+        if run and learning_resource:
+            msg = "run or learning_resource not both."
+            raise ValueError(msg)
+        if not run and not learning_resource:
+            if random.choice([True, False]):  # noqa: S311
+                run = LearningResourceRunFactory()
+                learning_resource = None
+            else:
+                learning_resource = LearningResourceFactory()
+                run = None
+        kwargs["run"] = run
+        kwargs["learning_resource"] = learning_resource
+
+        return super()._build(model_class, *args, **kwargs)
 
     class Meta:
         model = models.ContentFile

--- a/learning_resources/factories.py
+++ b/learning_resources/factories.py
@@ -720,24 +720,18 @@ class ContentFileFactory(DjangoModelFactory):
     content_tags = factory.PostGeneration(_post_gen_tags)
 
     @classmethod
-    def _build(cls, model_class, *args, **kwargs):
-        # make sure that run or learning_resource is defined but not both
+    def _create(cls, model_class, *args, **kwargs):
         run = kwargs.pop("run", None)
         learning_resource = kwargs.pop("learning_resource", None)
         if run and learning_resource:
-            msg = "run or learning_resource not both."
+            msg = "set run or learning_resource not both."
             raise ValueError(msg)
         if not run and not learning_resource:
-            if random.choice([True, False]):  # noqa: S311
-                run = LearningResourceRunFactory()
-                learning_resource = None
-            else:
-                learning_resource = LearningResourceFactory()
-                run = None
+            run = LearningResourceRunFactory()
+            learning_resource = None
         kwargs["run"] = run
         kwargs["learning_resource"] = learning_resource
-
-        return super()._build(model_class, *args, **kwargs)
+        return super()._create(model_class, *args, **kwargs)
 
     class Meta:
         model = models.ContentFile

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -773,12 +773,10 @@ class ContentFileSerializer(serializers.ModelSerializer):
         # prefetch related run and learning resource
         queryset = models.ContentFile.objects.prefetch_related(
             "learning_resource__course",
-            "content_tags",
             "learning_resource__platform",
-            Prefetch(
-                "run",
-                queryset=models.LearningResourceRun.objects.for_serialization(),
-            ),
+            "run__learning_resource__course",
+            "run__learning_resource__platform",
+            "content_tags",
             Prefetch(
                 "learning_resource__topics",
                 queryset=models.LearningResourceTopic.objects.for_serialization(),
@@ -789,6 +787,20 @@ class ContentFileSerializer(serializers.ModelSerializer):
             ),
             Prefetch(
                 "learning_resource__departments",
+                queryset=models.LearningResourceDepartment.objects.for_serialization().select_related(
+                    "school"
+                ),
+            ),
+            Prefetch(
+                "run__learning_resource__topics",
+                queryset=models.LearningResourceTopic.objects.for_serialization(),
+            ),
+            Prefetch(
+                "run__learning_resource__offered_by",
+                queryset=models.LearningResourceOfferor.objects.for_serialization(),
+            ),
+            Prefetch(
+                "run__learning_resource__departments",
                 queryset=models.LearningResourceDepartment.objects.for_serialization().select_related(
                     "school"
                 ),

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -771,13 +771,13 @@ class ContentFileSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         # prefetch related run and learning resource
-        queryset = instance.__class__.objects.prefetch_related(
+        queryset = models.ContentFile.objects.prefetch_related(
+            "learning_resource__course",
+            "content_tags",
+            "learning_resource__platform",
             Prefetch(
                 "run",
                 queryset=models.LearningResourceRun.objects.for_serialization(),
-            ),
-            Prefetch(
-                "learning_resource__course",
             ),
             Prefetch(
                 "learning_resource__topics",
@@ -786,12 +786,6 @@ class ContentFileSerializer(serializers.ModelSerializer):
             Prefetch(
                 "learning_resource__offered_by",
                 queryset=models.LearningResourceOfferor.objects.for_serialization(),
-            ),
-            Prefetch(
-                "learning_resource__platform",
-            ),
-            Prefetch(
-                "content_tags",
             ),
             Prefetch(
                 "learning_resource__departments",

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -760,39 +760,45 @@ class ContentFileSerializer(serializers.ModelSerializer):
     run_slug = serializers.CharField(source="run.slug", required=False)
     semester = serializers.CharField(source="run.semester", required=False)
     year = serializers.IntegerField(source="run.year", required=False)
-    topics = serializers.SerializerMethodField(read_only=True)
-    resource_id = serializers.SerializerMethodField(read_only=True)
-    departments = serializers.SerializerMethodField(read_only=True)
-    resource_readable_id = serializers.SerializerMethodField(read_only=True)
+    topics = serializers.SerializerMethodField()
+    resource_id = serializers.SerializerMethodField()
+    departments = serializers.SerializerMethodField()
+    resource_readable_id = serializers.SerializerMethodField()
     course_number = serializers.SerializerMethodField()
     content_feature_type = LearningResourceContentTagField(source="content_tags")
-    offered_by = serializers.SerializerMethodField(read_only=True)
-    platform = serializers.SerializerMethodField(read_only=True)
+    offered_by = serializers.SerializerMethodField()
+    platform = serializers.SerializerMethodField()
 
     def get_learning_resource(self, instance):
         if instance.run:
             return instance.run.learning_resource
         return instance.learning_resource
 
+    @extend_schema_field(LearningResourcePlatformSerializer())
     def get_platform(self, instance):
         platform = self.get_learning_resource(instance).platform
         return LearningResourcePlatformSerializer(platform).data
 
+    @extend_schema_field(LearningResourceOfferorSerializer())
     def get_offered_by(self, instance):
         offered_by = self.get_learning_resource(instance).offered_by
         return LearningResourceOfferorSerializer(offered_by).data
 
+    @extend_schema_field({"type": "string"})
     def get_resource_readable_id(self, instance):
         return self.get_learning_resource(instance).readable_id
 
+    @extend_schema_field(LearningResourceDepartmentSerializer(many=True))
     def get_departments(self, instance):
         return LearningResourceDepartmentSerializer(
             self.get_learning_resource(instance).departments, many=True
         ).data
 
+    @extend_schema_field({"type": "string"})
     def get_resource_id(self, instance):
         return self.get_learning_resource(instance).id
 
+    @extend_schema_field(LearningResourceTopicSerializer(many=True))
     def get_topics(self, instance):
         return LearningResourceTopicSerializer(
             self.get_learning_resource(instance).topics, many=True

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -794,7 +794,7 @@ class ContentFileSerializer(serializers.ModelSerializer):
             self.get_learning_resource(instance).departments, many=True
         ).data
 
-    @extend_schema_field({"type": "string"})
+    @extend_schema_field({"type": "number"})
     def get_resource_id(self, instance):
         return self.get_learning_resource(instance).id
 

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -794,9 +794,9 @@ class ContentFileSerializer(serializers.ModelSerializer):
             self.get_learning_resource(instance).departments, many=True
         ).data
 
-    @extend_schema_field({"type": "number"})
+    @extend_schema_field({"type": "string"})
     def get_resource_id(self, instance):
-        return self.get_learning_resource(instance).id
+        return str(self.get_learning_resource(instance).id)
 
     @extend_schema_field(LearningResourceTopicSerializer(many=True))
     def get_topics(self, instance):

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -260,6 +260,25 @@ def test_list_content_files_list_endpoint(client):
         assert result["id"] in content_file_ids
 
 
+def test_list_content_files_list_endpoint_with_no_runs(client):
+    """Test ContentFile list endpoint returns results even without associated runs"""
+    course = CourseFactory.create()
+    content_file_ids = [
+        cf.id
+        for cf in ContentFileFactory.create_batch(
+            5, learning_resource=course.learning_resource
+        )
+    ]
+
+    assert reverse("lr:v1:contentfiles_api-list") == "/api/v1/contentfiles/"
+
+    resp = client.get(f"{reverse('lr:v1:contentfiles_api-list')}")
+
+    assert resp.data.get("count") == 5
+    for result in resp.data.get("results"):
+        assert result["id"] in content_file_ids
+
+
 def test_list_content_files_list_filtered(client):
     """Test ContentFile list endpoint"""
     course_1 = CourseFactory.create()

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -745,11 +745,15 @@ class PercolateQuerySubscriptionRequestSerializer(
 
 def serialize_content_file_for_update(content_file_obj):
     """Serialize a content file for API request"""
-
+    parent = (
+        content_file_obj.run.learning_resource_id
+        if content_file_obj.run
+        else content_file_obj.learning_resource.id
+    )
     return {
         "resource_relations": {
             "name": CONTENT_FILE_TYPE,
-            "parent": content_file_obj.run.learning_resource_id,
+            "parent": parent,
         },
         **ContentFileSerializer(content_file_obj).data,
     }

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -1790,6 +1790,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceDepartment'
+          readOnly: true
         semester:
           type: string
         year:
@@ -1798,6 +1799,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
+          readOnly: true
         key:
           type: string
           nullable: true
@@ -1844,8 +1846,10 @@ components:
           maxLength: 200
         resource_id:
           type: string
+          readOnly: true
         resource_readable_id:
           type: string
+          readOnly: true
         course_number:
           type: array
           items:
@@ -1861,9 +1865,13 @@ components:
           nullable: true
           maxLength: 32
         offered_by:
-          $ref: '#/components/schemas/LearningResourceOfferor'
+          allOf:
+          - $ref: '#/components/schemas/LearningResourceOfferor'
+          readOnly: true
         platform:
-          $ref: '#/components/schemas/LearningResourcePlatform'
+          allOf:
+          - $ref: '#/components/schemas/LearningResourcePlatform'
+          readOnly: true
         run_readable_id:
           type: string
         edx_module_id:
@@ -1879,13 +1887,7 @@ components:
       - platform
       - resource_id
       - resource_readable_id
-      - run_id
-      - run_readable_id
-      - run_slug
-      - run_title
-      - semester
       - topics
-      - year
     ContentFileVectorSearchResponse:
       type: object
       description: SearchResponseSerializer with OpenAPI annotations for Content Files

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -1845,7 +1845,7 @@ components:
           nullable: true
           maxLength: 200
         resource_id:
-          type: string
+          type: number
           readOnly: true
         resource_readable_id:
           type: string

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -1845,7 +1845,7 @@ components:
           nullable: true
           maxLength: 200
         resource_id:
-          type: number
+          type: string
           readOnly: true
         resource_readable_id:
           type: string

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -8560,6 +8560,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceDepartment'
+          readOnly: true
         semester:
           type: string
         year:
@@ -8568,6 +8569,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
+          readOnly: true
         key:
           type: string
           nullable: true
@@ -8614,8 +8616,10 @@ components:
           maxLength: 200
         resource_id:
           type: string
+          readOnly: true
         resource_readable_id:
           type: string
+          readOnly: true
         course_number:
           type: array
           items:
@@ -8631,9 +8635,13 @@ components:
           nullable: true
           maxLength: 32
         offered_by:
-          $ref: '#/components/schemas/LearningResourceOfferor'
+          allOf:
+          - $ref: '#/components/schemas/LearningResourceOfferor'
+          readOnly: true
         platform:
-          $ref: '#/components/schemas/LearningResourcePlatform'
+          allOf:
+          - $ref: '#/components/schemas/LearningResourcePlatform'
+          readOnly: true
         run_readable_id:
           type: string
         edx_module_id:
@@ -8649,13 +8657,7 @@ components:
       - platform
       - resource_id
       - resource_readable_id
-      - run_id
-      - run_readable_id
-      - run_slug
-      - run_title
-      - semester
       - topics
-      - year
     ContentFileSearchResponse:
       type: object
       description: SearchResponseSerializer with OpenAPI annotations for Content Files

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -8615,7 +8615,7 @@ components:
           nullable: true
           maxLength: 200
         resource_id:
-          type: string
+          type: number
           readOnly: true
         resource_readable_id:
           type: string

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -8615,7 +8615,7 @@ components:
           nullable: true
           maxLength: 200
         resource_id:
-          type: number
+          type: string
           readOnly: true
         resource_readable_id:
           type: string

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -296,3 +296,38 @@ def test_embedded_content_from_latest_run_if_next_missing(mocker, mocked_celery)
         "content_file",
         True,  # noqa: FBT003
     )
+
+
+def test_embedded_content_file_without_runs(mocker, mocked_celery):
+    """
+    Ensure that contentfiles without runs are also embedded for a resource
+    """
+
+    mocker.patch("vector_search.tasks.load_course_blocklist", return_value=[])
+
+    course = CourseFactory.create(etl_source=ETLSource.ocw.value)
+    course.runs.all().delete()
+    latest_run = LearningResourceRunFactory.create(
+        learning_resource=course.learning_resource,
+        start_date=datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(hours=1),
+    )
+    ContentFileFactory.create_batch(3, run=latest_run)
+    # create contentfiles without runs
+    contentfiles_with_no_run = [
+        cf.id
+        for cf in ContentFileFactory.create_batch(
+            3, learning_resource=course.learning_resource
+        )
+    ]
+    generate_embeddings_mock = mocker.patch(
+        "vector_search.tasks.generate_embeddings", autospec=True
+    )
+
+    with pytest.raises(mocked_celery.replace_exception_class):
+        start_embed_resources.delay(
+            ["course"], skip_content_files=False, overwrite=True
+        )
+    embedded_ids = generate_embeddings_mock.mock_calls[-1].args[0]
+
+    for contentfile_id in contentfiles_with_no_run:
+        assert contentfile_id in embedded_ids

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -292,7 +292,9 @@ def _process_content_embeddings(serialized_content):
 
         split_ids = [
             vector_point_id(
-                f"{doc['resource_readable_id']}.{doc['run_readable_id']}.{doc['key']}.{md['chunk_number']}"
+                f"{doc['resource_readable_id']}."
+                f"{doc.get('run_readable_id', '')}."
+                f"{doc['key']}.{md['chunk_number']}"
             )
             for md in split_metadatas
         ]
@@ -372,7 +374,9 @@ def embed_learning_resources(ids, resource_type, overwrite):
         points = [
             (
                 vector_point_id(
-                    f"{doc['resource_readable_id']}.{doc['run_readable_id']}.{doc['key']}.0"
+                    f"{doc['resource_readable_id']}."
+                    f"{doc.get('run_readable_id', '')}."
+                    f"{doc['key']}.0"
                 ),
                 doc,
             )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/6931


### Description (What does it do?)
This PR resolves:
- an [initial issue](https://github.com/mitodl/hq/issues/6931) where the non-opensearch contentfile endpoint errors out if a contentfile's run is null (all the marketing page contentfiles we generate)
- a separate issue in which the embedding task does not pick up on contentfiles that don't have runs.This pr adjust the serializers so that they work with "run-less" contentfiles.


### How can this be tested?
1. checkout this branch
2. restart celery
3. run any etl pipeline for courses `python manage.py backpopulate_mitxonline_data`
4. upon completion, inspect the database and see that there are ContentFile objects with a "file_type" of "marketing_page"
```python
from learning_resources.models import ContentFile, LearningResource
ContentFile.objects.filter(file_type="marketing_page").all()
```
5. get the resouurce id of one of these marketing page contentfiles 
```python 
# print resource ids
print(ContentFile.objects.filter(file_type="marketing_page").values_list('learning_resource',flat=True))
```
6. generate embeddings for that resource:
```bash
python manage.py generate_embeddings --resource-ids <resource id> --overwrite
```
7. once complete visit your [local qdrant dashboard](http://localhost:6333/dashboard#/collections/)
8. search the contentfile collection for "file_type:marketing_page" and see that there is a result(s) <img width="541" alt="Screenshot 2025-03-17 at 9 56 58 AM" src="https://github.com/user-attachments/assets/fe41f532-b30c-4a4d-a96c-afe4b5541672" />

9. browse around the regular [contentfiles endpoint](http://open.odl.local:8063/api/v1/contentfiles/?limit=10&offset=25) - it should not throw exceptions when encountering a contentfile without a run


