### PR TITLE
Decrease lookback window for embedding new resources and contentfiles

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -753,7 +753,14 @@ DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY = get_float(
 DEFAULT_SEARCH_CONTENT_FILE_SCORE_WEIGHT = get_float(
     name="DEFAULT_SEARCH_CONTENT_FILE_SCORE_WEIGHT", default=1
 )
-
+"""
+the lookback window (in minutes) for the embeddings task
+the frequency of the embeddings tasks will be 1/4 of this for example
+lookback = 2 hours; task frequency = 30 minutes
+"""
+QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW = get_int(
+    name="QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW", default=60 * 2
+)
 QDRANT_API_KEY = get_string(name="QDRANT_API_KEY", default="")
 QDRANT_HOST = get_string(name="QDRANT_HOST", default="http://qdrant:6333")
 QDRANT_BASE_COLLECTION_NAME = get_string(

--- a/main/settings.py
+++ b/main/settings.py
@@ -754,13 +754,13 @@ DEFAULT_SEARCH_CONTENT_FILE_SCORE_WEIGHT = get_float(
     name="DEFAULT_SEARCH_CONTENT_FILE_SCORE_WEIGHT", default=1
 )
 """
-the lookback window (in minutes) for the embeddings task
-the frequency of the embeddings tasks will be 1/4 of this for example
-lookback = 2 hours; task frequency = 30 minutes
+the schedule (in minutes) for the embeddings task
+the lookback window for getting items to embed
+will be a constant 60 minutes greater more than the schedule frequency
 """
-QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW = max(
-    75, get_int(name="QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW", default=60 * 2)
-)
+EMBEDDING_SCHEDULE_MINUTES = get_int(name="EMBEDDING_SCHEDULE_MINUTES", default=60)
+QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW = EMBEDDING_SCHEDULE_MINUTES + 60
+
 QDRANT_API_KEY = get_string(name="QDRANT_API_KEY", default="")
 QDRANT_HOST = get_string(name="QDRANT_HOST", default="http://qdrant:6333")
 QDRANT_BASE_COLLECTION_NAME = get_string(

--- a/main/settings.py
+++ b/main/settings.py
@@ -758,8 +758,8 @@ the lookback window (in minutes) for the embeddings task
 the frequency of the embeddings tasks will be 1/4 of this for example
 lookback = 2 hours; task frequency = 30 minutes
 """
-QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW = get_int(
-    name="QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW", default=60 * 2
+QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW = max(
+    75, get_int(name="QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW", default=60 * 2)
 )
 QDRANT_API_KEY = get_string(name="QDRANT_API_KEY", default="")
 QDRANT_HOST = get_string(name="QDRANT_HOST", default="http://qdrant:6333")

--- a/main/settings_celery.py
+++ b/main/settings_celery.py
@@ -6,6 +6,16 @@ from celery.schedules import crontab
 
 from main.envs import get_bool, get_int, get_string
 
+"""
+the lookback window (in minutes) for the embeddings task
+the frequency of the embeddings tasks will be 1/4 of this for example
+lookback = 2 hours; task frequency = 30 minutes
+"""
+QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW = get_int(
+    name="QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW", default=60 * 2
+)
+EMBEDDING_SCHEDULE_MINUTES = int(QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW / 4)
+
 DEV_ENV = get_bool("DEV_ENV", False)  # noqa: FBT003
 USE_CELERY = True
 CELERY_BROKER_URL = get_string("CELERY_BROKER_URL", get_string("REDISCLOUD_URL", None))
@@ -147,13 +157,13 @@ if not DEV_ENV:
     CELERY_BEAT_SCHEDULE["daily_embed_new_learning_resources"] = {
         "task": "vector_search.tasks.embed_new_learning_resources",
         "schedule": get_int(
-            "EMBED_NEW_RESOURCES_SCHEDULE_SECONDS", 60 * 30
+            "EMBED_NEW_RESOURCES_SCHEDULE_SECONDS", 60 * EMBEDDING_SCHEDULE_MINUTES
         ),  # default is every 30 minutes
     }
     CELERY_BEAT_SCHEDULE["daily_embed_new_content_files"] = {
         "task": "vector_search.tasks.embed_new_content_files",
         "schedule": get_int(
-            "EMBED_NEW_CONTENT_FILES_SCHEDULE_SECONDS", 60 * 30
+            "EMBED_NEW_CONTENT_FILES_SCHEDULE_SECONDS", 60 * EMBEDDING_SCHEDULE_MINUTES
         ),  # default is every 30 minutes
     }
 

--- a/main/settings_celery.py
+++ b/main/settings_celery.py
@@ -7,15 +7,12 @@ from celery.schedules import crontab
 from main.envs import get_bool, get_int, get_string
 
 """
-the lookback window (in minutes) for the embeddings task
-the frequency of the embeddings tasks will be 1/4 of this for example
-lookback = 2 hours; task frequency = 30 minutes
+the schedule (in minutes) for the embeddings task
+the lookback window for getting items to embed
+will be a constant 60 minutes greater more than the schedule frequency
 """
-QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW = max(
-    75, get_int(name="QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW", default=60 * 2)
-)
-# schedule should be an hour less than lookback window
-EMBEDDING_SCHEDULE_MINUTES = QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW - 60
+EMBEDDING_SCHEDULE_MINUTES = get_int(name="EMBEDDING_SCHEDULE_MINUTES", default=60)
+QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW = EMBEDDING_SCHEDULE_MINUTES + 60
 
 DEV_ENV = get_bool("DEV_ENV", False)  # noqa: FBT003
 USE_CELERY = True

--- a/main/settings_celery.py
+++ b/main/settings_celery.py
@@ -11,10 +11,11 @@ the lookback window (in minutes) for the embeddings task
 the frequency of the embeddings tasks will be 1/4 of this for example
 lookback = 2 hours; task frequency = 30 minutes
 """
-QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW = get_int(
-    name="QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW", default=60 * 2
+QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW = max(
+    75, get_int(name="QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW", default=60 * 2)
 )
-EMBEDDING_SCHEDULE_MINUTES = int(QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW / 4)
+# schedule should be an hour less than lookback window
+EMBEDDING_SCHEDULE_MINUTES = QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW - 60
 
 DEV_ENV = get_bool("DEV_ENV", False)  # noqa: FBT003
 USE_CELERY = True

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -237,7 +237,7 @@ def embed_learning_resources_by_id(self, ids, skip_content_files, overwrite):
 @app.task(bind=True)
 def embed_new_learning_resources(self):
     """
-    Embed new resources from 40 minutes ago
+    Embed new resources from QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW minutes ago
     """
     log.info("Running new resource embedding task")
     delta = datetime.timedelta(minutes=settings.QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW)
@@ -271,7 +271,7 @@ def embed_new_learning_resources(self):
 @app.task(bind=True)
 def embed_new_content_files(self):
     """
-    Embed new content files from 40 minutes ago
+    Embed new content files from QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW minutes ago
     """
     log.info("Running content file embedding task")
     delta = datetime.timedelta(minutes=settings.QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW)

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -237,10 +237,10 @@ def embed_learning_resources_by_id(self, ids, skip_content_files, overwrite):
 @app.task(bind=True)
 def embed_new_learning_resources(self):
     """
-    Embed new resources from the last day
+    Embed new resources from 40 minutes ago
     """
     log.info("Running new resource embedding task")
-    delta = datetime.timedelta(days=1)
+    delta = datetime.timedelta(minutes=40)
     since = now_in_utc() - delta
     new_learning_resources = LearningResource.objects.filter(
         published=True,
@@ -271,10 +271,10 @@ def embed_new_learning_resources(self):
 @app.task(bind=True)
 def embed_new_content_files(self):
     """
-    Embed new content files from the last day
+    Embed new content files from 40 minutes ago
     """
     log.info("Running content file embedding task")
-    delta = datetime.timedelta(days=1)
+    delta = datetime.timedelta(minutes=40)
     since = now_in_utc() - delta
     new_content_files = (
         ContentFile.objects.filter(

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -240,7 +240,7 @@ def embed_new_learning_resources(self):
     Embed new resources from 40 minutes ago
     """
     log.info("Running new resource embedding task")
-    delta = datetime.timedelta(minutes=40)
+    delta = datetime.timedelta(minutes=settings.QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW)
     since = now_in_utc() - delta
     new_learning_resources = LearningResource.objects.filter(
         published=True,
@@ -274,7 +274,7 @@ def embed_new_content_files(self):
     Embed new content files from 40 minutes ago
     """
     log.info("Running content file embedding task")
-    delta = datetime.timedelta(minutes=40)
+    delta = datetime.timedelta(minutes=settings.QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW)
     since = now_in_utc() - delta
     new_content_files = (
         ContentFile.objects.filter(

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -165,7 +165,7 @@ def test_embed_new_learning_resources(mocker, mocked_celery):
 def test_embed_new_content_files(mocker, mocked_celery):
     """
     embed_new_content_files should generate embeddings for new content files
-    created within the last 40 minutes
+    created within the last QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW minutes
     """
     settings.QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW = 60 * 2
     mocker.patch("vector_search.tasks.load_course_blocklist", return_value=[])
@@ -176,7 +176,7 @@ def test_embed_new_content_files(mocker, mocked_celery):
             minutes=random.randint(1, settings.QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW)  # noqa: S311
         )
         cf.save()
-    # create resources older than 40 minutes
+    # create resources older than QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW minutes
     old_contents = ContentFileFactory.create_batch(
         4,
         published=True,
@@ -359,7 +359,7 @@ def test_embedded_content_file_without_runs(mocker, mocked_celery):
 def test_embed_new_content_files_without_runs(mocker, mocked_celery):
     """
     embed_new_content_files should generate embeddings for new content files
-    created within the last 40 minutes
+    created within the last QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW minutes
     """
     mocker.patch("vector_search.tasks.load_course_blocklist", return_value=[])
     course = CourseFactory.create(etl_source=ETLSource.ocw.value)

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -1,4 +1,5 @@
 import datetime
+import random
 
 import pytest
 from django.conf import settings
@@ -118,23 +119,30 @@ def test_embed_new_learning_resources(mocker, mocked_celery):
     """
     mocker.patch("vector_search.tasks.load_course_blocklist", return_value=[])
 
-    daily_since = now_in_utc() - datetime.timedelta(hours=5)
-
-    LearningResourceFactory.create_batch(
-        4, created_on=daily_since, resource_type=COURSE_TYPE, published=True
+    new_resources = LearningResourceFactory.create_batch(
+        4, resource_type=COURSE_TYPE, published=True
     )
+    for resource in new_resources:
+        resource.created_on = now_in_utc() - datetime.timedelta(
+            minutes=random.randint(1, 39)  # noqa: S311
+        )
+        resource.save()
     # create resources older than a day
-    LearningResourceFactory.create_batch(
+    old_resources = LearningResourceFactory.create_batch(
         4,
-        created_on=now_in_utc() - datetime.timedelta(days=5),
         resource_type=COURSE_TYPE,
         published=True,
     )
+    for resource in old_resources:
+        resource.created_on = now_in_utc() - datetime.timedelta(
+            minutes=random.randint(50, 100)  # noqa: S311
+        )
+        resource.save()
 
-    daily_resource_ids = [
+    new_resource_ids = [
         resource.id
         for resource in LearningResource.objects.filter(
-            created_on__gt=now_in_utc() - datetime.timedelta(days=1)
+            created_on__gt=now_in_utc() - datetime.timedelta(minutes=40)
         )
     ]
 
@@ -147,30 +155,35 @@ def test_embed_new_learning_resources(mocker, mocked_celery):
     list(mocked_celery.group.call_args[0][0])
 
     embedded_ids = generate_embeddings_mock.si.mock_calls[0].args[0]
-    assert sorted(daily_resource_ids) == sorted(embedded_ids)
+    assert sorted(new_resource_ids) == sorted(embedded_ids)
 
 
 def test_embed_new_content_files(mocker, mocked_celery):
     """
     embed_new_content_files should generate embeddings for new content files
-    created within the last day
+    created within the last 40 minutes
     """
     mocker.patch("vector_search.tasks.load_course_blocklist", return_value=[])
 
-    daily_since = now_in_utc() - datetime.timedelta(hours=5)
-
-    ContentFileFactory.create_batch(4, created_on=daily_since, published=True)
-    # create resources older than a day
-    ContentFileFactory.create_batch(
+    new_contents = ContentFileFactory.create_batch(4, published=True)
+    for cf in new_contents:
+        cf.created_on = now_in_utc() - datetime.timedelta(minutes=random.randint(1, 39))  # noqa: S311
+        cf.save()
+    # create resources older than 40 minutes
+    old_contents = ContentFileFactory.create_batch(
         4,
-        created_on=now_in_utc() - datetime.timedelta(days=5),
         published=True,
     )
+    for cf in old_contents:
+        cf.created_on = now_in_utc() - datetime.timedelta(
+            minutes=random.randint(50, 140)  # noqa: S311
+        )
+        cf.save()
 
-    daily_content_file_ids = [
+    new_content_file_ids = [
         resource.id
         for resource in ContentFile.objects.filter(
-            created_on__gt=now_in_utc() - datetime.timedelta(days=1)
+            created_on__gt=now_in_utc() - datetime.timedelta(minutes=40)
         )
     ]
 
@@ -183,7 +196,7 @@ def test_embed_new_content_files(mocker, mocked_celery):
     list(mocked_celery.group.call_args[0][0])
 
     embedded_ids = generate_embeddings_mock.si.mock_calls[0].args[0]
-    assert sorted(daily_content_file_ids) == sorted(embedded_ids)
+    assert sorted(new_content_file_ids) == sorted(embedded_ids)
 
 
 def test_embed_learning_resources_by_id(mocker, mocked_celery):
@@ -336,11 +349,11 @@ def test_embedded_content_file_without_runs(mocker, mocked_celery):
 def test_embed_new_content_files_without_runs(mocker, mocked_celery):
     """
     embed_new_content_files should generate embeddings for new content files
-    created within the last day
+    created within the last 40 minutes
     """
     mocker.patch("vector_search.tasks.load_course_blocklist", return_value=[])
     course = CourseFactory.create(etl_source=ETLSource.ocw.value)
-    daily_since = now_in_utc() - datetime.timedelta(hours=5)
+    daily_since = now_in_utc() - datetime.timedelta(minutes=5)
     ContentFileFactory.create_batch(4, created_on=daily_since, published=True)
     content_files_without_run = [
         cf.id


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7008


### Description (What does it do?)
We have celery tasks that pick up new learning resources and contentfiles from within the last day and run embeddings for them. This typically is not an issue unless we run etl pipelines manually in which case if there are several tens of thousands of new contentfiles, the periodic task (which runs every 30 minutes) may not complete and a new one gets spawned.

This PR reduces the lookback window to "embed new contentfiles/learning resources" from 40 minutes ago. 

### How can this be tested?
Its a faily straightforward adjustment to the timedelta for the lookback window. Tests have been adjusted for it and should pass.

To manually test:
1. checkout this branch.
2. find a contentfiles and learning resources and set their "created_on" attribute to within the last 40 minutes
```python
from learning_resources.models import LearningResource,ContentFile
import datetime
from main.utils import now_in_utc
for i in range(10):
    lr = LearningResource.objects.all()[i]
    lr.created_on =now_in_utc() - datetime.timedelta(minutes=20)
    lr.save()
for i in range(10):
    cf = ContentFile.objects.all()[i]
    cf.created_on =now_in_utc() - datetime.timedelta(minutes=30)
    cf.save()
```
3. manually run the embeddings tasks to see that those resources are picked up:
```python
from vector_search.tasks import embed_new_content_files,embed_new_learning_resources
 embed_new_content_files.apply()
embed_new_learning_resources.apply()
```
when the task succeeds the number of "None" elements outputted should match the number of resources you would have expected to see get picked up
<code>succeeded in 0.00019108298874925822s: **[None, None, None, None, None, None, None, None, None, None]**</code>

