### PR TITLE
update coursenumber weight in search

### DIFF
--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -223,7 +223,7 @@ def test_generate_learning_resources_text_clause(
                                                 "multi_match": {
                                                     "query": "math",
                                                     "fields": [
-                                                        "course.course_numbers.value",
+                                                        "course.course_numbers.value^5",
                                                     ],
                                                     **extra_params,
                                                 }
@@ -336,7 +336,7 @@ def test_generate_learning_resources_text_clause(
                             "multi_match": {
                                 "query": "math",
                                 "fields": [
-                                    "course.course_numbers.value",
+                                    "course.course_numbers.value^5",
                                 ],
                                 **extra_params,
                             }
@@ -446,7 +446,7 @@ def test_generate_learning_resources_text_clause(
                                                 "query_string": {
                                                     "query": '"math"',
                                                     "fields": [
-                                                        "course.course_numbers.value",
+                                                        "course.course_numbers.value^5",
                                                     ],
                                                 }
                                             },
@@ -553,7 +553,7 @@ def test_generate_learning_resources_text_clause(
                             "query_string": {
                                 "query": '"math"',
                                 "fields": [
-                                    "course.course_numbers.value",
+                                    "course.course_numbers.value^5",
                                 ],
                             }
                         },
@@ -688,7 +688,7 @@ def test_generate_learning_resources_text_clause_with_min_score():
                                                         "multi_match": {
                                                             "query": "math",
                                                             "fields": [
-                                                                "course.course_numbers.value"
+                                                                "course.course_numbers.value^5"
                                                             ],
                                                             "type": "phrase",
                                                             "slop": 2,
@@ -815,7 +815,7 @@ def test_generate_learning_resources_text_clause_with_min_score():
                         "query": {
                             "multi_match": {
                                 "query": "math",
-                                "fields": ["course.course_numbers.value"],
+                                "fields": ["course.course_numbers.value^5"],
                                 "type": "phrase",
                                 "slop": 2,
                             }
@@ -935,7 +935,7 @@ def test_generate_learning_resources_text_clause_with_min_score():
                                                         "query_string": {
                                                             "query": '"math"',
                                                             "fields": [
-                                                                "course.course_numbers.value"
+                                                                "course.course_numbers.value^5"
                                                             ],
                                                         }
                                                     },
@@ -1050,7 +1050,7 @@ def test_generate_learning_resources_text_clause_with_min_score():
                         "query": {
                             "query_string": {
                                 "query": '"math"',
-                                "fields": ["course.course_numbers.value"],
+                                "fields": ["course.course_numbers.value^5"],
                             }
                         },
                     }
@@ -1636,7 +1636,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                                     "multi_match": {
                                                                         "query": "math",
                                                                         "fields": [
-                                                                            "course.course_numbers.value"
+                                                                            "course.course_numbers.value^5"
                                                                         ],
                                                                         "type": "best_fields",
                                                                     }
@@ -1756,7 +1756,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                             "multi_match": {
                                                 "query": "math",
                                                 "fields": [
-                                                    "course.course_numbers.value"
+                                                    "course.course_numbers.value^5"
                                                 ],
                                                 "type": "best_fields",
                                             }
@@ -2107,7 +2107,7 @@ def test_execute_learn_search_with_script_score(
                                                                             "multi_match": {
                                                                                 "query": "math",
                                                                                 "fields": [
-                                                                                    "course.course_numbers.value"
+                                                                                    "course.course_numbers.value^5"
                                                                                 ],
                                                                                 "type": "phrase",
                                                                             }
@@ -2227,7 +2227,7 @@ def test_execute_learn_search_with_script_score(
                                                     "multi_match": {
                                                         "query": "math",
                                                         "fields": [
-                                                            "course.course_numbers.value"
+                                                            "course.course_numbers.value^5"
                                                         ],
                                                         "type": "phrase",
                                                     }
@@ -2538,7 +2538,7 @@ def test_execute_learn_search_with_min_score(mocker, settings, opensearch):
                                                                             "multi_match": {
                                                                                 "query": "math",
                                                                                 "fields": [
-                                                                                    "course.course_numbers.value"
+                                                                                    "course.course_numbers.value^5"
                                                                                 ],
                                                                                 "type": "best_fields",
                                                                             }
@@ -2661,7 +2661,7 @@ def test_execute_learn_search_with_min_score(mocker, settings, opensearch):
                                             "multi_match": {
                                                 "query": "math",
                                                 "fields": [
-                                                    "course.course_numbers.value"
+                                                    "course.course_numbers.value^5"
                                                 ],
                                                 "type": "best_fields",
                                             }

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -391,7 +391,7 @@ TOPICS_QUERY_FIELDS = ["topics.name"]
 DEPARTMENT_QUERY_FIELDS = ["departments.department_id", "departments.name"]
 
 COURSE_QUERY_FIELDS = [
-    "course.course_numbers.value",
+    "course.course_numbers.value^5",
 ]
 
 RUNS_QUERY_FIELDS = [


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7211

### Description (What does it do?)
This updates the weight of coursenumber in search results similar to instructor names

### How can this be tested?
Run `docker-compose run -u root --rm web ./manage.py backpopulate_ocw_data --course-name 18-01-single-variable-calculus-fall-2005`
Go to `http://open.odl.local:8062/search?q=18.01`
OCW single variable calculus should be the first result. This is a bit hard to test locally since that course would probably come up first anyway if you don't have many learning resources . We can test more on rc