### PR TITLE
fix dedupe issue

### DIFF
--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -337,7 +337,6 @@ def documents_from_olx(
                 yield (
                     filebytes,
                     {
-                        "key": checksum,
                         "content_type": CONTENT_TYPE_FILE,
                         "mime_type": mimetype,
                         "checksum": checksum,
@@ -426,12 +425,12 @@ def transform_content_files(
         check_call(["tar", "xf", course_tarpath], cwd=inner_tempdir)  # noqa: S603,S607
         olx_path = glob.glob(inner_tempdir + "/*")[0]  # noqa: PTH207
         for document, metadata in documents_from_olx(olx_path):
-            key = metadata["key"]
+            source_path = metadata.get("source_path")
+            edx_module_id = get_edx_module_id(source_path, run)
+            key = edx_module_id
             content_type = metadata["content_type"]
             mime_type = metadata.get("mime_type")
             file_extension = metadata.get("file_extension")
-            source_path = metadata.get("source_path")
-            edx_module_id = get_edx_module_id(source_path, run)
 
             existing_content = ContentFile.objects.filter(key=key, run=run).first()
             if (


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/6987
more details here
https://docs.google.com/document/d/1pbmksdRATLHMEjjRnScnzk3Mgw7hYgS9M7tQM_heO_8/edit?tab=t.0#heading=h.umn4dw1huqk

### Description (What does it do?)
We found that many mitxonline video chatbot requests were not finding a match for the transcript content file edx_module_id. The reason for the problem was the way we were deduping when we had more than one content file with the same content. This fixes the issue

### How can this be tested?
Run 
docker-compose run -u root --rm web ./manage.py backpopulate_xpro_data
docker-compose run -u root --rm web ./manage.py backpopulate_xpro_files --overwrite

https://api.learn.mit.edu/api/v1/contentfiles/?edx_module_id=asset-v1%3AxPRO%2BBioEngx%2BR18%2Btype%40asset%2Bblock%40subs_1003X_W7S1.srt.sjson 
returns a result

but

https://api.learn.mit.edu/api/v1/contentfiles/?edx_module_id=asset-v1%3AxPRO%2BBioEngx%2BR18%2Btype%40asset%2Bblock%40subs_UfS9lz_lLmU.srt.sjson

doesn't

both

http://api.open.odl.local:8063/api/v1/contentfiles/?edx_module_id=asset-v1%3AxPRO%2BBioEngx%2BR18%2Btype%40asset%2Bblock%40subs_1003X_W7S1.srt.sjson

and

http://api.open.odl.local:8063/api/v1/contentfiles/?edx_module_id=asset-v1%3AxPRO%2BBioEngx%2BR18%2Btype%40asset%2Bblock%40subs_UfS9lz_lLmU.srt.sjson

should return a result after the backpopulate job finishes 



### Additional Context
After this change the number of mitxonline files increased from 81643 to 95027 and the number of xpro files increased from 6728 to 8519 not sure if that's enough to justify creating some kind of one to many structure between edx_module_ids and content to avoid embedding the extra files. We would need to think through how a one-to many structure would work in particular if a file with duplicates is deleted or updated