### PR TITLE
Parameterize MITOL_API_BASE_URL in deployment workflows 

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -43,7 +43,7 @@ jobs:
           HEROKU_APP_NAME: mitopen-production-nextjs
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
           ORIGIN: https://learn.mit.edu
-          MITOL_API_BASE_URL: https://api.learn.mit.edu
+          MITOL_API_BASE_URL: ${{ vars.API_BASE_PROD }}
           SITE_NAME: MIT Learn
           SUPPORT_EMAIL: mitlearn-support@mit.edu
           EMBEDLY_KEY: ${{ secrets.EMBEDLY_KEY_PROD }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -43,7 +43,7 @@ jobs:
           HEROKU_APP_NAME: mitopen-rc-nextjs
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
           ORIGIN: https://rc.learn.mit.edu
-          MITOL_API_BASE_URL: https://api.rc.learn.mit.edu
+          MITOL_API_BASE_URL: ${{ vars.API_BASE_RC }}
           SITE_NAME: MIT Learn
           SUPPORT_EMAIL: mitlearn-support@mit.edu
           EMBEDLY_KEY: ${{ secrets.EMBEDLY_KEY_RC }}


### PR DESCRIPTION


### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6892

### Description (What does it do?)
Updated github workflows to use parameterized BASE_URL provided to gh by pulumi code.
