### PR TITLE
Retry requests on connection errors and additional behavior

### DIFF
--- a/frontends/api/src/ssr/prefetch.ts
+++ b/frontends/api/src/ssr/prefetch.ts
@@ -2,14 +2,11 @@ import { QueryClient, dehydrate } from "@tanstack/react-query"
 import type { Query } from "@tanstack/react-query"
 
 const MAX_RETRIES = 3
-const NO_RETRY_CODES: (number | undefined)[] = [404, 403, 401]
+const NO_RETRY_CODES = [400, 401, 403, 404, 405, 409, 422]
 
 type MaybeHasStatus = {
   response?: {
     status?: number
-  }
-  config?: {
-    url?: string
   }
 }
 
@@ -21,39 +18,31 @@ export const prefetch = async (
   queries: (Query | unknown)[],
   queryClient?: QueryClient,
 ) => {
+  /**
+   * The SSR QueryClient is transient - it is created only for prefetch
+   * while API requests are made to server render the page and discarded
+   * as the dehydrated state is produced and sent to the client.
+   *
+   * Create a new query client if one is not provided.
+   */
   queryClient =
     queryClient ||
     new QueryClient({
       defaultOptions: {
         queries: {
+          /**
+           * React Query's default retry logic is only active in the browser.
+           * Here we explicitly configure it to retry MAX_RETRIES times on
+           * the server, with an exclusion list of statuses that we expect not
+           * to succeed on retry.
+           *
+           * Includes status undefined as we want to retry on network errors
+           */
           retry: (failureCount, error) => {
             const status = (error as MaybeHasStatus)?.response?.status
             const isNetworkError = status === undefined || status === 0
-            const id = (error as MaybeHasStatus)?.config?.url
-            const isBrowser = typeof window !== "undefined"
-            const isOffline =
-              isBrowser && typeof navigator !== "undefined" && !navigator.onLine
-            console.log(
-              "retry",
-              failureCount,
-              isBrowser ? "client" : "server",
-              status,
-              id,
-              "network error:",
-              isNetworkError,
-              "id in browser:",
-              isBrowser ? id : undefined,
-              "offline:",
-              isOffline,
-            )
-            /**
-             * React Query's default behavior is to retry all failed queries 3
-             * times. Many things (e.g., 403, 404) are not worth retrying. Let's
-             * just retry some explicit whitelist of status codes.
-             *
-             * Includes status undefined as we want to retry on network errors
-             */
-            if (status === undefined || !NO_RETRY_CODES.includes(status)) {
+
+            if (isNetworkError || !NO_RETRY_CODES.includes(status)) {
               return failureCount < MAX_RETRIES
             }
             return false

--- a/frontends/api/src/ssr/prefetch.ts
+++ b/frontends/api/src/ssr/prefetch.ts
@@ -1,6 +1,18 @@
 import { QueryClient, dehydrate } from "@tanstack/react-query"
 import type { Query } from "@tanstack/react-query"
 
+const MAX_RETRIES = 3
+const NO_RETRY_CODES: (number | undefined)[] = [404, 403, 401]
+
+type MaybeHasStatus = {
+  response?: {
+    status?: number
+  }
+  config?: {
+    url?: string
+  }
+}
+
 /* Utility to avoid repetition in server components
  * Optionally pass the queryClient returned from a previous prefetch
  * where queries are dependent on previous results
@@ -9,7 +21,46 @@ export const prefetch = async (
   queries: (Query | unknown)[],
   queryClient?: QueryClient,
 ) => {
-  queryClient = queryClient || new QueryClient()
+  queryClient =
+    queryClient ||
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: (failureCount, error) => {
+            const status = (error as MaybeHasStatus)?.response?.status
+            const isNetworkError = status === undefined || status === 0
+            const id = (error as MaybeHasStatus)?.config?.url
+            const isBrowser = typeof window !== "undefined"
+            const isOffline =
+              isBrowser && typeof navigator !== "undefined" && !navigator.onLine
+            console.log(
+              "retry",
+              failureCount,
+              isBrowser ? "client" : "server",
+              status,
+              id,
+              "network error:",
+              isNetworkError,
+              "id in browser:",
+              isBrowser ? id : undefined,
+              "offline:",
+              isOffline,
+            )
+            /**
+             * React Query's default behavior is to retry all failed queries 3
+             * times. Many things (e.g., 403, 404) are not worth retrying. Let's
+             * just retry some explicit whitelist of status codes.
+             *
+             * Includes status undefined as we want to retry on network errors
+             */
+            if (status === undefined || !NO_RETRY_CODES.includes(status)) {
+              return failureCount < MAX_RETRIES
+            }
+            return false
+          },
+        },
+      },
+    })
 
   await Promise.all(
     queries

--- a/frontends/api/src/ssr/prefetch.ts
+++ b/frontends/api/src/ssr/prefetch.ts
@@ -10,14 +10,48 @@ type MaybeHasStatus = {
   }
 }
 
+const getPrefetchQueryClient = () => {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        /**
+         * React Query's default retry logic is only active in the browser.
+         * Here we explicitly configure it to retry MAX_RETRIES times on
+         * the server, with an exclusion list of statuses that we expect not
+         * to succeed on retry.
+         *
+         * Includes status undefined as we want to retry on network errors
+         */
+        retry: (failureCount, error) => {
+          const status = (error as MaybeHasStatus)?.response?.status
+          const isNetworkError = status === undefined || status === 0
+
+          if (isNetworkError || !NO_RETRY_CODES.includes(status)) {
+            return failureCount < MAX_RETRIES
+          }
+          return false
+        },
+
+        /**
+         * By default, React Query gradually applies a backoff delay, though it is
+         * preferable that we do not significantly delay initial page renders (or
+         * indeed pages that are Statically Rendered during the build process) and
+         * instead allow the request to fail quickly so it can be subsequently
+         * fetched on the client.
+         */
+        retryDelay: 1000,
+      },
+    },
+  })
+}
+
 /* Utility to avoid repetition in server components
  * Optionally pass the queryClient returned from a previous prefetch
  * where queries are dependent on previous results
  */
 export const prefetch = async (
   queries: (Query | unknown)[],
-  queryClient?: QueryClient,
-) => {
+
   /**
    * The SSR QueryClient is transient - it is created only for prefetch
    * while API requests are made to server render the page and discarded
@@ -25,41 +59,8 @@ export const prefetch = async (
    *
    * Create a new query client if one is not provided.
    */
-  queryClient =
-    queryClient ||
-    new QueryClient({
-      defaultOptions: {
-        queries: {
-          /**
-           * React Query's default retry logic is only active in the browser.
-           * Here we explicitly configure it to retry MAX_RETRIES times on
-           * the server, with an exclusion list of statuses that we expect not
-           * to succeed on retry.
-           *
-           * Includes status undefined as we want to retry on network errors
-           */
-          retry: (failureCount, error) => {
-            const status = (error as MaybeHasStatus)?.response?.status
-            const isNetworkError = status === undefined || status === 0
-
-            if (isNetworkError || !NO_RETRY_CODES.includes(status)) {
-              return failureCount < MAX_RETRIES
-            }
-            return false
-          },
-
-          /**
-           * By default, React Query gradually applies a backoff delay, though it is
-           * preferable that we do not significantly delay initial page renders (or
-           * indeed pages that are Statically Rendered during the build process) and
-           * instead allow the request to fail quickly so it can be subsequently
-           * fetched on the client.
-           */
-          retryDelay: 1000,
-        },
-      },
-    })
-
+  queryClient = getPrefetchQueryClient(),
+) => {
   await Promise.all(
     queries
       .filter(Boolean)

--- a/frontends/api/src/ssr/prefetch.ts
+++ b/frontends/api/src/ssr/prefetch.ts
@@ -1,7 +1,7 @@
 import { QueryClient, dehydrate } from "@tanstack/react-query"
 import type { Query } from "@tanstack/react-query"
 
-const MAX_RETRIES = 10
+const MAX_RETRIES = 3
 const NO_RETRY_CODES = [400, 401, 403, 404, 405, 409, 422]
 
 type MaybeHasStatus = {

--- a/frontends/api/src/ssr/prefetch.ts
+++ b/frontends/api/src/ssr/prefetch.ts
@@ -1,7 +1,7 @@
 import { QueryClient, dehydrate } from "@tanstack/react-query"
 import type { Query } from "@tanstack/react-query"
 
-const MAX_RETRIES = 3
+const MAX_RETRIES = 10
 const NO_RETRY_CODES = [400, 401, 403, 404, 405, 409, 422]
 
 type MaybeHasStatus = {
@@ -47,6 +47,15 @@ export const prefetch = async (
             }
             return false
           },
+
+          /**
+           * By default, React Query gradually applies a backoff delay, though it is
+           * preferable that we do not significantly delay initial page renders (or
+           * indeed pages that are Statically Rendered during the build process) and
+           * instead allow the request to fail quickly so it can be subsequently
+           * fetched on the client.
+           */
+          retryDelay: 1000,
         },
       },
     })

--- a/frontends/main/src/app/c/[channelType]/[name]/page.tsx
+++ b/frontends/main/src/app/c/[channelType]/[name]/page.tsx
@@ -71,17 +71,18 @@ const Page: React.FC = async ({
   const channel = queryClient.getQueryData<UnitChannel>(
     channelQueries.detailByType(channelType, name).queryKey,
   )
-  const offerors = queryClient
-    .getQueryData<PaginatedLearningResourceOfferorDetailList>(
-      offerorQueries.list({}).queryKey,
-    )!
-    .results.reduce(
-      (memo, offeror) => ({
-        ...memo,
-        [offeror.code]: offeror,
-      }),
-      [],
-    )
+  const offerors =
+    queryClient
+      .getQueryData<PaginatedLearningResourceOfferorDetailList>(
+        offerorQueries.list({}).queryKey,
+      )
+      ?.results.reduce(
+        (memo, offeror) => ({
+          ...memo,
+          [offeror.code]: offeror,
+        }),
+        [],
+      ) ?? {}
 
   const constantSearchParams = getConstantSearchParams(channel?.search_filter)
 

--- a/frontends/main/src/app/getQueryClient.test.tsx
+++ b/frontends/main/src/app/getQueryClient.test.tsx
@@ -13,7 +13,12 @@ const getWrapper = () => {
 }
 
 test.each([
+  { status: 0, retries: 3 },
+  { status: 404, retries: 0 },
+  { status: 405, retries: 0 },
   { status: 408, retries: 3 },
+  { status: 409, retries: 0 },
+  { status: 422, retries: 0 },
   { status: 429, retries: 3 },
   { status: 502, retries: 3 },
   { status: 503, retries: 3 },
@@ -24,6 +29,7 @@ test.each([
     allowConsoleErrors()
     const wrapper = getWrapper()
     const queryFn = jest.fn().mockRejectedValue({ response: { status } })
+
     const { result } = renderHook(
       () =>
         useQuery({

--- a/frontends/main/src/app/getQueryClient.ts
+++ b/frontends/main/src/app/getQueryClient.ts
@@ -9,7 +9,7 @@ type MaybeHasStatus = {
 }
 
 const MAX_RETRIES = 3
-const SHOULD_THROW_CODES = [400, 401, 403]
+const THROW_ERROR_CODES = [400, 401, 403]
 const NO_RETRY_CODES = [400, 401, 403, 404, 405, 409, 422]
 
 const makeQueryClient = (): QueryClient => {
@@ -27,7 +27,7 @@ const makeQueryClient = (): QueryClient => {
          */
         throwOnError: (error) => {
           const status = (error as MaybeHasStatus)?.response?.status
-          return SHOULD_THROW_CODES.includes(status ?? 0)
+          return THROW_ERROR_CODES.includes(status ?? 0)
         },
 
         retry: (failureCount, error) => {
@@ -46,6 +46,16 @@ const makeQueryClient = (): QueryClient => {
           }
           return false
         },
+
+        /**
+         * By default, React Query gradually applies a backoff delay, though it is
+         * preferable that we do not significantly delay initial page renders on
+         * the server and instead allow the request to fail quickly so it can be
+         * subsequently fetched on the client. Note that we aim to prefetch any API
+         * content needed to render the page, so we don't generally expect the retry
+         * rules above to be in use on the server.
+         */
+        retryDelay: isServer ? 1000 : undefined,
       },
     },
   })

--- a/frontends/main/src/app/getQueryClient.ts
+++ b/frontends/main/src/app/getQueryClient.ts
@@ -6,11 +6,16 @@ type MaybeHasStatus = {
   response?: {
     status?: number
   }
+  config?: {
+    url?: string
+  }
 }
 
-const RETRY_STATUS_CODES = [408, 429, 502, 503, 504]
+// const RETRY_STATUS_CODES = [408, 429, 502, 503, 504]
 const MAX_RETRIES = 3
-const THROW_ERROR_CODES: (number | undefined)[] = [404, 403, 401]
+const NO_RETRY_CODES: (number | undefined)[] = [404, 403, 401]
+
+console.log("TEST LOG?")
 
 const makeQueryClient = (): QueryClient => {
   return new QueryClient({
@@ -23,17 +28,55 @@ const makeQueryClient = (): QueryClient => {
         // For now, only do this for 404s, 403s, and 401s. Other errors should
         // be handled locally by components.
         throwOnError: (error) => {
+          console.log("Full error", error)
           const status = (error as MaybeHasStatus)?.response?.status
-          return THROW_ERROR_CODES.includes(status)
+          const isNetworkError = status === undefined || status === 0
+          const id = (error as MaybeHasStatus)?.config?.url
+          const isBrowser = typeof window !== "undefined"
+          const isOffline =
+            isBrowser && typeof navigator !== "undefined" && !navigator.onLine
+          console.log(
+            "throwOnError",
+            isServer ? "server" : "client",
+            status,
+            id,
+            "network error:",
+            isNetworkError,
+            "id in browser:",
+            isBrowser ? id : undefined,
+            "offline:",
+            isOffline,
+          )
+          return NO_RETRY_CODES.includes(status)
         },
         retry: (failureCount, error) => {
           const status = (error as MaybeHasStatus)?.response?.status
+          const isNetworkError = status === undefined || status === 0
+          const id = (error as MaybeHasStatus)?.config?.url
+          const isBrowser = typeof window !== "undefined"
+          const isOffline =
+            isBrowser && typeof navigator !== "undefined" && !navigator.onLine
+          console.log(
+            "retry",
+            failureCount,
+            isServer ? "server" : "client",
+            status,
+            id,
+            "network error:",
+            isNetworkError,
+            "id in browser:",
+            isBrowser ? id : undefined,
+            "offline:",
+            isOffline,
+          )
           /**
            * React Query's default behavior is to retry all failed queries 3
            * times. Many things (e.g., 403, 404) are not worth retrying. Let's
            * just retry some explicit whitelist of status codes.
+           *
+           * Includes status undefined as we want to retry on network errors
            */
-          if (status !== undefined && RETRY_STATUS_CODES.includes(status)) {
+          if (status === undefined || !NO_RETRY_CODES.includes(status)) {
             return failureCount < MAX_RETRIES
           }
           return false

--- a/frontends/main/src/app/getQueryClient.ts
+++ b/frontends/main/src/app/getQueryClient.ts
@@ -46,15 +46,6 @@ const makeQueryClient = (): QueryClient => {
           }
           return false
         },
-
-        /**
-         * By default, React Query gradually applies a backoff delay, though it is
-         * preferable that we do not significantly delay initial page renders (or
-         * indeed pages that are Statically Rendered during the build process) and
-         * instead allow the request to fail quickly so it can be subsequently
-         * fetched on the client.
-         */
-        retryDelay: 1000,
       },
     },
   })


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/7205

### Description (What does it do?)
<!--- Describe your changes in detail -->

- Fixes the core issue that errors thrown while fetching learning resource content to build page metadata (for pages loaded with the drawer open) were thrown up to the wide global error boundary causing the fallback error page to be shown in place of content. These are now caught, reported to Sentry and fall back to the default page metadata.

- Retries requests that have failed due to network issues (status 0 or undefined).

- Replaces our whitelist of status codes to retry and extends to all statuses with the exception of some that we wouldn't expect to succeed on retry, `[400, 401, 403, 404, 405, 409, 422]`.

- Also applies the above logic so that requests a retried during SSR prefetching. To note - we were retrying any requests that might have slipped through our prefetching on the server according to the previous rules (the `QueryClientProvider` provided query client), whereas the QueryClient created during the prefetch phase had no rules specified.

- During SSR prefetching and for any requests made from on the server not prefetched (none expected), fixes the retry delay to 1s.



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

It's tricky to test error responses / network errors - I've committed a small proxy to an otherwise identical branch for testing: https://github.com/mitodl/mit-learn/tree/jk/7205-query-retry-proxy/sandbox. This closes requests sockets with `ECONNRESET` and includes counts to test for retries. It will need be restarted after any test dependent on the counts:

```bash
cd ./sandbox
yarn install
yarn proxy
```

The Next.js server should be run in production mode as it will behave differently in dev mode:

```bash
NEXT_PUBLIC_MITOL_API_BASE_URL=http://api.open.odl.local:8063 \
NEXT_PUBLIC_CSRF_COOKIE_NAME=any \
NEXT_PUBLIC_MITOL_SUPPORT_EMAIL=any \
NEXT_PUBLIC_SITE_NAME=any \
NEXT_PUBLIC_ORIGIN=http://learn.odl.local:8062 \
yarn build

PORT=8062 yarn start
```

Navigate to the homepage with a drawer open, http://learn.odl.local:8062/?resource=17261 (or update proxy.ts for a different resource)
- Confirm that the error fetching page metadata for the open drawer does not produce the "Something went wrong." error page.
- The error should be logged in the Next.js console.
- The page should have default title "MIT Learn" and description "Learn with MIT".

The proxy is set to error on all requests to /api/v1/featured (homepage carousels) from the server and the first 3 from the client (per querystring / carousel).

Navigate to the homepage, http://learn.odl.local:8062/
- Observe that failed prefetch requests are made on the the server with 3 retries and a 1s delay.
- The homepage should load with skeleton carousels.
- The browser should retry requests unless success on the third.

Apply the proxy request counts from the server to confirm that it retries and prefetches successfully if < 3.

Note that the Next.js server should be restarted between tests as responses are cached, as should the proxy to reset counts.




