### PR TITLE
Fix for potential missing file attribute in contentfile json

### DIFF
--- a/learning_resources/etl/ocw.py
+++ b/learning_resources/etl/ocw.py
@@ -254,10 +254,15 @@ def transform_contentfile(
         content_type = CONTENT_TYPE_VIDEO
         file_s3_path = contentfile_data.get("transcript_file")
         image_src = contentfile_data.get("thumbnail_file")
-        file_extension = Path(contentfile_data.get("file")).suffix
+        file_extension = Path(
+            contentfile_data.get(
+                "file", contentfile_data.get("video_files", {}).get("archive_url")
+            )
+            or ""
+        ).suffix
     else:
         content_type = get_content_type(file_type)
-        file_s3_path = contentfile_data.get("file")
+        file_s3_path = contentfile_data.get("file") or ""
         image_src = None
         file_extension = Path(file_s3_path).suffix
 

--- a/learning_resources/etl/ocw.py
+++ b/learning_resources/etl/ocw.py
@@ -258,11 +258,13 @@ def transform_contentfile(
             contentfile_data.get(
                 "file", contentfile_data.get("video_files", {}).get("archive_url")
             )
-            or ""
+            or ""  # Assign blank str if missing/null
         ).suffix
     else:
         content_type = get_content_type(file_type)
-        file_s3_path = contentfile_data.get("file") or ""
+        file_s3_path = (
+            contentfile_data.get("file") or ""
+        )  # Assign blank str if missing/null
         image_src = None
         file_extension = Path(file_s3_path).suffix
 

--- a/learning_resources/etl/ocw_test.py
+++ b/learning_resources/etl/ocw_test.py
@@ -56,7 +56,7 @@ def test_transform_content_files(settings, mocker, base_ocw_url):
         transform_content_files(s3_resource, OCW_TEST_PREFIX, False)  # noqa: FBT003
     )
 
-    assert len(content_data) == 4
+    assert len(content_data) == 5
 
     assert content_data[0] == {
         "content": "Pages Section",
@@ -112,6 +112,21 @@ def test_transform_content_files(settings, mocker, base_ocw_url):
         "file_extension": ".mp4",
     }
 
+    assert content_data[4] == {
+        "content": "TEXT",
+        "content_type": "video",
+        "description": "Video Description, no file",
+        "file_type": "video/mp4",
+        "key": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video_no_file/",
+        "content_tags": ["Old Videos"],
+        "published": True,
+        "title": None,
+        "content_title": None,
+        "url": f"{ocw_url}/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video_no_file/",
+        "image_src": "https://img.youtube.com/vi/vKer2U5W5-s/default.jpg",
+        "file_extension": ".mp4",
+    }
+
 
 @mock_aws
 def test_transform_content_files_exceptions(settings, mocker):
@@ -129,7 +144,7 @@ def test_transform_content_files_exceptions(settings, mocker):
         transform_content_files(s3_resource, OCW_TEST_PREFIX, False)  # noqa: FBT003
     )
     assert len(content_data) == 0
-    assert mock_log.call_count == 5
+    assert mock_log.call_count == 7
 
 
 @mock_aws

--- a/learning_resources/etl/pipelines_test.py
+++ b/learning_resources/etl/pipelines_test.py
@@ -263,7 +263,7 @@ def test_ocw_courses_etl(settings, mocker, skip_content_files):
     run = resource.runs.first()
     assert run.instructors.count() == 10
     assert run.run_id == "97db384ef34009a64df7cb86cf701979"
-    assert run.content_files.count() == (0 if skip_content_files else 4)
+    assert run.content_files.count() == (0 if skip_content_files else 5)
     assert mock_cf_actions.call_count == (0 if skip_content_files else 1)
     assert mock_calc_score.call_count == (0 if skip_content_files else 1)
 

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -3197,7 +3197,7 @@ def test_document_percolation(opensearch, mocker):
     lr = LearningResourceFactory.create()
     percolate_matches_for_document(lr.id)
 
-    plugin_log_handler.info.assert_called_once_with(
+    plugin_log_handler.debug.assert_called_once_with(
         "document %i percolated - %s",
         lr.id,
         list(PercolateQuery.objects.filter(id__in=[p["id"] for p in percolate_hits])),

--- a/learning_resources_search/plugins.py
+++ b/learning_resources_search/plugins.py
@@ -58,7 +58,7 @@ class SearchIndexPlugin:
             resource(LearningResource): The Learning Resource that was percolated
             percolated_queries(PercolateQuery): list of percolated queries
         """
-        log.info("document %i percolated - %s", resource.id, list(percolated_queries))
+        log.debug("document %i percolated - %s", resource.id, list(percolated_queries))
 
     @hookimpl
     def resource_upserted(self, resource, percolate):

--- a/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/resource_no_file/data.json
+++ b/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/resource_no_file/data.json
@@ -1,0 +1,11 @@
+{
+  "description": "This resource contains problem set 2",
+  "file": "https://ol-ocw-studio-app-qa.s3.amazonaws.com/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/fubar.pdf",
+  "learning_resource_types": [
+    "Activity Assignments",
+    "Activity Assignments with Examples"
+  ],
+  "resource_type": "Document",
+  "file_type": "application/pdf",
+  "title": "Resource Title 2"
+}

--- a/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video_no_file/data.json
+++ b/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video_no_file/data.json
@@ -1,0 +1,14 @@
+{
+  "description": "Video Description, no file",
+  "video_files": {
+    "archive_url": "https://archive.org/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/2MTm4cjPnMl0AmnP42tDtBleiQ3Zc2g27/old_video.mp4"
+  },
+  "learning_resource_types": ["Old Videos"],
+  "resource_type": "Video",
+  "file_type": "video/mp4",
+  "youtube_key": "vKer2U5W5-s",
+  "captions_file": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/1MTm4cjPnMl0AmnP42tDtBleiQ3Zc2g26_transcript_webvtt",
+  "transcript_file": "courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/1MTm4cjPnMl0AmnP42tDtBleiQ3Zc2g26_transcript.pdf",
+  "thumbnail_file": "https://img.youtube.com/vi/vKer2U5W5-s/default.jpg",
+  "archive_url": null
+}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6939

### Description (What does it do?)
Handles missing/empty file attribute in contentfile JSON


### How can this be tested?
 - Make sure the following env variables are set in your backend.local.env file:
    ```
   OCW_LIVE_BUCKET=ocw-content-live-production
   AWS_ACCESS_KEY_ID
   AWS_SECRET_ACCESS_KEY
   ``` 
   

 - Run the following command, you should not see any logging errors like "TypeError: argument should be a str or an os.PathLike object"
 ```bash
 ./manage.py backpopulate_ocw_data --course-name 21m-342-composing-for-jazz-orchestra-fall-2008
 ```

I also changed a percolate info statement to a debug statement because it was filling up the console when running (@shanbady is this okay or are those log info statements necessary?)