### PR TITLE
add a prop to DashboardCard to optionally disable the not complete icon

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -156,3 +156,24 @@ describe("EnrollmentCard", () => {
     },
   )
 })
+
+test.each([
+  { enrollmentStatus: EnrollmentStatus.NotEnrolled, showNotComplete: true },
+  { enrollmentStatus: EnrollmentStatus.NotEnrolled, showNotComplete: false },
+])(
+  "Shows empty circle icon if not enrolled and showNotComplete is true",
+  ({ enrollmentStatus, showNotComplete }) => {
+    const course = dashboardCourse({
+      enrollment: { status: enrollmentStatus },
+    })
+    renderWithProviders(
+      <DashboardCard
+        dashboardResource={course}
+        showNotComplete={showNotComplete}
+      />,
+    )
+
+    const notCompletedIcon = screen.queryByTestId("not-complete-icon")
+    expect(!!notCompletedIcon).toBe(showNotComplete)
+  },
+)

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -206,8 +206,12 @@ const getMenuItems = (): SimpleMenuItem[] => [
 
 type DashboardCardProps = {
   dashboardResource: DashboardCourse
+  showNotComplete?: boolean
 }
-const DashboardCard: React.FC<DashboardCardProps> = ({ dashboardResource }) => {
+const DashboardCard: React.FC<DashboardCardProps> = ({
+  dashboardResource,
+  showNotComplete = true,
+}) => {
   const { title, marketingUrl, enrollment, run } = dashboardResource
   return (
     <CardRoot data-testid="enrollment-card">
@@ -234,9 +238,9 @@ const DashboardCard: React.FC<DashboardCardProps> = ({ dashboardResource }) => {
         <Stack direction="row" gap="8px" alignItems="center">
           {enrollment?.status === EnrollmentStatus.Completed ? (
             <Completed src={CompleteCheck} alt="Completed" />
-          ) : (
-            <NotComplete />
-          )}
+          ) : showNotComplete ? (
+            <NotComplete data-testid="not-complete-icon" />
+          ) : null}
           <CoursewareButton
             startDate={run.startDate}
             href={run.coursewareUrl}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -79,7 +79,7 @@ const EnrollmentDisplay = () => {
       <PlainList itemSpacing={"16px"}>
         {sorted?.map((course) => (
           <li key={course.id}>
-            <DashboardCard dashboardResource={course} />
+            <DashboardCard dashboardResource={course} showNotComplete={false} />
           </li>
         ))}
       </PlainList>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7042

### Description (What does it do?)
This PR adds a prop to disable the rendering of the `NotComplete` "empty circle" icons in the `DashboardCard` component. The 

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/77ab9f26-cc04-4295-8c3e-547384940fec)
(Mobile designs not yet implemented)

### How can this be tested?
- Ensure you have Posthog connected to your local instance of `mit-learn`
- In  your connected Posthog project, make sure you have added and enabled the `enrollment-dashboard` feature flag
- Visit http://open.odl.local:8062/dashboard and log in (if you are not already logged in)
- Compare to RC (https://rc.learn.mit.edu/dashboard) and ensure that the empty circle icons next to courses you have not enrolled in are not present in your local site
