### PR TITLE
enrollment dashboard mobile layout

### DIFF
--- a/frontends/api/src/mitxonline/test-utils/factories/enrollment.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/enrollment.ts
@@ -10,7 +10,8 @@ import type {
 const courseEnrollment: PartialFactory<CourseRunEnrollment> = (
   overrides = {},
 ) => {
-  const title = faker.word.words(3)
+  const title =
+    overrides.run?.title ?? overrides.run?.course?.title ?? faker.word.words(3)
   return mergeOverrides<CourseRunEnrollment>(
     {
       id: faker.number.int(),

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { renderWithProviders, screen } from "@/test-utils"
+import { renderWithProviders, screen, within } from "@/test-utils"
 import { DashboardCard } from "./DashboardCard"
 import { dashboardCourse } from "./test-utils"
 import { faker } from "@faker-js/faker/locale/en"
@@ -101,8 +101,12 @@ describe("EnrollmentCard", () => {
     ({ overrides, expectation }) => {
       const course = dashboardCourse(overrides)
       renderWithProviders(<DashboardCard dashboardResource={course} />)
-      const upgradeRootDesktop = screen.queryByTestId("upgrade-root-desktop")
-      const upgradeRootMobile = screen.queryByTestId("upgrade-root-mobile")
+      const upgradeRootDesktop = within(
+        screen.getByTestId("enrollment-card-desktop"),
+      ).queryByTestId("upgrade-root")
+      const upgradeRootMobile = within(
+        screen.getByTestId("enrollment-card-mobile"),
+      ).queryByTestId("upgrade-root")
       expect(!!upgradeRootDesktop).toBe(expectation.visible)
       expect(!!upgradeRootMobile).toBe(expectation.visible)
     },
@@ -127,8 +131,12 @@ describe("EnrollmentCard", () => {
 
     renderWithProviders(<DashboardCard dashboardResource={course} />)
 
-    const upgradeRootDesktop = screen.queryByTestId("upgrade-root-desktop")
-    const upgradeRootMobile = screen.queryByTestId("upgrade-root-mobile")
+    const upgradeRootDesktop = within(
+      screen.getByTestId("enrollment-card-desktop"),
+    ).queryByTestId("upgrade-root")
+    const upgradeRootMobile = within(
+      screen.getByTestId("enrollment-card-mobile"),
+    ).queryByTestId("upgrade-root")
     for (const upgradeRoot of [upgradeRootDesktop, upgradeRootMobile]) {
       expect(upgradeRoot).toBeVisible()
 
@@ -211,12 +219,12 @@ test.each([
       />,
     )
 
-    const notCompletedIconDesktop = screen.queryByTestId(
-      "not-complete-icon-desktop",
-    )
-    const notCompletedIconMobile = screen.queryByTestId(
-      "not-complete-icon-mobile",
-    )
+    const notCompletedIconDesktop = within(
+      screen.getByTestId("enrollment-card-desktop"),
+    ).queryByTestId("not-complete-icon")
+    const notCompletedIconMobile = within(
+      screen.getByTestId("enrollment-card-mobile"),
+    ).queryByTestId("not-complete-icon")
     expect(!!notCompletedIconDesktop).toBe(showNotComplete)
     expect(!!notCompletedIconMobile).toBe(showNotComplete)
   },

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -101,10 +101,10 @@ describe("EnrollmentCard", () => {
     ({ overrides, expectation }) => {
       const course = dashboardCourse(overrides)
       renderWithProviders(<DashboardCard dashboardResource={course} />)
-      const upgradeRoots = screen.queryAllByTestId("upgrade-root")
-      for (const upgradeRoot of upgradeRoots) {
-        expect(!!upgradeRoot).toBe(expectation.visible)
-      }
+      const upgradeRootDesktop = screen.queryByTestId("upgrade-root-desktop")
+      const upgradeRootMobile = screen.queryByTestId("upgrade-root-mobile")
+      expect(!!upgradeRootDesktop).toBe(expectation.visible)
+      expect(!!upgradeRootMobile).toBe(expectation.visible)
     },
   )
 
@@ -127,8 +127,9 @@ describe("EnrollmentCard", () => {
 
     renderWithProviders(<DashboardCard dashboardResource={course} />)
 
-    const upgradeRoots = screen.getAllByTestId("upgrade-root")
-    for (const upgradeRoot of upgradeRoots) {
+    const upgradeRootDesktop = screen.queryByTestId("upgrade-root-desktop")
+    const upgradeRootMobile = screen.queryByTestId("upgrade-root-mobile")
+    for (const upgradeRoot of [upgradeRootDesktop, upgradeRootMobile]) {
       expect(upgradeRoot).toBeVisible()
 
       expect(upgradeRoot).toHaveTextContent(/5 days remaining/)
@@ -210,9 +211,13 @@ test.each([
       />,
     )
 
-    const notCompletedIcons = screen.queryAllByTestId("not-complete-icon")
-    for (const notCompletedIcon of notCompletedIcons) {
-      expect(!!notCompletedIcon).toBe(showNotComplete)
-    }
+    const notCompletedIconDesktop = screen.queryByTestId(
+      "not-complete-icon-desktop",
+    )
+    const notCompletedIconMobile = screen.queryByTestId(
+      "not-complete-icon-mobile",
+    )
+    expect(!!notCompletedIconDesktop).toBe(showNotComplete)
+    expect(!!notCompletedIconMobile).toBe(showNotComplete)
   },
 )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -11,10 +11,12 @@ describe("EnrollmentCard", () => {
     const course = dashboardCourse()
     renderWithProviders(<DashboardCard dashboardResource={course} />)
 
-    const courseLink = screen.getByRole("link", {
+    const courseLinks = screen.getAllByRole("link", {
       name: course.title,
     })
-    expect(courseLink).toHaveAttribute("href", course.marketingUrl)
+    for (const courseLink of courseLinks) {
+      expect(courseLink).toHaveAttribute("href", course.marketingUrl)
+    }
   })
 
   test("Courseware button is disabled if course has not started", () => {
@@ -24,11 +26,13 @@ describe("EnrollmentCard", () => {
       },
     })
     renderWithProviders(<DashboardCard dashboardResource={course} />)
-    const coursewareButton = screen.getByRole("button", {
+    const coursewareButtons = screen.getAllByRole("button", {
       name: "Continue Course",
       hidden: true,
     })
-    expect(coursewareButton).toBeDisabled()
+    for (const coursewareButton of coursewareButtons) {
+      expect(coursewareButton).toBeDisabled()
+    }
   })
 
   test("Courseware button is enabled if course has started AND NOT ended", () => {
@@ -39,10 +43,12 @@ describe("EnrollmentCard", () => {
       },
     })
     renderWithProviders(<DashboardCard dashboardResource={course} />)
-    const coursewareLink = screen.getByRole("link", {
+    const coursewareLinks = screen.getAllByRole("link", {
       name: "Continue Course",
     })
-    expect(coursewareLink).toHaveAttribute("href", course.run.coursewareUrl)
+    for (const coursewareLink of coursewareLinks) {
+      expect(coursewareLink).toHaveAttribute("href", course.run.coursewareUrl)
+    }
   })
 
   test("Courseware button says 'View Course' if course has ended", () => {
@@ -53,10 +59,12 @@ describe("EnrollmentCard", () => {
       },
     })
     renderWithProviders(<DashboardCard dashboardResource={course} />)
-    const coursewareLink = screen.getByRole("link", {
+    const coursewareLinks = screen.getAllByRole("link", {
       name: "View Course",
     })
-    expect(coursewareLink).toHaveAttribute("href", course.run.coursewareUrl)
+    for (const coursewareLink of coursewareLinks) {
+      expect(coursewareLink).toHaveAttribute("href", course.run.coursewareUrl)
+    }
   })
 
   test.each([
@@ -93,8 +101,10 @@ describe("EnrollmentCard", () => {
     ({ overrides, expectation }) => {
       const course = dashboardCourse(overrides)
       renderWithProviders(<DashboardCard dashboardResource={course} />)
-      const upgradeRoot = screen.queryByTestId("upgrade-root")
-      expect(!!upgradeRoot).toBe(expectation.visible)
+      const upgradeRoots = screen.queryAllByTestId("upgrade-root")
+      for (const upgradeRoot of upgradeRoots) {
+        expect(!!upgradeRoot).toBe(expectation.visible)
+      }
     },
   )
 
@@ -117,13 +127,15 @@ describe("EnrollmentCard", () => {
 
     renderWithProviders(<DashboardCard dashboardResource={course} />)
 
-    const upgradeRoot = screen.getByTestId("upgrade-root")
-    expect(upgradeRoot).toBeVisible()
+    const upgradeRoots = screen.getAllByTestId("upgrade-root")
+    for (const upgradeRoot of upgradeRoots) {
+      expect(upgradeRoot).toBeVisible()
 
-    expect(upgradeRoot).toHaveTextContent(/5 days remaining/)
-    expect(upgradeRoot).toHaveTextContent(
-      `Add a certificate for $${certificateUpgradePrice}`,
-    )
+      expect(upgradeRoot).toHaveTextContent(/5 days remaining/)
+      expect(upgradeRoot).toHaveTextContent(
+        `Add a certificate for $${certificateUpgradePrice}`,
+      )
+    }
   })
 
   test("Shows number of days until course starts", () => {
@@ -141,18 +153,43 @@ describe("EnrollmentCard", () => {
   })
 
   test.each([
-    { enrollmentStatus: EnrollmentStatus.Completed, hasCompleted: true },
-    { enrollmentStatus: EnrollmentStatus.Enrolled, hasCompleted: false },
+    {
+      enrollmentStatus: EnrollmentStatus.Completed,
+      hasCompleted: true,
+      showNotComplete: false,
+    },
+    {
+      enrollmentStatus: EnrollmentStatus.Enrolled,
+      hasCompleted: false,
+      showNotComplete: false,
+    },
+    {
+      enrollmentStatus: EnrollmentStatus.Completed,
+      hasCompleted: true,
+      showNotComplete: true,
+    },
+    {
+      enrollmentStatus: EnrollmentStatus.Enrolled,
+      hasCompleted: false,
+      showNotComplete: true,
+    },
   ])(
     "Shows completed icon if course is completed",
-    ({ enrollmentStatus, hasCompleted }) => {
+    ({ enrollmentStatus, hasCompleted, showNotComplete }) => {
       const course = dashboardCourse({
         enrollment: { status: enrollmentStatus },
       })
-      renderWithProviders(<DashboardCard dashboardResource={course} />)
+      renderWithProviders(
+        <DashboardCard
+          dashboardResource={course}
+          showNotComplete={showNotComplete}
+        />,
+      )
 
-      const completedIcon = screen.queryByRole("img", { name: "Completed" })
-      expect(!!completedIcon).toBe(hasCompleted)
+      const completedIcon = screen.queryAllByRole("img", { name: "Completed" })
+      for (const icon of completedIcon) {
+        expect(!!icon).toBe(hasCompleted)
+      }
     },
   )
 })
@@ -173,7 +210,9 @@ test.each([
       />,
     )
 
-    const notCompletedIcon = screen.queryByTestId("not-complete-icon")
-    expect(!!notCompletedIcon).toBe(showNotComplete)
+    const notCompletedIcons = screen.queryAllByTestId("not-complete-icon")
+    for (const notCompletedIcon of notCompletedIcons) {
+      expect(!!notCompletedIcon).toBe(showNotComplete)
+    }
   },
 )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -34,6 +34,7 @@ const MobileOnly = styled.div(({ theme }) => ({
 }))
 
 const CardRoot = styled.div(({ theme }) => ({
+  position: "relative",
   border: `1px solid ${theme.custom.colors.lightGray2}`,
   borderRadius: "8px",
   backgroundColor: theme.custom.colors.white,
@@ -53,7 +54,9 @@ const CardRoot = styled.div(({ theme }) => ({
 }))
 
 const MenuButton = styled(ActionButton)({
-  marginLeft: "-8px",
+  position: "absolute",
+  top: "0",
+  right: "0",
 })
 
 const getCoursewareText = (endDate?: string | null) => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -24,6 +24,11 @@ const CardRoot = styled.div(({ theme }) => ({
   display: "flex",
   gap: "8px",
   alignItems: "center",
+  [theme.breakpoints.down("md")]: {
+    borderTop: "none",
+    borderRadius: "0px",
+    boxShadow: "none",
+  },
 }))
 
 const MenuButton = styled(ActionButton)({

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -15,6 +15,24 @@ import { calendarDaysUntil, isInPast, NoSSR } from "ol-utilities"
 
 import CompleteCheck from "@/public/images/icons/complete-check.svg"
 
+const DesktopOnly = styled.div(({ theme }) => ({
+  [theme.breakpoints.up("md")]: {
+    display: "list-item",
+  },
+  [theme.breakpoints.down("md")]: {
+    display: "none",
+  },
+}))
+
+const MobileOnly = styled.div(({ theme }) => ({
+  [theme.breakpoints.down("md")]: {
+    display: "list-item",
+  },
+  [theme.breakpoints.up("md")]: {
+    display: "none",
+  },
+}))
+
 const CardRoot = styled.div(({ theme }) => ({
   border: `1px solid ${theme.custom.colors.lightGray2}`,
   borderRadius: "8px",
@@ -25,9 +43,12 @@ const CardRoot = styled.div(({ theme }) => ({
   gap: "8px",
   alignItems: "center",
   [theme.breakpoints.down("md")]: {
-    borderTop: "none",
+    border: "none",
+    borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
     borderRadius: "0px",
     boxShadow: "none",
+    flexDirection: "column",
+    gap: "16px",
   },
 }))
 
@@ -144,13 +165,17 @@ const UpgradeBanner: React.FC<
   )
 }
 
-const CountdownRoot = styled.div({
+const CountdownRoot = styled.div(({ theme }) => ({
   width: "142px",
   marginRight: "32px",
   display: "flex",
   justifyContent: "center",
   alignSelf: "end",
-})
+  [theme.breakpoints.down("md")]: {
+    marginRight: "0px",
+    justifyContent: "flex-start",
+  },
+}))
 const CourseStartCountdown: React.FC<{
   startDate: string
   className?: string
@@ -218,7 +243,17 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   showNotComplete = true,
 }) => {
   const { title, marketingUrl, enrollment, run } = dashboardResource
-  return (
+  const contextMenu = (
+    <SimpleMenu
+      items={getMenuItems()}
+      trigger={
+        <MenuButton size="small" variant="text" aria-label="More options">
+          <RiMore2Line />
+        </MenuButton>
+      }
+    />
+  )
+  const desktopLayout = (
     <CardRoot data-testid="enrollment-card">
       <Stack justifyContent="start" alignItems="stretch" gap="8px" flex={1}>
         <Link size="medium" color="black" href={marketingUrl}>
@@ -251,20 +286,76 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
             href={run.coursewareUrl}
             endDate={run.endDate}
           />
-          <SimpleMenu
-            items={getMenuItems()}
-            trigger={
-              <MenuButton size="small" variant="text" aria-label="More options">
-                <RiMore2Line />
-              </MenuButton>
-            }
-          />
+          {contextMenu}
         </Stack>
         {run.startDate ? (
           <CourseStartCountdown startDate={run.startDate} />
         ) : null}
       </Stack>
     </CardRoot>
+  )
+
+  const mobileLayout = (
+    <CardRoot data-testid="enrollment-card">
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="stretch"
+        flex={1}
+        width="100%"
+      >
+        <Stack direction="column" gap="8px">
+          <Link size="medium" color="black" href={marketingUrl}>
+            {title}
+          </Link>
+          {enrollment?.status === EnrollmentStatus.Completed ? (
+            <SubtitleLink href="#">
+              {<RiAwardLine size="16px" />}
+              View Certificate
+            </SubtitleLink>
+          ) : null}
+          {enrollment?.mode !== EnrollmentMode.Verified ? (
+            <UpgradeBanner
+              data-testid="upgrade-root"
+              canUpgrade={run.canUpgrade}
+              certificateUpgradeDeadline={run.certificateUpgradeDeadline}
+              certificateUpgradePrice={run.certificateUpgradePrice}
+            />
+          ) : null}
+        </Stack>
+        {contextMenu}
+      </Stack>
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        width="100%"
+      >
+        {run.startDate ? (
+          <Stack justifyContent="start">
+            <CourseStartCountdown startDate={run.startDate} />
+          </Stack>
+        ) : null}
+        <Stack direction="row" gap="8px" alignItems="center">
+          {enrollment?.status === EnrollmentStatus.Completed ? (
+            <Completed src={CompleteCheck} alt="Completed" />
+          ) : showNotComplete ? (
+            <NotComplete data-testid="not-complete-icon" />
+          ) : null}
+          <CoursewareButton
+            startDate={run.startDate}
+            href={run.coursewareUrl}
+            endDate={run.endDate}
+          />
+        </Stack>
+      </Stack>
+    </CardRoot>
+  )
+  return (
+    <>
+      <DesktopOnly>{desktopLayout}</DesktopOnly>
+      <MobileOnly>{mobileLayout}</MobileOnly>
+    </>
   )
 }
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -53,11 +53,14 @@ const CardRoot = styled.div(({ theme }) => ({
   },
 }))
 
-const MenuButton = styled(ActionButton)({
-  position: "absolute",
-  top: "0",
-  right: "0",
-})
+const MenuButton = styled(ActionButton)(({ theme }) => ({
+  marginLeft: "-8px",
+  [theme.breakpoints.down("md")]: {
+    position: "absolute",
+    top: "0",
+    right: "0",
+  },
+}))
 
 const getCoursewareText = (endDate?: string | null) => {
   if (!endDate) return "Continue Course"

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -279,7 +279,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
         ) : null}
         {enrollment?.mode !== EnrollmentMode.Verified ? (
           <UpgradeBanner
-            data-testid="upgrade-root-desktop"
+            data-testid="upgrade-root"
             canUpgrade={run.canUpgrade}
             certificateUpgradeDeadline={run.certificateUpgradeDeadline}
             certificateUpgradePrice={run.certificateUpgradePrice}
@@ -291,7 +291,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
           {enrollment?.status === EnrollmentStatus.Completed ? (
             <Completed src={CompleteCheck} alt="Completed" />
           ) : showNotComplete ? (
-            <NotComplete data-testid="not-complete-icon-desktop" />
+            <NotComplete data-testid="not-complete-icon" />
           ) : null}
           <CoursewareButton
             startDate={run.startDate}
@@ -328,7 +328,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
           ) : null}
           {enrollment?.mode !== EnrollmentMode.Verified ? (
             <UpgradeBanner
-              data-testid="upgrade-root-mobile"
+              data-testid="upgrade-root"
               canUpgrade={run.canUpgrade}
               certificateUpgradeDeadline={run.certificateUpgradeDeadline}
               certificateUpgradePrice={run.certificateUpgradePrice}
@@ -352,7 +352,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
           {enrollment?.status === EnrollmentStatus.Completed ? (
             <Completed src={CompleteCheck} alt="Completed" />
           ) : showNotComplete ? (
-            <NotComplete data-testid="not-complete-icon-mobile" />
+            <NotComplete data-testid="not-complete-icon" />
           ) : null}
           <CoursewareButton
             startDate={run.startDate}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -53,6 +53,12 @@ const CardRoot = styled.div(({ theme }) => ({
   },
 }))
 
+const TitleLink = styled(Link)(({ theme }) => ({
+  [theme.breakpoints.down("md")]: {
+    maxWidth: "calc(100% - 16px)",
+  },
+}))
+
 const MenuButton = styled(ActionButton)(({ theme }) => ({
   marginLeft: "-8px",
   [theme.breakpoints.down("md")]: {
@@ -262,9 +268,9 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   const desktopLayout = (
     <CardRoot data-testid="enrollment-card-desktop">
       <Stack justifyContent="start" alignItems="stretch" gap="8px" flex={1}>
-        <Link size="medium" color="black" href={marketingUrl}>
+        <TitleLink size="medium" color="black" href={marketingUrl}>
           {title}
-        </Link>
+        </TitleLink>
         {enrollment?.status === EnrollmentStatus.Completed ? (
           <SubtitleLink href="#">
             {<RiAwardLine size="16px" />}
@@ -311,9 +317,9 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
         width="100%"
       >
         <Stack direction="column" gap="8px">
-          <Link size="medium" color="black" href={marketingUrl}>
+          <TitleLink size="medium" color="black" href={marketingUrl}>
             {title}
-          </Link>
+          </TitleLink>
           {enrollment?.status === EnrollmentStatus.Completed ? (
             <SubtitleLink href="#">
               {<RiAwardLine size="16px" />}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -260,7 +260,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
     />
   )
   const desktopLayout = (
-    <CardRoot data-testid="enrollment-card">
+    <CardRoot data-testid="enrollment-card-desktop">
       <Stack justifyContent="start" alignItems="stretch" gap="8px" flex={1}>
         <Link size="medium" color="black" href={marketingUrl}>
           {title}
@@ -273,7 +273,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
         ) : null}
         {enrollment?.mode !== EnrollmentMode.Verified ? (
           <UpgradeBanner
-            data-testid="upgrade-root"
+            data-testid="upgrade-root-desktop"
             canUpgrade={run.canUpgrade}
             certificateUpgradeDeadline={run.certificateUpgradeDeadline}
             certificateUpgradePrice={run.certificateUpgradePrice}
@@ -285,7 +285,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
           {enrollment?.status === EnrollmentStatus.Completed ? (
             <Completed src={CompleteCheck} alt="Completed" />
           ) : showNotComplete ? (
-            <NotComplete data-testid="not-complete-icon" />
+            <NotComplete data-testid="not-complete-icon-desktop" />
           ) : null}
           <CoursewareButton
             startDate={run.startDate}
@@ -302,7 +302,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   )
 
   const mobileLayout = (
-    <CardRoot data-testid="enrollment-card">
+    <CardRoot data-testid="enrollment-card-mobile">
       <Stack
         direction="row"
         justifyContent="space-between"
@@ -322,7 +322,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
           ) : null}
           {enrollment?.mode !== EnrollmentMode.Verified ? (
             <UpgradeBanner
-              data-testid="upgrade-root"
+              data-testid="upgrade-root-mobile"
               canUpgrade={run.canUpgrade}
               certificateUpgradeDeadline={run.certificateUpgradeDeadline}
               certificateUpgradePrice={run.certificateUpgradePrice}
@@ -346,7 +346,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
           {enrollment?.status === EnrollmentStatus.Completed ? (
             <Completed src={CompleteCheck} alt="Completed" />
           ) : showNotComplete ? (
-            <NotComplete data-testid="not-complete-icon" />
+            <NotComplete data-testid="not-complete-icon-mobile" />
           ) : null}
           <CoursewareButton
             startDate={run.startDate}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
@@ -76,20 +76,18 @@ describe("EnrollmentDisplay", () => {
     screen.getByRole("heading", { name: "My Learning" })
 
     const cards = await screen.findAllByTestId("enrollment-card")
-    expect(cards.length).toBe(7)
-    return
-    const expectedTitled = [
+    expect(cards.length).toBe(14)
+    const expectedTitles = [
       ...mitxonlineCourses.started,
       ...mitxonlineCourses.notStarted,
       ...mitxonlineCourses.ended,
     ].map((e) => e.run.title)
 
-    expect(cards[0]).toHaveTextContent(expectedTitled[0])
-    expect(cards[1]).toHaveTextContent(expectedTitled[1])
-    expect(cards[2]).toHaveTextContent(expectedTitled[2])
-    expect(cards[3]).toHaveTextContent(expectedTitled[3])
-    expect(cards[4]).toHaveTextContent(expectedTitled[4])
-    expect(cards[5]).toHaveTextContent(expectedTitled[5])
-    expect(cards[6]).toHaveTextContent(expectedTitled[6])
+    for (const expectedTitle of expectedTitles) {
+      const matchingCards = cards.filter((card) =>
+        card.textContent?.includes(expectedTitle),
+      )
+      expect(matchingCards.length).toBe(2)
+    }
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
@@ -75,8 +75,10 @@ describe("EnrollmentDisplay", () => {
 
     screen.getByRole("heading", { name: "My Learning" })
 
-    const cards = await screen.findAllByTestId("enrollment-card")
-    expect(cards.length).toBe(14)
+    const desktopCards = await screen.findAllByTestId("enrollment-card-desktop")
+    const mobileCards = await screen.findAllByTestId("enrollment-card-mobile")
+    expect(desktopCards.length).toBe(7)
+    expect(mobileCards.length).toBe(7)
     const expectedTitles = [
       ...mitxonlineCourses.started,
       ...mitxonlineCourses.notStarted,
@@ -84,10 +86,10 @@ describe("EnrollmentDisplay", () => {
     ].map((e) => e.run.title)
 
     for (const expectedTitle of expectedTitles) {
-      const matchingCards = cards.filter((card) =>
+      const cards = [...desktopCards, ...mobileCards].filter((card) =>
         card.textContent?.includes(expectedTitle),
       )
-      expect(matchingCards.length).toBe(2)
+      expect(cards.length).toBe(2)
     }
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -20,6 +20,8 @@ const Wrapper = styled.div(({ theme }) => ({
   boxShadow: "0px 4px 8px 0px rgba(19, 20, 21, 0.08)",
   borderRadius: "8px",
   [theme.breakpoints.down("md")]: {
+    borderColor: theme.custom.colors.lightGray2,
+    backgroundColor: "rgba(243, 244, 248, 0.60);", // TODO: use theme color
     marginTop: "16px",
     padding: "0",
   },

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -1,6 +1,12 @@
 import React from "react"
 import { enrollmentQueries } from "api/mitxonline-hooks/enrollment"
-import { PlainList, Typography, styled } from "ol-components"
+import {
+  PlainList,
+  PlainListProps,
+  Typography,
+  TypographyProps,
+  styled,
+} from "ol-components"
 import { useQuery } from "@tanstack/react-query"
 import { mitxonlineEnrollments } from "./transform"
 import { DashboardCard } from "./DashboardCard"
@@ -13,7 +19,33 @@ const Wrapper = styled.div(({ theme }) => ({
   borderBottom: `1px solid ${theme.custom.colors.red}`,
   boxShadow: "0px 4px 8px 0px rgba(19, 20, 21, 0.08)",
   borderRadius: "8px",
+  [theme.breakpoints.down("md")]: {
+    marginTop: "16px",
+    padding: "0",
+  },
 }))
+
+const Title = styled(Typography)<Pick<TypographyProps, "component">>(
+  ({ theme }) => ({
+    ...theme.typography.h5,
+    marginBottom: "16px",
+    [theme.breakpoints.down("md")]: {
+      padding: "16px",
+      marginBottom: "0",
+    },
+  }),
+)
+
+const EnrollmentList = styled(PlainList)<Pick<PlainListProps, "itemSpacing">>(
+  ({ theme }) => ({
+    [theme.breakpoints.down("md")]: {
+      borderTop: `1px solid ${theme.custom.colors.lightGray2}`,
+      ">li+li": {
+        marginTop: "0",
+      },
+    },
+  }),
+)
 
 const alphabeticalSort = (a: DashboardCourse, b: DashboardCourse) =>
   a.title.localeCompare(b.title)
@@ -73,16 +105,16 @@ const EnrollmentDisplay = () => {
 
   return (
     <Wrapper>
-      <Typography variant="h5" component="h2" sx={{ marginBottom: "16px" }}>
+      <Title variant="h5" component="h2">
         My Learning
-      </Typography>
-      <PlainList itemSpacing={"16px"}>
+      </Title>
+      <EnrollmentList itemSpacing={"16px"}>
         {sorted?.map((course) => (
           <li key={course.id}>
             <DashboardCard dashboardResource={course} showNotComplete={false} />
           </li>
         ))}
-      </PlainList>
+      </EnrollmentList>
     </Wrapper>
   )
 }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -20,7 +20,7 @@ const Wrapper = styled.div(({ theme }) => ({
   boxShadow: "0px 4px 8px 0px rgba(19, 20, 21, 0.08)",
   borderRadius: "8px",
   [theme.breakpoints.down("md")]: {
-    borderColor: theme.custom.colors.lightGray2,
+    border: `1px solid ${theme.custom.colors.lightGray2}`,
     backgroundColor: "rgba(243, 244, 248, 0.60);", // TODO: use theme color
     marginTop: "16px",
     padding: "0",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7042

### Description (What does it do?)
This PR implements mobile designs on the enrollments display in the dashboard home page.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/8dd4d007-b347-4476-bef7-880e6fda3f89)
![image](https://github.com/user-attachments/assets/0594e68b-ffba-4daf-91fd-c94c006d4277)
![image](https://github.com/user-attachments/assets/df19f9e1-7c7c-4f09-a0c0-2e7774b928f8)

### How can this be tested?
- Ensure you have Posthog connected to your local instance of `mit-learn`
- In  your connected Posthog project, make sure you have added and enabled the `enrollment-dashboard` feature flag
- Visit http://open.odl.local:8062/dashboard and log in (if you are not already logged in)
- Ensure nothing has changed with the desktop view of the enrollments display
- View the site using your browser's mobile simulator and ensure that it looks and behaves properly
