### PR TITLE
design refactor: make link black style bolder

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/EnrollmentDisplay/EnrollmentCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/EnrollmentDisplay/EnrollmentCard.tsx
@@ -12,9 +12,6 @@ import { ActionButton, Button, ButtonLink } from "@mitodl/smoot-design"
 import { RiArrowRightLine, RiAwardLine, RiMoreLine } from "@remixicon/react"
 import { calendarDaysUntil, isInPast, NoSSR } from "ol-utilities"
 
-const LinkStyled = styled(Link)(({ theme }) => ({
-  ...theme.typography.subtitle2,
-}))
 const CourseButtonLink = styled(ButtonLink)({
   width: "142px",
 })
@@ -186,9 +183,9 @@ const EnrollmentCard: React.FC<EnrollmentCardProps> = ({ enrollment }) => {
     <CardRoot data-testid="enrollment-card">
       <Stack direction="row">
         <Left>
-          <LinkStyled size="medium" color="black" href={marketingUrl}>
+          <Link size="medium" color="black" href={marketingUrl}>
             {title}
-          </LinkStyled>
+          </Link>
         </Left>
         <Right>
           <Stack gap="4px">

--- a/frontends/main/src/app-pages/DashboardPage/SettingsContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/SettingsContent.tsx
@@ -31,10 +31,6 @@ const FollowList = styled(PlainList)(({ theme }) => ({
   border: `1px solid ${theme.custom.colors.lightGray2}`,
 }))
 
-const StyledLink = styled(Link)(({ theme }) => ({
-  color: theme.custom.colors.red,
-}))
-
 const TitleText = styled(Typography)(({ theme }) => ({
   marginTop: "16px",
   marginBottom: "8px",
@@ -223,7 +219,8 @@ const SettingsContent: React.FC = () => {
                 ]
               }
             />
-            <StyledLink
+            <Link
+              color="red"
               onClick={() =>
                 NiceModal.show(UnfollowDialog, {
                   subscriptionIds: [subscriptionItem.id],
@@ -233,7 +230,7 @@ const SettingsContent: React.FC = () => {
               }
             >
               Unfollow
-            </StyledLink>
+            </Link>
           </ListItem>
         ))}
       </FollowList>

--- a/frontends/main/src/app-pages/TopicsListingPage/TopicsListingPage.tsx
+++ b/frontends/main/src/app-pages/TopicsListingPage/TopicsListingPage.tsx
@@ -95,9 +95,10 @@ const TopicBoxHeader = styled(
     },
   },
   ".view-topic": [
-    linkStyles({ size: "medium" }),
+    linkStyles({ size: "medium", color: "black" }),
     {
       color: theme.custom.colors.darkGray1,
+      ...theme.typography.body2,
       marginLeft: "16px",
       [theme.breakpoints.down("sm")]: {
         ...theme.typography.body3,

--- a/frontends/main/src/page-components/HeroSearch/HeroSearch.tsx
+++ b/frontends/main/src/page-components/HeroSearch/HeroSearch.tsx
@@ -197,10 +197,6 @@ const TrendingContainer = styled.div({
   gap: "8px",
 })
 
-const BoldLink = styled(Link)(({ theme }) => ({
-  ...theme.typography.subtitle1,
-}))
-
 const HeroSearch: React.FC<{ imageIndex: number }> = ({ imageIndex }) => {
   const posthog = usePostHog()
   const posthogCapture = (event: string) => {
@@ -239,12 +235,14 @@ const HeroSearch: React.FC<{ imageIndex: number }> = ({ imageIndex }) => {
         </Typography>
         <Typography>
           Explore MIT's{" "}
-          <BoldLink
+          <Link
+            color="black"
+            size="large"
             href={`${ABOUT}#${ABOUT_NON_DEGREE_LEARNING_FRAGMENT}`}
             prefetch={false}
           >
             Non-Degree Learning
-          </BoldLink>
+          </Link>
         </Typography>
         <ControlsContainer>
           <SearchField

--- a/frontends/main/src/page-components/ItemsListing/ItemsListingComponent.tsx
+++ b/frontends/main/src/page-components/ItemsListing/ItemsListingComponent.tsx
@@ -1,6 +1,6 @@
 import React from "react"
-import { Grid, Typography, styled, Link } from "ol-components"
-import { Button } from "@mitodl/smoot-design"
+import { Grid, Typography, styled } from "ol-components"
+import { Button, ButtonLink } from "@mitodl/smoot-design"
 import { RiArrowLeftLine, RiArrowUpDownLine } from "@remixicon/react"
 import { useToggle, pluralize } from "ol-utilities"
 import { GridColumn, GridContainer } from "@/components/GridLayout/GridLayout"
@@ -95,11 +95,13 @@ const ItemsListingComponent: React.FC<ItemsListingComponentProps> = ({
             marginBottom="24px"
           >
             <Grid item>
-              <Link href={MY_LISTS}>
-                <Button variant="tertiary" startIcon={<RiArrowLeftLine />}>
-                  My Lists
-                </Button>
-              </Link>
+              <ButtonLink
+                href={MY_LISTS}
+                variant="tertiary"
+                startIcon={<RiArrowLeftLine />}
+              >
+                My Lists
+              </ButtonLink>
             </Grid>
           </Grid>
           <Grid

--- a/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.tsx
@@ -7,10 +7,10 @@ import {
   theme,
   PlatformLogo,
   PLATFORM_LOGOS,
-  Link,
   Input,
   Typography,
 } from "ol-components"
+import Link from "next/link"
 import type { ImageConfig, LearningResourceCardProps } from "ol-components"
 import { DEFAULT_RESOURCE_IMG } from "ol-utilities"
 import { ResourceTypeEnum, PlatformEnum } from "api"
@@ -158,6 +158,9 @@ const ShareButtonContainer = styled.div({
 
 const ShareLink = styled(Link)({
   color: theme.custom.colors.silverGrayDark,
+  "&:hover": {
+    color: theme.custom.colors.lightRed,
+  },
 })
 
 const RedLinkIcon = styled(RiLink)({

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -37,6 +37,7 @@ export const Linkable: React.FC<LinkableProps> = ({
   if (href) {
     return (
       <Link
+        color="black"
         {...others}
         className={className}
         href={href}

--- a/frontends/ol-components/src/components/Link/Link.tsx
+++ b/frontends/ol-components/src/components/Link/Link.tsx
@@ -5,15 +5,14 @@ import { theme } from "../ThemeProvider/ThemeProvider"
 import { LinkAdapter } from "../LinkAdapter/LinkAdapter"
 
 type LinkStyleProps = {
+  color: "black" | "white" | "red"
   size?: "small" | "medium" | "large"
-  color?: "black" | "white" | "red"
   hovercolor?: "black" | "white" | "red"
   nohover?: boolean
 }
 
-const DEFAULT_PROPS: Required<LinkStyleProps> = {
+const DEFAULT_PROPS: Required<Omit<LinkStyleProps, "color">> = {
   size: "medium",
-  color: "black",
   hovercolor: "red",
   nohover: false,
 }
@@ -33,16 +32,22 @@ const NO_FORWARD = Object.keys({
  */
 const linkStyles = (props: LinkStyleProps) => {
   const { size, color, hovercolor, nohover } = { ...DEFAULT_PROPS, ...props }
+
   return css([
-    size === "small" && {
-      ...theme.typography.body3,
-    },
-    size === "medium" && {
-      ...theme.typography.body2,
-    },
-    size === "large" && {
-      ...theme.typography.h5,
-    },
+    {
+      small:
+        color === "black"
+          ? { ...theme.typography.subtitle3 }
+          : { ...theme.typography.body3 },
+      medium:
+        color === "black"
+          ? { ...theme.typography.subtitle2 }
+          : { ...theme.typography.body2 },
+      large:
+        color === "black"
+          ? { ...theme.typography.subtitle1 }
+          : { ...theme.typography.body1 },
+    }[size],
     {
       color: {
         ["black"]: theme.custom.colors.darkGray2,


### PR DESCRIPTION
### What are the relevant tickets?
None, but came across this discrepancy during https://github.com/mitodl/mit-learn/pull/2142

### Description (What does it do?)
This PR updates the `Link` component to match designs:
- the change is `color="black"` now has a bolder typography.
- **There are no visual changes.** In all cases where we were using `color="black"` (previously also the default value of `color`, but that prop is now required) we were always overriding the styling to match figma on a case-by-case basis.


### How can this be tested?
Check that things look the same. Some things worth checking:
- the social media share icons on drawer
- the homepage "Non Degree Learning" link in hero section
- Card titles
