### PR TITLE
add email settings and unenroll dialogs as default context menu items in dashboard cards

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
-import { renderWithProviders, screen, within } from "@/test-utils"
-import { DashboardCard } from "./DashboardCard"
+import { renderWithProviders, screen, user, within } from "@/test-utils"
+import { DashboardCard, getDefaultContextMenuItems } from "./DashboardCard"
 import { dashboardCourse } from "./test-utils"
 import { faker } from "@faker-js/faker/locale/en"
 import moment from "moment"
@@ -326,6 +326,49 @@ describe.each([
         expect(img).toHaveAttribute("alt", "")
       } else {
         expect(img).toBe(null)
+      }
+    },
+  )
+
+  test.each([
+    { contextMenuItems: [] },
+    {
+      contextMenuItems: [
+        {
+          key: "test-key",
+          label: "Test",
+          onClick: () => {},
+        },
+      ],
+    },
+  ])(
+    "getDefaultContextMenuItems returns correct items",
+    async ({ contextMenuItems }) => {
+      const course = dashboardCourse()
+      renderWithProviders(
+        <DashboardCard
+          dashboardResource={course}
+          contextMenuItems={contextMenuItems}
+        />,
+      )
+      const card = getCard()
+      const contextMenuButton = within(card).getByRole("button", {
+        name: "More options",
+      })
+      await user.click(contextMenuButton)
+      const expectedMenuItems = [
+        ...contextMenuItems,
+        ...getDefaultContextMenuItems("Test Course"),
+      ]
+      const menuItems = screen.getAllByRole("menuitem")
+      for (let i = 0; i < expectedMenuItems.length; i++) {
+        const menuItem = expectedMenuItems[i]
+        const menuItemElement = menuItems.find((item) => {
+          if (item.textContent === menuItem.label) {
+            return item
+          }
+        })
+        expect(menuItemElement?.textContent).toBe(menuItem.label)
       }
     },
   )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -66,6 +66,7 @@ const MenuButton = styled(ActionButton)(({ theme }) => ({
 const getDefaultContextMenuItems = (title: string) => {
   return [
     {
+      className: "dashboard-card-menu-item",
       key: "email-settings",
       label: "Email Settings",
       onClick: () => {
@@ -73,6 +74,7 @@ const getDefaultContextMenuItems = (title: string) => {
       },
     },
     {
+      className: "dashboard-card-menu-item",
       key: "unenroll",
       label: "Unenroll",
       onClick: () => {
@@ -256,9 +258,10 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   contextMenuItems = [],
 }) => {
   const { title, marketingUrl, enrollment, run } = dashboardResource
+  const menuItems = contextMenuItems.concat(getDefaultContextMenuItems(title))
   const contextMenu = (
     <SimpleMenu
-      items={contextMenuItems.concat(getDefaultContextMenuItems(title))}
+      items={menuItems}
       trigger={
         <MenuButton size="small" variant="text" aria-label="More options">
           <RiMore2Line />

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -20,6 +20,8 @@ import {
 import { calendarDaysUntil, isInPast, NoSSR } from "ol-utilities"
 
 import { EnrollmentStatusIndicator } from "./EnrollmentStatusIndicator"
+import { EmailSettingsDialog, UnenrollDialog } from "./DashboardDialogs"
+import NiceModal from "@ebay/nice-modal-react"
 
 const CardRoot = styled.div<{
   screenSize: "desktop" | "mobile"
@@ -68,14 +70,14 @@ const MenuButton = styled(ActionButton)(({ theme }) => ({
   },
 }))
 
-const getStandardContextMenuItems = () => {
+const getStandardContextMenuItems = (courseId: string, title: string) => {
   return [
     {
       key: "email-settings",
       label: "Email Settings",
       className: "dashboard-card-email-settings-menu-item",
       onClick: () => {
-        alert("Email Settings") // TODO: Implement email settings modal
+        NiceModal.show(EmailSettingsDialog, { title })
       },
     },
     {
@@ -83,7 +85,7 @@ const getStandardContextMenuItems = () => {
       label: "Unenroll",
       className: "dashboard-card-unenroll-menu-item",
       onClick: () => {
-        alert("Unenroll") // TODO: Implement unenroll functionality
+        NiceModal.show(UnenrollDialog, { title })
       },
     },
   ]
@@ -265,7 +267,9 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   const { title, marketingUrl, enrollment, run } = dashboardResource
   const contextMenu = (
     <SimpleMenu
-      items={contextMenuItems.concat(getStandardContextMenuItems())}
+      items={contextMenuItems.concat(
+        getStandardContextMenuItems(dashboardResource.id, title),
+      )}
       menuOverrideProps={{
         sx: {
           "li:hover": {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -1,5 +1,12 @@
 import React from "react"
-import { styled, Link, SimpleMenu, SimpleMenuItem, Stack } from "ol-components"
+import {
+  styled,
+  Link,
+  SimpleMenu,
+  SimpleMenuItem,
+  Stack,
+  theme,
+} from "ol-components"
 import NextLink from "next/link"
 import { EnrollmentStatus, EnrollmentMode } from "./types"
 import type { DashboardCourse } from "./types"
@@ -66,6 +73,7 @@ const getStandardContextMenuItems = () => {
     {
       key: "email-settings",
       label: "Email Settings",
+      className: "dashboard-card-email-settings-menu-item",
       onClick: () => {
         alert("Email Settings") // TODO: Implement email settings modal
       },
@@ -73,6 +81,7 @@ const getStandardContextMenuItems = () => {
     {
       key: "unenroll",
       label: "Unenroll",
+      className: "dashboard-card-unenroll-menu-item",
       onClick: () => {
         alert("Unenroll") // TODO: Implement unenroll functionality
       },
@@ -257,6 +266,27 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   const contextMenu = (
     <SimpleMenu
       items={contextMenuItems.concat(getStandardContextMenuItems())}
+      menuOverrideProps={{
+        sx: {
+          "li:hover": {
+            backgroundColor: theme.custom.colors.white,
+          },
+          ".dashboard-card-email-settings-menu-item": {
+            color: theme.custom.colors.silverGrayDark,
+            "&:hover": {
+              color: theme.custom.colors.lightRed,
+              textDecoration: "underline",
+            },
+          },
+          ".dashboard-card-unenroll-menu-item": {
+            color: theme.custom.colors.red,
+            "&:hover": {
+              color: theme.custom.colors.lightRed,
+              textDecoration: "underline",
+            },
+          },
+        },
+      }}
       trigger={
         <MenuButton size="small" variant="text" aria-label="More options">
           <RiMore2Line />

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -63,7 +63,7 @@ const MenuButton = styled(ActionButton)(({ theme }) => ({
   },
 }))
 
-const getStandardContextMenuItems = (courseId: string, title: string) => {
+const getDefaultContextMenuItems = (title: string) => {
   return [
     {
       key: "email-settings",
@@ -258,9 +258,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   const { title, marketingUrl, enrollment, run } = dashboardResource
   const contextMenu = (
     <SimpleMenu
-      items={contextMenuItems.concat(
-        getStandardContextMenuItems(dashboardResource.id, title),
-      )}
+      items={contextMenuItems.concat(getDefaultContextMenuItems(title))}
       trigger={
         <MenuButton size="small" variant="text" aria-label="More options">
           <RiMore2Line />
@@ -386,4 +384,4 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   )
 }
 
-export { DashboardCard, getStandardContextMenuItems }
+export { DashboardCard, getDefaultContextMenuItems }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -61,6 +61,25 @@ const MenuButton = styled(ActionButton)(({ theme }) => ({
   },
 }))
 
+const getStandardContextMenuItems = () => {
+  return [
+    {
+      key: "email-settings",
+      label: "Email Settings",
+      onClick: () => {
+        alert("Email Settings") // TODO: Implement email settings modal
+      },
+    },
+    {
+      key: "unenroll",
+      label: "Unenroll",
+      onClick: () => {
+        alert("Unenroll") // TODO: Implement unenroll functionality
+      },
+    },
+  ]
+}
+
 type CoursewareButtonProps = {
   startDate?: string | null
   endDate?: string | null
@@ -216,24 +235,6 @@ const CourseStartCountdown: React.FC<{
   )
 }
 
-const getMenuItems = (): SimpleMenuItem[] => [
-  {
-    key: "placeholder1",
-    label: "Placeholder 1",
-    onClick: () => {},
-  },
-  {
-    key: "placeholder2",
-    label: "Placeholder 2",
-    onClick: () => {},
-  },
-  {
-    key: "placeholder3",
-    label: "Placeholder 3",
-    onClick: () => {},
-  },
-]
-
 type DashboardCardProps = {
   Component?: React.ElementType
   dashboardResource: DashboardCourse
@@ -241,6 +242,7 @@ type DashboardCardProps = {
   className?: string
   courseNoun?: string
   offerUpgrade?: boolean
+  contextMenuItems?: SimpleMenuItem[]
 }
 const DashboardCard: React.FC<DashboardCardProps> = ({
   dashboardResource,
@@ -249,11 +251,12 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   className,
   courseNoun = "Course",
   offerUpgrade = true,
+  contextMenuItems = [],
 }) => {
   const { title, marketingUrl, enrollment, run } = dashboardResource
   const contextMenu = (
     <SimpleMenu
-      items={getMenuItems()}
+      items={contextMenuItems.concat(getStandardContextMenuItems())}
       trigger={
         <MenuButton size="small" variant="text" aria-label="More options">
           <RiMore2Line />
@@ -379,4 +382,4 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   )
 }
 
-export { DashboardCard }
+export { DashboardCard, getStandardContextMenuItems }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -1,12 +1,5 @@
 import React from "react"
-import {
-  styled,
-  Link,
-  SimpleMenu,
-  SimpleMenuItem,
-  Stack,
-  theme,
-} from "ol-components"
+import { styled, Link, SimpleMenu, SimpleMenuItem, Stack } from "ol-components"
 import NextLink from "next/link"
 import { EnrollmentStatus, EnrollmentMode } from "./types"
 import type { DashboardCourse } from "./types"
@@ -75,7 +68,6 @@ const getStandardContextMenuItems = (courseId: string, title: string) => {
     {
       key: "email-settings",
       label: "Email Settings",
-      className: "dashboard-card-email-settings-menu-item",
       onClick: () => {
         NiceModal.show(EmailSettingsDialog, { title })
       },
@@ -83,7 +75,6 @@ const getStandardContextMenuItems = (courseId: string, title: string) => {
     {
       key: "unenroll",
       label: "Unenroll",
-      className: "dashboard-card-unenroll-menu-item",
       onClick: () => {
         NiceModal.show(UnenrollDialog, { title })
       },
@@ -270,27 +261,6 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
       items={contextMenuItems.concat(
         getStandardContextMenuItems(dashboardResource.id, title),
       )}
-      menuOverrideProps={{
-        sx: {
-          "li:hover": {
-            backgroundColor: theme.custom.colors.white,
-          },
-          ".dashboard-card-email-settings-menu-item": {
-            color: theme.custom.colors.silverGrayDark,
-            "&:hover, &.Mui-selected": {
-              color: theme.custom.colors.lightRed,
-              textDecoration: "underline",
-            },
-          },
-          ".dashboard-card-unenroll-menu-item": {
-            color: theme.custom.colors.red,
-            "&:hover, &.Mui-selected": {
-              color: theme.custom.colors.lightRed,
-              textDecoration: "underline",
-            },
-          },
-        },
-      }}
       trigger={
         <MenuButton size="small" variant="text" aria-label="More options">
           <RiMore2Line />

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -277,14 +277,14 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
           },
           ".dashboard-card-email-settings-menu-item": {
             color: theme.custom.colors.silverGrayDark,
-            "&:hover": {
+            "&:hover, &.Mui-selected": {
               color: theme.custom.colors.lightRed,
               textDecoration: "underline",
             },
           },
           ".dashboard-card-unenroll-menu-item": {
             color: theme.custom.colors.red,
-            "&:hover": {
+            "&:hover, &.Mui-selected": {
               color: theme.custom.colors.lightRed,
               textDecoration: "underline",
             },

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
@@ -1,0 +1,126 @@
+import React from "react"
+import {
+  Typography,
+  styled,
+  FormDialog,
+  DialogActions,
+  Stack,
+  Alert,
+  Checkbox,
+} from "ol-components"
+import { Button } from "@mitodl/smoot-design"
+
+import NiceModal, { muiDialogV5 } from "@ebay/nice-modal-react"
+import { useFormik } from "formik"
+
+const BoldText = styled.span(({ theme }) => ({
+  ...theme.typography.subtitle1,
+}))
+
+type DashboardDialogProps = {
+  title: string
+}
+const EmailSettingsDialogInner: React.FC<DashboardDialogProps> = ({
+  title,
+}) => {
+  const modal = NiceModal.useModal()
+  const formik = useFormik({
+    enableReinitialize: true,
+    validateOnChange: false,
+    validateOnBlur: false,
+    initialValues: {
+      recieve_emails: true,
+    },
+    onSubmit: async () => {
+      // TODO: Handle form submission
+    },
+  })
+  return (
+    <FormDialog
+      title={"Email Settings"}
+      fullWidth
+      onReset={formik.resetForm}
+      onSubmit={formik.handleSubmit}
+      {...muiDialogV5(modal)}
+      actions={
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={() => {
+              modal.hide()
+            }}
+          >
+            Cancel
+          </Button>
+          <Button variant="primary" type="submit" disabled={!formik.dirty}>
+            Save Settings
+          </Button>
+        </DialogActions>
+      }
+    >
+      <Stack direction="column" gap="24px">
+        <Typography variant="body1">
+          Update your email preferences for <BoldText>{title}.</BoldText>
+        </Typography>
+        <Alert severity="warning">
+          <Typography variant="body2" color="textPrimary">
+            Unchecking the box will prevent you from receiving important course
+            updates and emails.
+          </Typography>
+        </Alert>
+        <Checkbox
+          name="recieve_emails"
+          label="Receive course emails"
+          checked={formik.values.recieve_emails}
+          onChange={formik.handleChange}
+        />
+      </Stack>
+    </FormDialog>
+  )
+}
+
+const UnenrollDialogInner: React.FC<DashboardDialogProps> = ({ title }) => {
+  const modal = NiceModal.useModal()
+  const formik = useFormik({
+    enableReinitialize: true,
+    validateOnChange: false,
+    validateOnBlur: false,
+    initialValues: {},
+    onSubmit: async () => {
+      // TODO: Handle form submission
+    },
+  })
+  return (
+    <FormDialog
+      title={`Unenroll from ${title}`}
+      fullWidth
+      onReset={formik.resetForm}
+      onSubmit={formik.handleSubmit}
+      {...muiDialogV5(modal)}
+      actions={
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={() => {
+              modal.hide()
+            }}
+          >
+            Cancel
+          </Button>
+          <Button variant="primary" type="submit">
+            Unenroll
+          </Button>
+        </DialogActions>
+      }
+    >
+      <Typography variant="body1">
+        Are you sure you want to unenroll from {title}?
+      </Typography>
+    </FormDialog>
+  )
+}
+
+const EmailSettingsDialog = NiceModal.create(EmailSettingsDialogInner)
+const UnenrollDialog = NiceModal.create(UnenrollDialogInner)
+
+export { EmailSettingsDialog, UnenrollDialog }

--- a/frontends/ol-components/src/components/SimpleMenu/SimpleMenu.tsx
+++ b/frontends/ol-components/src/components/SimpleMenu/SimpleMenu.tsx
@@ -8,6 +8,7 @@ interface SimpleMenuItemBase {
   key: string
   label: React.ReactNode
   icon?: React.ReactNode
+  className?: string
   LinkComponent?: React.ElementType
 }
 
@@ -108,7 +109,12 @@ const SimpleMenu: React.FC<SimpleMenuProps> = ({
             setOpen(false)
           }
           return (
-            <MenuItem {...linkProps} key={item.key} onClick={onClick}>
+            <MenuItem
+              {...linkProps}
+              className={item.className}
+              key={item.key}
+              onClick={onClick}
+            >
               {item.icon ? <ListItemIcon>{item.icon}</ListItemIcon> : null}
               {item.label}
             </MenuItem>


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7127

### Description (What does it do?)
This PR adds a function to `DashboardCard` called `getDefaultContextMenuItems`. It returns an array of objects representing `MenuItem` objects, with Email Settings and Unenroll being the default options. An optional property was also added to `DashboardCard` that supports passing in a `contextMenuItems` property. These are concatenated with the default options before being set on the `SimpleMenu`.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/250663d4-d5f2-4344-9106-10c0b666d3d3)
![image](https://github.com/user-attachments/assets/3bce66a5-1d4b-452c-a1b9-5b020d373ffc)
![image](https://github.com/user-attachments/assets/4e29e490-3289-45fd-94d3-81c8b65078dc)
![image](https://github.com/user-attachments/assets/eb106154-634e-46b7-bef6-abc77f405c6b)
![image](https://github.com/user-attachments/assets/5627405a-1abd-4712-b4c5-17e579a64214)
![image](https://github.com/user-attachments/assets/9249bbe7-7982-474e-8514-6ed80bd10949)

### How can this be tested?
- Spin up this branch of `mit-learn`
- Visit http://od.odl.local:8062/dashboard
- Log in with any user
- On one of the dashboard cards, click the 3 dots context menu
- Ensure that you see the Email Settings and Unenroll items in the menu
- Click both of them an ensure that the proper dialog is displayed as indicated in the screenshots above and the issue

### Additional Context
There are some minor differences in the UI currently that will be addressed with follow-up PR's, per the comments on the issue linked above:

- `MenuItems` do not have a hover state matching the newly added component in Figma
- The `Alert` component has some differences that need to be addressed
- Potenentially some other small style differences in components that need to be updated globally, not just in `DashboardCard`