### PR TITLE
enrollments dashboard expand collapse

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
@@ -1,5 +1,10 @@
 import React from "react"
-import { renderWithProviders, screen, setMockResponse } from "@/test-utils"
+import {
+  renderWithProviders,
+  screen,
+  setMockResponse,
+  user,
+} from "@/test-utils"
 import { EnrollmentDisplay } from "./EnrollmentDisplay"
 import * as mitxonline from "api/mitxonline-test-utils"
 import moment from "moment"
@@ -73,6 +78,25 @@ describe("EnrollmentDisplay", () => {
   test("Renders the expected cards", async () => {
     const { mitxonlineCourses } = setupApis()
     renderWithProviders(<EnrollmentDisplay />)
+
+    screen.getByRole("heading", { name: "My Learning" })
+
+    const cards = await screen.findAllByTestId("enrollment-card-desktop")
+    const expectedTitles = [
+      ...mitxonlineCourses.started,
+      ...mitxonlineCourses.notStarted,
+    ].map((e) => e.run.title)
+
+    expectedTitles.forEach((title, i) => {
+      expect(cards[i]).toHaveTextContent(title)
+    })
+  })
+
+  test("Clicking show all reveals ended courses", async () => {
+    const { mitxonlineCourses } = setupApis()
+    renderWithProviders(<EnrollmentDisplay />)
+
+    await user.click(screen.getByText("Show all"))
 
     screen.getByRole("heading", { name: "My Learning" })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
@@ -14,7 +14,13 @@ const courseEnrollment = mitxonline.factories.enrollment.courseEnrollment
 const grade = mitxonline.factories.enrollment.grade
 describe("EnrollmentDisplay", () => {
   const setupApis = () => {
-    const ended = [
+    const completed = [
+      courseEnrollment({
+        run: { title: "C Course Ended" },
+        grades: [grade({ passed: true })],
+      }),
+    ]
+    const expired = [
       courseEnrollment({
         run: {
           title: "A Course Ended",
@@ -26,10 +32,6 @@ describe("EnrollmentDisplay", () => {
           title: "B Course Ended",
           end_date: faker.date.past().toISOString(),
         },
-      }),
-      courseEnrollment({
-        run: { title: "C Course Ended" },
-        grades: [grade({ passed: true })],
       }),
     ]
     const started = [
@@ -59,7 +61,8 @@ describe("EnrollmentDisplay", () => {
       }),
     ]
     const mitxonlineCourseEnrollments = faker.helpers.shuffle([
-      ...ended,
+      ...expired,
+      ...completed,
       ...started,
       ...notStarted,
     ])
@@ -71,7 +74,7 @@ describe("EnrollmentDisplay", () => {
 
     return {
       mitxonlineCourseEnrollments,
-      mitxonlineCourses: { started, ended, notStarted },
+      mitxonlineCourses: { completed, expired, started, notStarted },
     }
   }
 
@@ -85,6 +88,7 @@ describe("EnrollmentDisplay", () => {
     const expectedTitles = [
       ...mitxonlineCourses.started,
       ...mitxonlineCourses.notStarted,
+      ...mitxonlineCourses.completed,
     ].map((e) => e.run.title)
 
     expectedTitles.forEach((title, i) => {
@@ -104,7 +108,8 @@ describe("EnrollmentDisplay", () => {
     const expectedTitles = [
       ...mitxonlineCourses.started,
       ...mitxonlineCourses.notStarted,
-      ...mitxonlineCourses.ended,
+      ...mitxonlineCourses.completed,
+      ...mitxonlineCourses.expired,
     ].map((e) => e.run.title)
 
     expectedTitles.forEach((title, i) => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -59,6 +59,7 @@ const EnrollmentsList = styled(PlainList)<Pick<PlainListProps, "itemSpacing">>(
 const HiddenEnrollmentsList = styled(EnrollmentsList)({
   marginTop: "16px",
   [theme.breakpoints.down("md")]: {
+    borderTop: "none",
     marginTop: "0",
   },
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -116,13 +116,16 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
       <EnrollmentList itemSpacing={"16px"}>
         {shownEnrollments?.map((course) => (
           <li key={course.id}>
-            <DashboardCard dashboardResource={course} showNotComplete={false} />
+            <DashboardCardStyled
+              dashboardResource={course}
+              showNotComplete={false}
+            />
           </li>
         ))}
         {shown
           ? hiddenEnrollments?.map((course) => (
               <li key={course.id}>
-                <DashboardCard
+                <DashboardCardStyled
                   dashboardResource={course}
                   showNotComplete={false}
                 />

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -111,9 +111,16 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
   hiddenEnrollments,
 }) => {
   const [shown, setShown] = React.useState(false)
+
+  const handleToggle = (event: React.MouseEvent) => {
+    event.preventDefault()
+    setShown(!shown)
+  }
+
   const enrollments = shown
     ? shownEnrollments.concat(hiddenEnrollments)
     : shownEnrollments
+
   return (
     <>
       <EnrollmentList itemSpacing={"16px"}>
@@ -127,7 +134,7 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
         ))}
       </EnrollmentList>
       <ShowAllContainer>
-        <Link color="red" size="medium" onClick={() => setShown(!shown)}>
+        <Link color="red" size="medium" onClick={handleToggle}>
           {shown ? "Show less" : "Show all"}
         </Link>
       </ShowAllContainer>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -115,21 +115,21 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
     <>
       <EnrollmentList itemSpacing={"16px"}>
         {shownEnrollments?.map((course) => (
-          <li key={course.id}>
-            <DashboardCardStyled
-              dashboardResource={course}
-              showNotComplete={false}
-            />
-          </li>
+          <DashboardCardStyled
+            key={course.id}
+            Component="li"
+            dashboardResource={course}
+            showNotComplete={false}
+          />
         ))}
         {shown
           ? hiddenEnrollments?.map((course) => (
-              <li key={course.id}>
-                <DashboardCardStyled
-                  dashboardResource={course}
-                  showNotComplete={false}
-                />
-              </li>
+              <DashboardCardStyled
+                key={course.id}
+                Component="li"
+                dashboardResource={course}
+                showNotComplete={false}
+              />
             ))
           : null}
       </EnrollmentList>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { enrollmentQueries } from "api/mitxonline-hooks/enrollment"
 import {
+  Link,
   PlainList,
   PlainListProps,
   Typography,
@@ -53,6 +54,15 @@ const EnrollmentList = styled(PlainList)<Pick<PlainListProps, "itemSpacing">>(
   }),
 )
 
+const ShowAllContainer = styled.div(({ theme }) => ({
+  display: "flex",
+  justifyContent: "center",
+  marginTop: "24px",
+  [theme.breakpoints.down("md")]: {
+    marginBottom: "24px",
+  },
+}))
+
 const alphabeticalSort = (a: DashboardCourse, b: DashboardCourse) =>
   a.title.localeCompare(b.title)
 
@@ -91,6 +101,44 @@ const sortEnrollments = (resources: DashboardCourse[]) => {
   }
 }
 
+interface EnrollmentExpandCollapseProps {
+  shownEnrollments: DashboardCourse[]
+  hiddenEnrollments: DashboardCourse[]
+}
+
+const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
+  shownEnrollments,
+  hiddenEnrollments,
+}) => {
+  const [shown, setShown] = React.useState(false)
+  return (
+    <>
+      <EnrollmentList itemSpacing={"16px"}>
+        {shownEnrollments?.map((course) => (
+          <li key={course.id}>
+            <DashboardCard dashboardResource={course} showNotComplete={false} />
+          </li>
+        ))}
+        {shown
+          ? hiddenEnrollments?.map((course) => (
+              <li key={course.id}>
+                <DashboardCard
+                  dashboardResource={course}
+                  showNotComplete={false}
+                />
+              </li>
+            ))
+          : null}
+      </EnrollmentList>
+      <ShowAllContainer>
+        <Link color="red" size="medium" onClick={() => setShown(!shown)}>
+          {shown ? "Show less" : "Show all"}
+        </Link>
+      </ShowAllContainer>
+    </>
+  )
+}
+
 const EnrollmentDisplay = () => {
   const { data: enrolledCourses } = useQuery({
     ...enrollmentQueries.coursesList(),
@@ -107,23 +155,17 @@ const EnrollmentDisplay = () => {
    * The above TODO could be handled then.
    */
   const { ended, started, notStarted } = sortEnrollments(enrolledCourses || [])
-  const sorted = [...started, ...notStarted, ...ended]
+  const shownEnrollments = [...started, ...notStarted]
 
   return (
     <Wrapper>
       <Title variant="h5" component="h2">
         My Learning
       </Title>
-      <EnrollmentList itemSpacing={"16px"}>
-        {sorted?.map((course) => (
-          <DashboardCardStyled
-            key={course.id}
-            Component="li"
-            showNotComplete={false}
-            dashboardResource={course}
-          />
-        ))}
-      </EnrollmentList>
+      <EnrollmentExpandCollapse
+        shownEnrollments={shownEnrollments}
+        hiddenEnrollments={ended}
+      />
     </Wrapper>
   )
 }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -111,10 +111,13 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
   hiddenEnrollments,
 }) => {
   const [shown, setShown] = React.useState(false)
+  const enrollments = shown
+    ? shownEnrollments
+    : shownEnrollments.concat(hiddenEnrollments)
   return (
     <>
       <EnrollmentList itemSpacing={"16px"}>
-        {shownEnrollments?.map((course) => (
+        {enrollments.map((course) => (
           <DashboardCardStyled
             key={course.id}
             Component="li"
@@ -122,16 +125,6 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
             showNotComplete={false}
           />
         ))}
-        {shown
-          ? hiddenEnrollments?.map((course) => (
-              <DashboardCardStyled
-                key={course.id}
-                Component="li"
-                dashboardResource={course}
-                showNotComplete={false}
-              />
-            ))
-          : null}
       </EnrollmentList>
       <ShowAllContainer>
         <Link color="red" size="medium" onClick={() => setShown(!shown)}>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -112,8 +112,8 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
 }) => {
   const [shown, setShown] = React.useState(false)
   const enrollments = shown
-    ? shownEnrollments
-    : shownEnrollments.concat(hiddenEnrollments)
+    ? shownEnrollments.concat(hiddenEnrollments)
+    : shownEnrollments
   return (
     <>
       <EnrollmentList itemSpacing={"16px"}>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { enrollmentQueries } from "api/mitxonline-hooks/enrollment"
 import {
+  Collapse,
   Link,
   PlainList,
   PlainListProps,
@@ -117,14 +118,10 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
     setShown(!shown)
   }
 
-  const enrollments = shown
-    ? shownEnrollments.concat(hiddenEnrollments)
-    : shownEnrollments
-
   return (
     <>
       <EnrollmentList itemSpacing={"16px"}>
-        {enrollments.map((course) => (
+        {shownEnrollments.map((course) => (
           <DashboardCardStyled
             key={course.id}
             Component="li"
@@ -132,6 +129,20 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
             showNotComplete={false}
           />
         ))}
+        <li>
+          <Collapse orientation="vertical" in={shown}>
+            <EnrollmentList itemSpacing={"16px"}>
+              {hiddenEnrollments.map((course) => (
+                <DashboardCardStyled
+                  key={course.id}
+                  Component="li"
+                  dashboardResource={course}
+                  showNotComplete={false}
+                />
+              ))}
+            </EnrollmentList>
+          </Collapse>
+        </li>
       </EnrollmentList>
       <ShowAllContainer>
         <Link color="red" size="medium" onClick={handleToggle}>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -84,15 +84,18 @@ const startsSooner = (a: DashboardCourse, b: DashboardCourse) => {
   return x.getTime() - y.getTime()
 }
 const sortEnrollments = (resources: DashboardCourse[]) => {
-  const ended: DashboardCourse[] = []
+  const expired: DashboardCourse[] = []
+  const completed: DashboardCourse[] = []
   const started: DashboardCourse[] = []
   const notStarted: DashboardCourse[] = []
   resources.forEach((resource) => {
-    if (
-      resource.enrollment?.status === EnrollmentStatus.Completed ||
-      (resource.run.endDate && new Date(resource.run.endDate) < new Date())
+    if (resource.enrollment?.status === EnrollmentStatus.Completed) {
+      completed.push(resource)
+    } else if (
+      resource.run.endDate &&
+      new Date(resource.run.endDate) < new Date()
     ) {
-      ended.push(resource)
+      expired.push(resource)
     } else if (
       resource.run.startDate &&
       new Date(resource.run.startDate) < new Date()
@@ -104,7 +107,8 @@ const sortEnrollments = (resources: DashboardCourse[]) => {
   })
 
   return {
-    ended: ended.sort(alphabeticalSort),
+    completed: completed.sort(alphabeticalSort),
+    expired: expired.sort(alphabeticalSort),
     started: started.sort(alphabeticalSort),
     notStarted: notStarted.sort(startsSooner),
   }
@@ -174,8 +178,10 @@ const EnrollmentDisplay = () => {
    * The constants below are separate for impending "Show All" functionality.
    * The above TODO could be handled then.
    */
-  const { ended, started, notStarted } = sortEnrollments(enrolledCourses || [])
-  const shownEnrollments = [...started, ...notStarted]
+  const { completed, expired, started, notStarted } = sortEnrollments(
+    enrolledCourses || [],
+  )
+  const shownEnrollments = [...started, ...notStarted, ...completed]
 
   return (
     <Wrapper>
@@ -184,7 +190,7 @@ const EnrollmentDisplay = () => {
       </Title>
       <EnrollmentExpandCollapse
         shownEnrollments={shownEnrollments}
-        hiddenEnrollments={ended}
+        hiddenEnrollments={expired}
       />
     </Wrapper>
   )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
   TypographyProps,
   styled,
+  theme,
 } from "ol-components"
 import { useQuery } from "@tanstack/react-query"
 import { mitxonlineEnrollments } from "./transform"
@@ -44,7 +45,7 @@ const Title = styled(Typography)<Pick<TypographyProps, "component">>(
   }),
 )
 
-const EnrollmentList = styled(PlainList)<Pick<PlainListProps, "itemSpacing">>(
+const EnrollmentsList = styled(PlainList)<Pick<PlainListProps, "itemSpacing">>(
   ({ theme }) => ({
     [theme.breakpoints.down("md")]: {
       borderTop: `1px solid ${theme.custom.colors.lightGray2}`,
@@ -54,6 +55,13 @@ const EnrollmentList = styled(PlainList)<Pick<PlainListProps, "itemSpacing">>(
     },
   }),
 )
+
+const HiddenEnrollmentsList = styled(EnrollmentsList)({
+  marginTop: "16px",
+  [theme.breakpoints.down("md")]: {
+    marginTop: "0",
+  },
+})
 
 const ShowAllContainer = styled.div(({ theme }) => ({
   display: "flex",
@@ -120,7 +128,7 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
 
   return (
     <>
-      <EnrollmentList itemSpacing={"16px"}>
+      <EnrollmentsList itemSpacing={"16px"}>
         {shownEnrollments.map((course) => (
           <DashboardCardStyled
             key={course.id}
@@ -129,21 +137,19 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
             showNotComplete={false}
           />
         ))}
-        <li>
-          <Collapse orientation="vertical" in={shown}>
-            <EnrollmentList itemSpacing={"16px"}>
-              {hiddenEnrollments.map((course) => (
-                <DashboardCardStyled
-                  key={course.id}
-                  Component="li"
-                  dashboardResource={course}
-                  showNotComplete={false}
-                />
-              ))}
-            </EnrollmentList>
-          </Collapse>
-        </li>
-      </EnrollmentList>
+      </EnrollmentsList>
+      <Collapse orientation="vertical" in={shown}>
+        <HiddenEnrollmentsList itemSpacing={"16px"}>
+          {hiddenEnrollments.map((course) => (
+            <DashboardCardStyled
+              key={course.id}
+              Component="li"
+              dashboardResource={course}
+              showNotComplete={false}
+            />
+          ))}
+        </HiddenEnrollmentsList>
+      </Collapse>
       <ShowAllContainer>
         <Link color="red" size="medium" onClick={handleToggle}>
           {shown ? "Show less" : "Show all"}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7042

### Description (What does it do?)
This PR adds expand / collapse functionality to the My Learning dashboard. By default, only started or not started enrollments are shown. Ended enrollments are revealed by clicking the "Show all" link button.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/658aa7cb-4c57-40d4-b149-cee3b1e1ec9c)
![image](https://github.com/user-attachments/assets/73f85766-3a20-464d-ad96-cb38eb83f641)
![image](https://github.com/user-attachments/assets/9c4c6937-48a4-4207-9be7-ed84b8f284c1)
![image](https://github.com/user-attachments/assets/7b10cda2-60b5-4259-93cf-9400128bacbe)

### How can this be tested?
- Ensure you have Posthog connected to your local instance of `mit-learn`
- In  your connected Posthog project, make sure you have added and enabled the `enrollment-dashboard` feature flag
- Visit http://open.odl.local:8062/dashboard and log in (if you are not already logged in)
- Click "Show all" and verify that the ended enrollments are revealed
- Click "Show less" and verify that the ended enrollments are hidden again
