### PR TITLE
remove initial messages

### DIFF
--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -14,7 +14,7 @@
     "@emotion/cache": "^11.13.1",
     "@emotion/styled": "^11.11.0",
     "@mitodl/course-search-utils": "3.3.2",
-    "@mitodl/smoot-design": "^6.0.0",
+    "@mitodl/smoot-design": "^6.1.0",
     "@next/bundle-analyzer": "^14.2.15",
     "@remixicon/react": "^4.2.0",
     "@sentry/nextjs": "^9.0.0",

--- a/frontends/main/src/page-components/AiChat/AiRecommendationBotDrawer.tsx
+++ b/frontends/main/src/page-components/AiChat/AiRecommendationBotDrawer.tsx
@@ -3,7 +3,6 @@ import { styled, RoutedDrawer } from "ol-components"
 import { RiCloseLine } from "@remixicon/react"
 import { ActionButton } from "@mitodl/smoot-design"
 import { AiChat } from "@mitodl/smoot-design/ai"
-import type { AiChatProps } from "@mitodl/smoot-design/ai"
 import { getCsrfToken } from "@/common/utils"
 import { RECOMMENDER_QUERY_PARAM } from "@/common/urls"
 
@@ -34,13 +33,6 @@ const StyledAiChat = styled(AiChat)({
     paddingTop: "152px",
   },
 })
-
-const INITIAL_MESSAGES: AiChatProps["initialMessages"] = [
-  {
-    content: "What do you want to learn about today?",
-    role: "assistant",
-  },
-]
 
 const STARTERS = [
   {
@@ -77,7 +69,6 @@ const DrawerContent: React.FC<{
         entryScreenTitle="What do you want to learn from MIT?"
         conversationStarters={STARTERS}
         askTimTitle="to recommend a course"
-        initialMessages={INITIAL_MESSAGES}
         scrollElement={scrollElement}
         requestOpts={{
           apiUrl: process.env.NEXT_PUBLIC_LEARN_AI_RECOMMENDATION_ENDPOINT!,

--- a/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.test.tsx
@@ -3,7 +3,8 @@ import AiChatSyllabusSlideDown, {
   ChatTransitionState,
 } from "./AiChatSyllabusSlideDown"
 import { renderWithProviders, screen, user } from "@/test-utils"
-import { factories, setMockResponse, urls } from "api/test-utils"
+import { factories } from "api/test-utils"
+import invariant from "tiny-invariant"
 
 /**
  * Note: This component is primarily tested in @mitodl/smoot-design.
@@ -11,40 +12,9 @@ import { factories, setMockResponse, urls } from "api/test-utils"
  * Here we just check a few config settings.
  */
 describe("AiChatSyllabus", () => {
-  test("User clicks a starter. Greets authenticated user by name", async () => {
-    const resource = factories.learningResources.course()
-    const userMe = factories.user.user()
-
-    // Sanity
-    expect(userMe.profile?.name).toBeTruthy()
-
-    setMockResponse.get(urls.userMe.get(), userMe)
-    renderWithProviders(
-      <AiChatSyllabusSlideDown
-        open
-        resource={resource}
-        onTransitionEnd={jest.fn()}
-        scrollElement={null}
-        contentTopPosition={0}
-        chatTransitionState={ChatTransitionState.Open}
-      />,
-    )
-
-    await user.click(
-      screen.getByRole("button", { name: "What is this course about?" }),
-    )
-
-    // byAll because there are two instances, one is SR-only in an aria-live area
-    // check for username and resource title
-    await screen.findAllByText(
-      new RegExp(`Hello ${userMe.profile?.name}.*${resource.title}.*`),
-    )
-  })
-
-  test("User enters a prompt. Greets anonymous user generically", async () => {
+  test("User's message is first message", async () => {
     const resource = factories.learningResources.course()
 
-    setMockResponse.get(urls.userMe.get(), { is_authenticated: false })
     renderWithProviders(
       <AiChatSyllabusSlideDown
         open
@@ -61,8 +31,8 @@ describe("AiChatSyllabus", () => {
 
     await user.type(input, "tell me more{enter}")
 
-    // byAll because there are two instances, one is SR-only in an aria-live area
-    // check for username and resource title
-    await screen.findAllByText(new RegExp(`Hello and.*${resource.title}.*`))
+    const firstMessage = document.querySelector("[data-chat-role]")
+    invariant(firstMessage instanceof HTMLElement)
+    expect(firstMessage?.dataset.chatRole).toBe("user")
   })
 })

--- a/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx
@@ -8,8 +8,6 @@ import {
 } from "@remixicon/react"
 import type { AiChatProps } from "@mitodl/smoot-design/ai"
 import { LearningResource } from "api"
-import { useUserMe } from "api/hooks/user"
-import type { User } from "api/hooks/user"
 import { AiChat } from "@mitodl/smoot-design/ai"
 import { getCsrfToken } from "@/common/utils"
 
@@ -126,21 +124,6 @@ const STARTERS: AiChatProps["conversationStarters"] = [
   { content: "How will this course be graded?" },
 ]
 
-const getInitialMessage = (
-  resource: LearningResource,
-  user?: User,
-): AiChatProps["initialMessages"] => {
-  const greetings = user?.profile?.name
-    ? `Hello ${user.profile.name}, `
-    : "Hello and "
-  return [
-    {
-      content: `${greetings} welcome to **${resource.title}**. How can I assist you today?`,
-      role: "assistant",
-    },
-  ]
-}
-
 export const AiChatSyllabusOpener = ({
   open,
   className,
@@ -184,7 +167,6 @@ const AiChatSyllabusSlideDown = ({
   contentTopPosition: number
   chatTransitionState: ChatTransitionState
 }) => {
-  const user = useUserMe()
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -215,7 +197,6 @@ const AiChatSyllabusSlideDown = ({
         chatId={resource.readable_id}
         entryScreenTitle="What do you want to know about this course?"
         conversationStarters={STARTERS}
-        initialMessages={getInitialMessage(resource, user.data)}
         topPosition={contentTopPosition}
         scrollElement={scrollElement}
         requestOpts={{

--- a/frontends/main/src/test-utils/index.tsx
+++ b/frontends/main/src/test-utils/index.tsx
@@ -107,11 +107,7 @@ const renderWithTheme = (ui: React.ReactElement) =>
  * @param fc the mock or spied upon functional component
  * @param partialProps an object of props
  */
-const expectProps = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fc: (...args: any[]) => void,
-  partialProps: unknown,
-) => {
+const expectProps = <P,>(fc: React.FC<P>, partialProps: Partial<P>) => {
   expect(fc).toHaveBeenCalledWith(
     expect.objectContaining(partialProps),
     expect.toBeOneOf([expect.anything(), undefined]),
@@ -124,11 +120,7 @@ const expectProps = (
  * @param fc the mock or spied upon functional component
  * @param partialProps an object of props
  */
-const expectLastProps = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fc: (...args: any[]) => void,
-  partialProps: unknown,
-) => {
+const expectLastProps = <P,>(fc: React.FC<P>, partialProps: Partial<P>) => {
   expect(fc).toHaveBeenLastCalledWith(
     expect.objectContaining(partialProps),
     expect.toBeOneOf([expect.anything(), undefined]),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2694,9 +2694,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/smoot-design@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@mitodl/smoot-design@npm:6.0.0"
+"@mitodl/smoot-design@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@mitodl/smoot-design@npm:6.1.0"
   dependencies:
     "@emotion/cache": "npm:^11.14.0"
     "@mui/utils": "npm:^6.1.6"
@@ -2716,7 +2716,7 @@ __metadata:
     "@remixicon/react": ^4.2.0
     react: ^18 || ^19
     react-dom: ^18 || ^19
-  checksum: 10/c956df5a0ea5a75ef815424314346124f9d62e228675e8e22a76270e1ddf2bcd085964d09b41afa40187a28014eea5d3918ff64b5dce35b4f872eac823e0b90d
+  checksum: 10/1395c039f7b30dc73d317de264e37ccf98c2e9d9a87083e4549136bcb3b15017a472a5a98c476ba22b942a9ea97f4bc93d2182902db05b9ffbaca5b66e53fc80
   languageName: node
   linkType: hard
 
@@ -12916,7 +12916,7 @@ __metadata:
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^9.0.0"
     "@mitodl/course-search-utils": "npm:3.3.2"
-    "@mitodl/smoot-design": "npm:^6.0.0"
+    "@mitodl/smoot-design": "npm:^6.1.0"
     "@next/bundle-analyzer": "npm:^14.2.15"
     "@remixicon/react": "npm:^4.2.0"
     "@sentry/nextjs": "npm:^9.0.0"


### PR DESCRIPTION
### What are the relevant tickets?
Closes

### Description (What does it do?)
Removes the initial message from AI chat screens. (Splash screen still in place.)

### Screenshots (if appropriate):
<img width="1084" alt="Screenshot 2025-04-07 at 1 39 19 PM" src="https://github.com/user-attachments/assets/a55b918a-daf1-4d36-b3e3-07810e2fac83" />
<img width="1022" alt="Screenshot 2025-04-07 at 1 39 29 PM" src="https://github.com/user-attachments/assets/245ce138-5545-417d-8ba8-0cf66db8ebeb" />

### How can this be tested?
1. With AI Chats enabled (posthog feature flags`lr-drawer-chatbot` for syllabus bot, `home-page-recommendation-bot` for reccomendation bot)...
2. Click "AskTim" below homepage search bar. You should see:
    - "Splash screen" with beaver and big textbox. Enter some text and submit.
    - **This PR:** The first message in chat conversation should be yours, not AI's
2. Click "AskTim" within a course resource drawer. You should see:
    - "Splash screen" with beaver and big textbox. Enter some text and submit.
    - **This PR:** The first message in chat conversation should be yours, not AI's

