### PR TITLE
typeerror nonetype error

### DIFF
--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -741,7 +741,7 @@ class LearningResourceMetadataDisplaySerializer(serializers.Serializer):
             location = run.get("location") or "Online"
             duration = run.get("duration")
             prices = run.get("prices", [])
-            price = f"${prices[0]}" if len(prices) > 0 else None
+            price = f"${prices[0]}" if prices else None
             delivery_modes = [delivery["name"] for delivery in run.get("delivery", [])]
             instructors = [
                 instructor.get("full_name")
@@ -799,7 +799,7 @@ class LearningResourceMetadataDisplaySerializer(serializers.Serializer):
             and serialized_resource["certification_type"]
             and serialized_resource["certification_type"]["code"]
             == CertificationType.completion.name
-        ) and len(prices) > 1:
+        ) and prices:
             return f"Earn a certificate: ${prices[1]}"
         return None
 

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -505,7 +505,9 @@ class LearningResourceMetadataDisplaySerializer(serializers.Serializer):
 
         distinct_locations = set()
         for run in serialized_resource.get("runs", []):
-            distinct_prices.update(run["prices"])
+            prices = run.get("prices", [])
+            if prices:
+                distinct_prices.update(prices)
             distinct_delivery_methods.update(
                 [delivery["code"] for delivery in run.get("delivery", [])]
             )

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -1244,6 +1244,35 @@ def test_learning_resources_display_info_list_view(mocker, client):
         assert hit["title"] in titles
 
 
+def test_run_with_null_prices_does_not_throw_error(mocker, client):
+    """Test learning_resources_display_info_detail_view does not throw exception"""
+    from learning_resources.models import LearningResource
+
+    run = LearningResourceRunFactory.create(
+        run_id="test",
+        learning_resource=CourseFactory.create(
+            platform=PlatformType.ocw.name
+        ).learning_resource,
+    )
+    run.prices = None
+    run.save()
+
+    lr = LearningResource.objects.for_search_serialization().get(
+        id=run.learning_resource.id
+    )
+    serialized_resource = LearningResourceDisplayInfoResponseSerializer(
+        serialize_learning_resource_for_update(lr)
+    ).data
+
+    resp = client.get(
+        reverse(
+            "lr:v1:learning_resource_display_info_api-detail",
+            args=[run.learning_resource.id],
+        )
+    )
+    assert resp.json() == serialized_resource
+
+
 def test_learning_resources_display_info_detail_view(mocker, client):
     """Test learning_resources_display_info_detail_view returns expected result"""
     from learning_resources.models import LearningResource


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/6986

### Description (What does it do?)
This PR fixes a 500 being thrown at the [learning resource display info](http://api.rc.learn.mit.edu/api/v1/learning_resource_display_info/) endpoint when a run has None for the prices attribute.

### How can this be tested?
1. checkout main 
2. visit the learning resource display info endpoint and make note of a run in the response
3. set the prices for that run to None and save it
4. go back to the endpoint - it should throw an exception (you may need to cache break by passing some random parameter) 
5. checkout this branch and see no exceptions

