### PR TITLE
UAI dashboard - unenrolled module card changes

### DIFF
--- a/frontends/main/public/images/icons/course-unenrolled.svg
+++ b/frontends/main/public/images/icons/course-unenrolled.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Vector" d="M5 10C2.23858 10 0 7.7614 0 5C0 2.23858 2.23858 0 5 0C7.7614 0 10 2.23858 10 5C10 7.7614 7.7614 10 5 10Z" fill="#b8c2cc"/>
+</svg>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -305,7 +305,11 @@ describe.each([
       expectedLabel: "Enrolled",
       hiddenImage: true,
     },
-    { status: EnrollmentStatus.NotEnrolled, expectedLabel: "Not Enrolled" },
+    {
+      status: EnrollmentStatus.NotEnrolled,
+      expectedLabel: "Not Enrolled",
+      hiddenImage: true,
+    },
   ])(
     "Enrollment indicator shows meaningful text",
     ({ status, expectedLabel, hiddenImage }) => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -345,6 +345,10 @@ describe.each([
     "getDefaultContextMenuItems returns correct items",
     async ({ contextMenuItems }) => {
       const course = dashboardCourse()
+      course.enrollment = {
+        status: EnrollmentStatus.Completed,
+        mode: EnrollmentMode.Verified,
+      }
       renderWithProviders(
         <DashboardCard
           dashboardResource={course}
@@ -369,6 +373,33 @@ describe.each([
           }
         })
         expect(menuItemElement?.textContent).toBe(menuItem.label)
+      }
+    },
+  )
+
+  test.each([
+    { status: EnrollmentStatus.Completed },
+    { status: EnrollmentStatus.Enrolled },
+    { status: EnrollmentStatus.NotEnrolled },
+    { status: undefined },
+  ])(
+    "Context menu button is not shown when enrollment status is not Completed or Enrolled",
+    ({ status }) => {
+      renderWithProviders(
+        <DashboardCard
+          dashboardResource={dashboardCourse({ enrollment: { status } })}
+        />,
+      )
+      const card = getCard()
+      const expectedVisible =
+        status === EnrollmentStatus.Completed ||
+        status === EnrollmentStatus.Enrolled
+      const contextMenuButton = within(card).queryByRole("button", {
+        name: "More options",
+        hidden: !expectedVisible,
+      })
+      if (expectedVisible) {
+        expect(contextMenuButton).toBeVisible()
       }
     },
   )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -61,14 +61,22 @@ const TitleLink = styled(Link)(({ theme }) => ({
   },
 }))
 
-const MenuButton = styled(ActionButton)(({ theme }) => ({
-  marginLeft: "-8px",
-  [theme.breakpoints.down("md")]: {
-    position: "absolute",
-    top: "0",
-    right: "0",
+const MenuButton = styled(ActionButton)<{
+  status?: EnrollmentStatus
+}>(({ theme, status }) => [
+  {
+    marginLeft: "-8px",
+    [theme.breakpoints.down("md")]: {
+      position: "absolute",
+      top: "0",
+      right: "0",
+    },
   },
-}))
+  status !== EnrollmentStatus.Completed &&
+    status !== EnrollmentStatus.Enrolled && {
+      visibility: "hidden",
+    },
+])
 
 const getDefaultContextMenuItems = (title: string) => {
   return [
@@ -323,7 +331,12 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
     <SimpleMenu
       items={menuItems}
       trigger={
-        <MenuButton size="small" variant="text" aria-label="More options">
+        <MenuButton
+          size="small"
+          variant="text"
+          aria-label="More options"
+          status={enrollment?.status}
+        >
           <RiMore2Line />
         </MenuButton>
       }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentStatusIndicator.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentStatusIndicator.tsx
@@ -3,6 +3,7 @@ import Image from "next/image"
 import { styled, VisuallyHidden } from "ol-components"
 import CourseComplete from "@/public/images/icons/course-complete.svg"
 import CourseInProgress from "@/public/images/icons/course-in-progress.svg"
+import CourseUnenrolled from "@/public/images/icons/course-unenrolled.svg"
 import { EnrollmentStatus } from "./types"
 
 const CompletedImage = styled(Image)({
@@ -63,6 +64,12 @@ const EnrollmentStatusIndicator: React.FC<EnrollmentStatusIndicatorProps> = ({
 
   return (
     <Ring data-testid="enrollment-status">
+      <Image
+        src={CourseUnenrolled}
+        alt=""
+        // use VisuallyHidden text for consistency with the non-image case.
+        aria-hidden
+      />
       <VisuallyHidden>Not Enrolled</VisuallyHidden>
     </Ring>
   )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7255

### Description (What does it do?)
This PR solves the first two items in the above issue:

- The `DashboardCard` context menu is now hidden if `enrollment.status` is not either `EnrollmentStatus.Completed` or `EnrollmentStatus.Enrolled`
- The new unenrolled status indicator was added

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/6a06ac18-f057-43de-9c51-83d8accf6e90)
![image](https://github.com/user-attachments/assets/bca7f7e6-508a-4619-b3c5-01dd08c884d4)

### How can this be tested?
- Ensure that you have a Posthog project configured and have run the basic setup for `mit-learn`
- Enable both the `enrollment-dashboard` and `mitlearn-organization-dashboard` feature flags
- Visit the dashboard at http://open.odl.local:8062/dashboard (or wherever your site is hosted), logging in if necessary
- The "My Learning" dashboard should be unchanged by this PR
- Click either "Organization X" or Organization Y" to open the UAI dashboard
- Ensure that on unenrolled modules, you see the new filled grey circle status indicator
- Ensure that the context menu (3 dots) are hidden on unenrolled modules
