### PR TITLE
Drawer/chat accessibility fixes

### DIFF
--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -14,7 +14,7 @@
     "@emotion/cache": "^11.13.1",
     "@emotion/styled": "^11.11.0",
     "@mitodl/course-search-utils": "3.3.2",
-    "@mitodl/smoot-design": "^6.1.0",
+    "@mitodl/smoot-design": "^6.2.1",
     "@next/bundle-analyzer": "^14.2.15",
     "@remixicon/react": "^4.2.0",
     "@sentry/nextjs": "^9.0.0",

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -14,7 +14,7 @@
     "@emotion/cache": "^11.13.1",
     "@emotion/styled": "^11.11.0",
     "@mitodl/course-search-utils": "3.3.2",
-    "@mitodl/smoot-design": "^6.2.1",
+    "@mitodl/smoot-design": "^6.2.2",
     "@next/bundle-analyzer": "^14.2.15",
     "@remixicon/react": "^4.2.0",
     "@sentry/nextjs": "^9.0.0",

--- a/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx
@@ -1,11 +1,7 @@
 import React, { useRef, useEffect } from "react"
 import { Typography, styled } from "ol-components"
 import { Button } from "@mitodl/smoot-design"
-import {
-  RiSparkling2Line,
-  RiArrowDownSLine,
-  RiArrowUpSLine,
-} from "@remixicon/react"
+import { RiSparkling2Line, RiArrowDownSLine } from "@remixicon/react"
 import type { AiChatProps } from "@mitodl/smoot-design/ai"
 import { LearningResource } from "api"
 import { AiChat } from "@mitodl/smoot-design/ai"
@@ -74,29 +70,19 @@ const StyledButton = styled(Button)<{ open: boolean }>(({ theme, open }) => ({
   "&&": {
     ":hover": {
       backgroundColor: theme.custom.colors.white,
-      borderColor: open
-        ? theme.custom.colors.darkGray1
-        : theme.custom.colors.silverGray,
-      "svg:last-child": {
-        backgroundColor: open ? theme.custom.colors.darkGray1 : "transparent",
-      },
+      borderColor: theme.custom.colors.silverGray,
     },
+  },
+  "svg:last-child": {
+    transform: open ? "rotate(-180deg)" : "rotate(0deg)",
+    transition: "transform 0.3s ease-in-out",
   },
 }))
 
-const OpenChevron = styled(RiArrowDownSLine)(({ theme }) => ({
+const Chevron = styled(RiArrowDownSLine)(({ theme }) => ({
   fill: theme.custom.colors.mitRed,
   position: "absolute",
   right: "9px",
-}))
-
-const CloseChevron = styled(RiArrowUpSLine)(({ theme }) => ({
-  fill: theme.custom.colors.white,
-  position: "absolute",
-  right: "0",
-  padding: "9px",
-  boxSizing: "content-box",
-  backgroundColor: theme.custom.colors.silverGray,
 }))
 
 const StyledAiChat = styled(AiChat)<{
@@ -146,7 +132,7 @@ export const AiChatSyllabusOpener = ({
         <Typography variant="body1">
           Ask<strong>TIM</strong> about this course
         </Typography>
-        {open ? <CloseChevron /> : <OpenChevron />}
+        <Chevron />
       </StyledButton>
     </Opener>
   )

--- a/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx
@@ -4,7 +4,7 @@ import { Button } from "@mitodl/smoot-design"
 import {
   RiSparkling2Line,
   RiArrowDownSLine,
-  RiCloseLine,
+  RiArrowUpSLine,
 } from "@remixicon/react"
 import type { AiChatProps } from "@mitodl/smoot-design/ai"
 import { LearningResource } from "api"
@@ -90,7 +90,7 @@ const OpenChevron = styled(RiArrowDownSLine)(({ theme }) => ({
   right: "9px",
 }))
 
-const CloseButton = styled(RiCloseLine)(({ theme }) => ({
+const CloseChevron = styled(RiArrowUpSLine)(({ theme }) => ({
   fill: theme.custom.colors.white,
   position: "absolute",
   right: "0",
@@ -146,7 +146,7 @@ export const AiChatSyllabusOpener = ({
         <Typography variant="body1">
           Ask<strong>TIM</strong> about this course
         </Typography>
-        {open ? <CloseButton /> : <OpenChevron />}
+        {open ? <CloseChevron /> : <OpenChevron />}
       </StyledButton>
     </Opener>
   )

--- a/frontends/main/src/page-components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -174,7 +174,9 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
       outerContainerRef.current.scrollTo(0, 0)
     }
     if (scrollElement) {
-      scrollElement.scrollTop = 0
+      requestAnimationFrame(() => {
+        scrollElement.scrollTop = 0
+      })
     }
   }, [resourceId, scrollElement])
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2703,9 +2703,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/smoot-design@npm:^6.2.1":
-  version: 6.2.1
-  resolution: "@mitodl/smoot-design@npm:6.2.1"
+"@mitodl/smoot-design@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "@mitodl/smoot-design@npm:6.2.2"
   dependencies:
     "@emotion/cache": "npm:^11.14.0"
     "@mui/utils": "npm:^6.1.6"
@@ -2725,7 +2725,7 @@ __metadata:
     "@remixicon/react": ^4.2.0
     react: ^18 || ^19
     react-dom: ^18 || ^19
-  checksum: 10/72f2c1e8525e9204e7bc92699768ec55efb7c02cffcca097d32f6acce6b4bf528d6c7988587a31313f5cf4911182b0381f7626574f45956d624419826ed8c71e
+  checksum: 10/e82638cf078014d970e720061f85a4b4338dcb20c0bae022b968f2ec3c6a6b25a37dd927400f443324cf033efba9dbfa882175bb00ac13001c237be3a3255039
   languageName: node
   linkType: hard
 
@@ -13083,7 +13083,7 @@ __metadata:
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^9.0.0"
     "@mitodl/course-search-utils": "npm:3.3.2"
-    "@mitodl/smoot-design": "npm:^6.2.1"
+    "@mitodl/smoot-design": "npm:^6.2.2"
     "@next/bundle-analyzer": "npm:^14.2.15"
     "@remixicon/react": "npm:^4.2.0"
     "@sentry/nextjs": "npm:^9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2703,9 +2703,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/smoot-design@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "@mitodl/smoot-design@npm:6.1.0"
+"@mitodl/smoot-design@npm:^6.2.1":
+  version: 6.2.1
+  resolution: "@mitodl/smoot-design@npm:6.2.1"
   dependencies:
     "@emotion/cache": "npm:^11.14.0"
     "@mui/utils": "npm:^6.1.6"
@@ -2725,7 +2725,7 @@ __metadata:
     "@remixicon/react": ^4.2.0
     react: ^18 || ^19
     react-dom: ^18 || ^19
-  checksum: 10/1395c039f7b30dc73d317de264e37ccf98c2e9d9a87083e4549136bcb3b15017a472a5a98c476ba22b942a9ea97f4bc93d2182902db05b9ffbaca5b66e53fc80
+  checksum: 10/72f2c1e8525e9204e7bc92699768ec55efb7c02cffcca097d32f6acce6b4bf528d6c7988587a31313f5cf4911182b0381f7626574f45956d624419826ed8c71e
   languageName: node
   linkType: hard
 
@@ -13083,7 +13083,7 @@ __metadata:
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^9.0.0"
     "@mitodl/course-search-utils": "npm:3.3.2"
-    "@mitodl/smoot-design": "npm:^6.1.0"
+    "@mitodl/smoot-design": "npm:^6.2.1"
     "@next/bundle-analyzer": "npm:^14.2.15"
     "@remixicon/react": "npm:^4.2.0"
     "@sentry/nextjs": "npm:^9.0.0"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Closes https://github.com/mitodl/hq/issues/7082

### Description (What does it do?)
<!--- Describe your changes in detail -->

Addresses the competing close buttons on the syllabus drawer with a rotating chevron for slide down/up.

Upgrades Smoot Design for:

https://github.com/mitodl/smoot-design/pull/92
- Chat prompt input should receive focus after submit from entry screen (text inut and starters buttons).
- High: Entry screen conversation starter buttons should have a natural tab order (tabindex: 0).
- High: Entry screen prompt submit needs a label for screen readers.
- Entry screen prompt input should have more prominent focus styles (match blue border on starts buttons).
- Add structure and mechanisms to navigate the messages thread for screen readers.

https://github.com/mitodl/smoot-design/pull/93
- fix: Remove double indent for chat message ordered lists

Adds a `requestAnimationFrame` to wait for first render before scrolling to the top - fixes an issue where the drawer opened with content scrolled to bottom.




### Screenshots (if appropriate):

https://github.com/user-attachments/assets/59d61128-e36c-4c71-a21f-3a389a66fd80

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

You'll need to set `chatEnabled` to true in LearningResourceExpanded.tsx to bypass the Posthog setting. Open the drawer on a course and open/close the AskTIM slidedown.



### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->

We've pulled out the drawer limited content at zoom item as designs are in flight and it's covered by an earlier ticket (https://github.com/mitodl/hq/issues/6513). This [branch](https://github.com/mitodl/mit-learn/tree/jk/7082-accessibility-test-static-header) captures the wip design.

- High: The syllabus drawer messages thread needs more space at page zoom magnification - the drawer header area limits space further). At 200% only a couple of lines are visible. At 300% it is obscured completely.
