### PR TITLE
Make /users/me/ api endpoint accessible for anonymous users

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -3391,6 +3391,12 @@ export interface PatchedUserRequest {
    * @memberof PatchedUserRequest
    */
   email?: string
+  /**
+   *
+   * @type {boolean}
+   * @memberof PatchedUserRequest
+   */
+  is_authenticated?: boolean
 }
 /**
  * Serializer for WidgetLists
@@ -5462,10 +5468,10 @@ export interface User {
   is_learning_path_editor: boolean
   /**
    *
-   * @type {string}
+   * @type {boolean}
    * @memberof User
    */
-  is_authenticated: string
+  is_authenticated: boolean
 }
 /**
  * Serializer for User
@@ -5485,6 +5491,12 @@ export interface UserRequest {
    * @memberof UserRequest
    */
   email: string
+  /**
+   *
+   * @type {boolean}
+   * @memberof UserRequest
+   */
+  is_authenticated: boolean
 }
 /**
  * Serializer for UserWebsite

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -3391,12 +3391,6 @@ export interface PatchedUserRequest {
    * @memberof PatchedUserRequest
    */
   email?: string
-  /**
-   *
-   * @type {boolean}
-   * @memberof PatchedUserRequest
-   */
-  is_authenticated?: boolean
 }
 /**
  * Serializer for WidgetLists
@@ -5491,12 +5485,6 @@ export interface UserRequest {
    * @memberof UserRequest
    */
   email: string
-  /**
-   *
-   * @type {boolean}
-   * @memberof UserRequest
-   */
-  is_authenticated: boolean
 }
 /**
  * Serializer for UserWebsite

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -5435,7 +5435,7 @@ export interface User {
    * @type {Profile}
    * @memberof User
    */
-  profile: Profile
+  profile?: Profile
   /**
    *
    * @type {string}
@@ -5460,6 +5460,12 @@ export interface User {
    * @memberof User
    */
   is_learning_path_editor: boolean
+  /**
+   *
+   * @type {string}
+   * @memberof User
+   */
+  is_authenticated: string
 }
 /**
  * Serializer for User
@@ -5472,7 +5478,7 @@ export interface UserRequest {
    * @type {ProfileRequest}
    * @memberof UserRequest
    */
-  profile: ProfileRequest
+  profile?: ProfileRequest
   /**
    *
    * @type {string}

--- a/frontends/api/src/hooks/user/index.ts
+++ b/frontends/api/src/hooks/user/index.ts
@@ -16,7 +16,6 @@ const useUserMe = () =>
       return {
         ...response.data,
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     },
   })
 

--- a/frontends/api/src/hooks/user/index.ts
+++ b/frontends/api/src/hooks/user/index.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { usersApi } from "../../clients"
-import type { User as UserApi } from "../../generated/v0/api"
+import type { User } from "../../generated/v0/api"
 
 enum Permission {
   ArticleEditor = "is_article_editor",
@@ -8,29 +8,15 @@ enum Permission {
   LearningPathEditor = "is_learning_path_editor",
 }
 
-interface User extends Partial<UserApi> {
-  is_authenticated: boolean
-}
-
 const useUserMe = () =>
   useQuery({
     queryKey: ["userMe"],
     queryFn: async (): Promise<User> => {
-      try {
-        const response = await usersApi.usersMeRetrieve()
-        return {
-          is_authenticated: true,
-          ...response.data,
-        }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (error: any) {
-        if (error.response?.status === 403) {
-          return {
-            is_authenticated: false,
-          }
-        }
-        throw error
+      const response = await usersApi.usersMeRetrieve()
+      return {
+        ...response.data,
       }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     },
   })
 

--- a/frontends/api/src/test-utils/factories/user.ts
+++ b/frontends/api/src/test-utils/factories/user.ts
@@ -32,9 +32,9 @@ const user: PartialFactory<User> = (overrides = {}): User => {
     is_article_editor: false,
     is_learning_path_editor: false,
     username: faker.internet.userName(),
+    is_authenticated: true,
     ...overrides,
     profile: profile(overrides?.profile),
-    is_authenticated: true,
   }
   return result
 }

--- a/frontends/api/src/test-utils/factories/user.ts
+++ b/frontends/api/src/test-utils/factories/user.ts
@@ -34,6 +34,7 @@ const user: PartialFactory<User> = (overrides = {}): User => {
     username: faker.internet.userName(),
     ...overrides,
     profile: profile(overrides?.profile),
+    is_authenticated: true,
   }
   return result
 }

--- a/frontends/main/src/app-pages/ChannelPage/ChannelSearch.test.tsx
+++ b/frontends/main/src/app-pages/ChannelPage/ChannelSearch.test.tsx
@@ -77,7 +77,7 @@ const setMockApiResponses = ({
     results: [],
   })
 
-  setMockResponse.get(urls.userMe.get(), {})
+  setMockResponse.get(urls.userMe.get(), { is_authenticated: true })
   setMockResponse.get(urls.userLists.membershipList(), [])
   setMockResponse.get(urls.learningPaths.membershipList(), [])
 

--- a/frontends/main/src/app-pages/HomePage/HomePage.test.tsx
+++ b/frontends/main/src/app-pages/HomePage/HomePage.test.tsx
@@ -36,7 +36,7 @@ const assertLinksTo = (
 }
 
 const setupAPIs = () => {
-  setMockResponse.get(urls.userMe.get(), {})
+  setMockResponse.get(urls.userMe.get(), { is_authenticated: true })
   setMockResponse.get(urls.userLists.membershipList(), [])
   setMockResponse.get(urls.learningPaths.membershipList(), [])
 
@@ -272,7 +272,7 @@ describe("Home Page personalize section", () => {
   test("Links to login when not authenticated", async () => {
     setupAPIs()
 
-    setMockResponse.get(urls.userMe.get(), {}, { code: 403 })
+    setMockResponse.get(urls.userMe.get(), { is_authenticated: false })
     renderWithProviders(<HomePage heroImageIndex={1} />)
     const personalize = (
       await screen.findByRole("heading", {

--- a/frontends/main/src/app-pages/ProgramLetterPage/ProgramLetter.test.tsx
+++ b/frontends/main/src/app-pages/ProgramLetterPage/ProgramLetter.test.tsx
@@ -11,7 +11,7 @@ const setup = ({ programLetter }: { programLetter: ProgramLetter }) => {
     urls.programLetters.details(programLetter.id),
     programLetter,
   )
-  setMockResponse.get(urls.userMe.get(), {})
+  setMockResponse.get(urls.userMe.get(), { is_authenticated: true })
   renderWithProviders(<ProgramLetterPage />, {
     url: programLetterView(programLetter.id),
   })

--- a/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
@@ -328,6 +328,7 @@ describe("SearchPage", () => {
     })
     setMockResponse.get(urls.userMe.get(), {
       is_learning_path_editor: true,
+      is_authenticated: true,
     })
 
     setMockResponse.get(urls.adminSearchParams.get(), {
@@ -375,6 +376,7 @@ test("admin users can set the search mode and slop", async () => {
   })
   setMockResponse.get(urls.userMe.get(), {
     is_learning_path_editor: true,
+    is_authenticated: true,
   })
   setMockResponse.get(urls.adminSearchParams.get(), {
     search_mode: "phrase",

--- a/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
@@ -252,7 +252,7 @@ describe("SearchPage", () => {
       },
     })
 
-    setMockResponse.get(urls.userMe.get(), {})
+    setMockResponse.get(urls.userMe.get(), { is_authenticated: true })
 
     renderWithProviders(<SearchPage />)
     await waitFor(() => {

--- a/frontends/main/src/page-components/Header/Header.test.tsx
+++ b/frontends/main/src/page-components/Header/Header.test.tsx
@@ -34,7 +34,10 @@ describe("UserMenu", () => {
   test.each([{}, { profile: null }, { profile: {} }])(
     "Trigger button shows UserIcon for authenticated users w/o initials",
     async (userSettings) => {
-      setMockResponse.get(urls.userMe.get(), userSettings)
+      setMockResponse.get(urls.userMe.get(), {
+        is_authenticated: true,
+        ...userSettings,
+      })
 
       renderWithProviders(<Header />)
 
@@ -44,7 +47,10 @@ describe("UserMenu", () => {
   )
 
   test("Trigger button shows name if available", async () => {
-    setMockResponse.get(urls.userMe.get(), { profile: { name: "Alice Bee" } })
+    setMockResponse.get(urls.userMe.get(), {
+      is_authenticated: true,
+      profile: { name: "Alice Bee" },
+    })
 
     renderWithProviders(<Header />)
     const trigger = await screen.findByRole("button", { name: "User Menu" })
@@ -99,7 +105,10 @@ describe("UserMenu", () => {
   })
 
   test("Learning path editors see 'Learning Paths' link", async () => {
-    setMockResponse.get(urls.userMe.get(), { is_learning_path_editor: true })
+    setMockResponse.get(urls.userMe.get(), {
+      is_learning_path_editor: true,
+      is_authenticated: true,
+    })
     renderWithProviders(<Header />)
     const menu = await findUserMenu()
     const link = within(menu).getByRole("menuitem", {
@@ -109,7 +118,10 @@ describe("UserMenu", () => {
   })
 
   test("Users WITHOUT LearningPathEditor permission do not see 'Learning Paths' link", async () => {
-    setMockResponse.get(urls.userMe.get(), { is_learning_path_editor: false })
+    setMockResponse.get(urls.userMe.get(), {
+      is_learning_path_editor: false,
+      is_authenticated: true,
+    })
     renderWithProviders(<Header />)
     const menu = await findUserMenu()
     const link = within(menu).queryByRole("menuitem", {

--- a/frontends/main/src/page-components/Header/Header.test.tsx
+++ b/frontends/main/src/page-components/Header/Header.test.tsx
@@ -13,7 +13,7 @@ import { setMockResponse, urls } from "api/test-utils"
 
 describe("Header", () => {
   it("Includes a link to the Homepage", async () => {
-    setMockResponse.get(urls.userMe.get(), {})
+    setMockResponse.get(urls.userMe.get(), { is_authenticated: true })
     renderWithProviders(<Header />)
     const header = screen.getByRole("banner")
     within(header).getAllByTitle("MIT Learn Homepage")

--- a/frontends/main/src/page-components/ItemsListing/ItemsListing.test.tsx
+++ b/frontends/main/src/page-components/ItemsListing/ItemsListing.test.tsx
@@ -105,7 +105,7 @@ describe("ItemsListing", () => {
   ])(
     "Shows empty message when there are no items",
     ({ listType, count, hasEmptyMessage }) => {
-      setMockResponse.get(urls.userMe.get(), {})
+      setMockResponse.get(urls.userMe.get(), { is_authenticated: true })
       setMockResponse.get(urls.userLists.membershipList(), [])
       setMockResponse.get(urls.learningPaths.membershipList(), [])
       const emptyMessage = faker.lorem.sentence()

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
@@ -50,7 +50,7 @@ describe("LearningResourceDrawer", () => {
       setMockResponse.get(urls.userMe.get(), user)
       setMockResponse.get(urls.userLists.membershipList(), [])
     } else {
-      setMockResponse.get(urls.userMe.get(), null, { code: 403 })
+      setMockResponse.get(urls.userMe.get(), { is_authenticated: false })
     }
     if (user.is_learning_path_editor) {
       setMockResponse.get(urls.learningPaths.membershipList(), [])

--- a/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.test.tsx
@@ -44,7 +44,7 @@ describe("AiChatSyllabus", () => {
   test("User enters a prompt. Greets anonymous user generically", async () => {
     const resource = factories.learningResources.course()
 
-    setMockResponse.get(urls.userMe.get(), {}, { code: 403 })
+    setMockResponse.get(urls.userMe.get(), { is_authenticated: false })
     renderWithProviders(
       <AiChatSyllabusSlideDown
         open

--- a/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.test.tsx
@@ -16,7 +16,7 @@ describe("AiChatSyllabus", () => {
     const userMe = factories.user.user()
 
     // Sanity
-    expect(userMe.profile.name).toBeTruthy()
+    expect(userMe.profile?.name).toBeTruthy()
 
     setMockResponse.get(urls.userMe.get(), userMe)
     renderWithProviders(
@@ -37,7 +37,7 @@ describe("AiChatSyllabus", () => {
     // byAll because there are two instances, one is SR-only in an aria-live area
     // check for username and resource title
     await screen.findAllByText(
-      new RegExp(`Hello ${userMe.profile.name}.*${resource.title}.*`),
+      new RegExp(`Hello ${userMe.profile?.name}.*${resource.title}.*`),
     )
   })
 

--- a/frontends/main/src/page-components/ResourceCard/ResourceCard.test.tsx
+++ b/frontends/main/src/page-components/ResourceCard/ResourceCard.test.tsx
@@ -78,7 +78,7 @@ describe.each([
         learningPathMemberships,
       )
     } else {
-      setMockResponse.get(urls.userMe.get(), {}, { code: 403 })
+      setMockResponse.get(urls.userMe.get(), { is_authenticated: false })
     }
     const { view, location, queryClient } = renderWithProviders(
       <ResourceCard {...props} resource={resource} list={isList} />,

--- a/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
+++ b/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
@@ -32,7 +32,7 @@ describe("ResourceCarousel", () => {
       search: factories.learningResources.resources({ count }),
       list: factories.learningResources.resources({ count }),
     }
-    setMockResponse.get(urls.userMe.get(), {})
+    setMockResponse.get(urls.userMe.get(), { is_authenticated: true })
     setMockResponse.get(urls.userLists.membershipList(), [])
     setMockResponse.get(urls.learningPaths.membershipList(), [])
 
@@ -161,7 +161,7 @@ describe("ResourceCarousel", () => {
         },
       },
     ]
-    setMockResponse.get(urls.userMe.get(), {})
+    setMockResponse.get(urls.userMe.get(), { is_authenticated: true })
     setupApis()
     renderWithProviders(
       <ResourceCarousel
@@ -205,7 +205,7 @@ describe("ResourceCarousel", () => {
           },
         },
       ]
-      setMockResponse.get(urls.userMe.get(), {})
+      setMockResponse.get(urls.userMe.get(), { is_authenticated: true })
       setupApis()
       renderWithProviders(
         <ResourceCarousel

--- a/frontends/main/src/page-components/SearchSubscriptionToggle/SearchSubscriptionToggle.test.tsx
+++ b/frontends/main/src/page-components/SearchSubscriptionToggle/SearchSubscriptionToggle.test.tsx
@@ -40,7 +40,7 @@ const setupApis = ({
 
 test("Shows subscription popover if user is NOT authenticated", async () => {
   // Don't set up all the APIs... We don't want to call the others for unauthenticated users.
-  setMockResponse.get(urls.userMe.get(), {}, { code: 403 })
+  setMockResponse.get(urls.userMe.get(), { is_authenticated: false })
   renderWithProviders(
     <SearchSubscriptionToggle
       itemName="Test"

--- a/frontends/main/src/page-components/TestimonialDisplay/TestimonialDisplay.test.tsx
+++ b/frontends/main/src/page-components/TestimonialDisplay/TestimonialDisplay.test.tsx
@@ -6,7 +6,7 @@ import { testimonials as factory } from "api/test-utils/factories"
 import TestimonialDisplay from "./TestimonialDisplay"
 
 const setupAPIs = () => {
-  setMockResponse.get(urls.userMe.get(), {})
+  setMockResponse.get(urls.userMe.get(), { is_authenticated: true })
 }
 
 describe("TestimonialDisplay", () => {

--- a/frontends/main/src/test-utils/index.tsx
+++ b/frontends/main/src/test-utils/index.tsx
@@ -7,7 +7,7 @@ import type { QueryClient } from "@tanstack/react-query"
 
 import { makeQueryClient } from "@/app/getQueryClient"
 import { render } from "@testing-library/react"
-import { setMockResponse } from "api/test-utils"
+import { factories, setMockResponse } from "api/test-utils"
 import type { User } from "api/hooks/user"
 import {
   mockRouter,
@@ -40,9 +40,7 @@ interface TestAppOptions {
 const defaultTestAppOptions = {
   url: "/",
 }
-const defaultUser: User = {
-  is_authenticated: true,
-}
+const defaultUser: User = factories.user.user()
 
 const TestProviders: React.FC<{
   children: React.ReactNode

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -3748,8 +3748,6 @@ components:
           type: string
           writeOnly: true
           minLength: 1
-        is_authenticated:
-          type: boolean
     PatchedWidgetListRequest:
       type: object
       description: Serializer for WidgetLists
@@ -5346,6 +5344,7 @@ components:
           readOnly: true
         is_authenticated:
           type: boolean
+          readOnly: true
       required:
       - first_name
       - id
@@ -5364,11 +5363,8 @@ components:
           type: string
           writeOnly: true
           minLength: 1
-        is_authenticated:
-          type: boolean
       required:
       - email
-      - is_authenticated
     UserWebsite:
       type: object
       description: Serializer for UserWebsite

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -3748,6 +3748,8 @@ components:
           type: string
           writeOnly: true
           minLength: 1
+        is_authenticated:
+          type: boolean
     PatchedWidgetListRequest:
       type: object
       description: Serializer for WidgetLists
@@ -5343,8 +5345,7 @@ components:
           type: boolean
           readOnly: true
         is_authenticated:
-          type: string
-          readOnly: true
+          type: boolean
       required:
       - first_name
       - id
@@ -5363,8 +5364,11 @@ components:
           type: string
           writeOnly: true
           minLength: 1
+        is_authenticated:
+          type: boolean
       required:
       - email
+      - is_authenticated
     UserWebsite:
       type: object
       description: Serializer for UserWebsite

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -5342,13 +5342,16 @@ components:
         is_learning_path_editor:
           type: boolean
           readOnly: true
+        is_authenticated:
+          type: string
+          readOnly: true
       required:
       - first_name
       - id
       - is_article_editor
+      - is_authenticated
       - is_learning_path_editor
       - last_name
-      - profile
       - username
     UserRequest:
       type: object
@@ -5362,7 +5365,6 @@ components:
           minLength: 1
       required:
       - email
-      - profile
     UserWebsite:
       type: object
       description: Serializer for UserWebsite

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -322,6 +322,7 @@ class UserSerializer(serializers.ModelSerializer):
         return False
 
     def is_authenticated(self, instance) -> bool:
+        """Return whether the user is authenticated"""
         return instance.is_authenticated
 
     def create(self, validated_data):

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -307,6 +307,7 @@ class UserSerializer(serializers.ModelSerializer):
     email = serializers.CharField(write_only=True)
     is_learning_path_editor = serializers.SerializerMethodField()
     is_article_editor = serializers.SerializerMethodField()
+    is_authenticated = serializers.BooleanField(read_only=True)
     profile = ProfileSerializer(required=False)
 
     def get_is_learning_path_editor(self, instance) -> bool:  # noqa: ARG002

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -321,10 +321,6 @@ class UserSerializer(serializers.ModelSerializer):
             return is_admin_user(request)
         return False
 
-    def is_authenticated(self, instance) -> bool:
-        """Return whether the user is authenticated"""
-        return instance.is_authenticated
-
     def create(self, validated_data):
         profile_data = validated_data.pop("profile") or {}
         username = ulid.new()

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -307,7 +307,7 @@ class UserSerializer(serializers.ModelSerializer):
     email = serializers.CharField(write_only=True)
     is_learning_path_editor = serializers.SerializerMethodField()
     is_article_editor = serializers.SerializerMethodField()
-    profile = ProfileSerializer()
+    profile = ProfileSerializer(required=False)
 
     def get_is_learning_path_editor(self, instance) -> bool:  # noqa: ARG002
         request = self.context.get("request")
@@ -320,6 +320,9 @@ class UserSerializer(serializers.ModelSerializer):
         if request:
             return is_admin_user(request)
         return False
+
+    def is_authenticated(self, instance) -> bool:
+        return instance.is_authenticated
 
     def create(self, validated_data):
         profile_data = validated_data.pop("profile") or {}
@@ -360,8 +363,9 @@ class UserSerializer(serializers.ModelSerializer):
             "last_name",
             "is_article_editor",
             "is_learning_path_editor",
+            "is_authenticated",
         )
-        read_only_fields = ("id", "username")
+        read_only_fields = ("id", "username", "is_authenticated")
 
 
 class ProgramCertificateSerializer(serializers.ModelSerializer):

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -42,6 +42,7 @@ def test_serialize_user(user):
         "is_learning_path_editor": False,
         "is_article_editor": False,
         "profile": ProfileSerializer(user.profile).data,
+        "is_authenticated": True,
     }
 
 
@@ -94,6 +95,7 @@ def test_serialize_create_user(db, mocker):
         "is_learning_path_editor": False,
         "is_article_editor": False,
         "profile": {**profile, "preference_search_filters": {}},
+        "is_authenticated": True,
     }
 
 

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -48,7 +48,10 @@ class CurrentUserRetrieveViewSet(mixins.RetrieveModelMixin, viewsets.GenericView
     """User retrieve and update viewsets for the current user"""
 
     serializer_class = UserSerializer
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (
+        AnonymousAccessReadonlyPermission,
+        HasEditPermission,
+    )
 
     def get_object(self):
         """Return the current request user"""

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -44,6 +44,7 @@ def test_list_users(staff_client, staff_user):
             "is_learning_path_editor": True,
             "is_article_editor": True,
             "profile": ProfileSerializer(staff_user.profile).data,
+            "is_authenticated": True,
         }
     ]
 
@@ -102,6 +103,7 @@ def test_get_user(staff_client, user):
         "is_article_editor": True,
         "is_learning_path_editor": True,
         "profile": ProfileSerializer(user.profile).data,
+        "is_authenticated": True,
     }
 
 
@@ -190,6 +192,7 @@ def test_patch_user(staff_client, user, email, email_optin, toc_optin):
         "is_learning_path_editor": True,
         "is_article_editor": True,
         "profile": ProfileSerializer(user.profile).data,
+        "is_authenticated": True,
     }
     user.refresh_from_db()
     profile.refresh_from_db()
@@ -382,7 +385,13 @@ def test_get_user_by_me(mocker, client, user, is_anonymous):
     resp = client.get(reverse("profile:v0:users_api-me"))
 
     if is_anonymous:
-        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert resp.json() == {
+            "id": None,
+            "username": "",
+            "is_learning_path_editor": False,
+            "is_article_editor": False,
+            "is_authenticated": False,
+        }
     else:
         assert resp.json() == {
             "id": user.id,
@@ -392,6 +401,7 @@ def test_get_user_by_me(mocker, client, user, is_anonymous):
             "is_learning_path_editor": False,
             "is_article_editor": False,
             "profile": ProfileSerializer(user.profile).data,
+            "is_authenticated": True,
         }
 
 


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/mit-learn/pull/2119

### Description (What does it do?)
- Makes the `api/v0/users/me` endpoint accessibe to anonymous users
- Adjusts the `UserSerializer`, making `profile` optional (anon users don't have one) and adding an `is_authenticated` boolean field.


### How can this be tested?
- You should still see the `Login` button at the top if not authenticated and your name with a dropdown menu if authenticated.  Editing your profile at https://open.odl.local:8062/dashboard/profile should still work. Tests should pass.

### Additional Context
This is being done to see if a redirect to keycloak can be avoided on RC/prod when initially loading this url > 30 minutes after logging in. 


