### PR TITLE
Remove param based onboarding navigation  

### DIFF
--- a/authentication/views.py
+++ b/authentication/views.py
@@ -4,7 +4,7 @@ import logging
 
 from django.contrib.auth import logout
 from django.shortcuts import redirect
-from django.utils.http import url_has_allowed_host_and_scheme, urlencode
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views import View
 
 from main import settings
@@ -80,8 +80,7 @@ class CustomLoginView(View):
                 not profile.completed_onboarding
                 and request.GET.get("skip_onboarding", "0") == "0"
             ):
-                params = urlencode({"next": redirect_url})
-                redirect_url = f"{settings.MITOL_NEW_USER_LOGIN_URL}?{params}"
+                redirect_url = settings.MITOL_NEW_USER_LOGIN_URL
                 profile.completed_onboarding = True
                 profile.save()
         return redirect(redirect_url)

--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -120,7 +120,6 @@ def test_custom_login_view_authenticated_user_with_onboarding(mocker):
     request.user = MagicMock(is_anonymous=False)
     request.user.profile = MagicMock(completed_onboarding=False)
     mocker.patch("authentication.views.get_redirect_url", return_value="/dashboard")
-    mocker.patch("authentication.views.urlencode", return_value="next=/dashboard")
     mocker.patch(
         "authentication.views.settings.MITOL_NEW_USER_LOGIN_URL", "/onboarding"
     )
@@ -128,7 +127,7 @@ def test_custom_login_view_authenticated_user_with_onboarding(mocker):
     response = CustomLoginView().get(request)
 
     assert response.status_code == 302
-    assert response.url == "/onboarding?next=/dashboard"
+    assert response.url == "/onboarding"
 
 
 def test_custom_login_view_authenticated_user_skip_onboarding(mocker):

--- a/frontends/main/src/app-pages/OnboardingPage/OnboardingPage.test.tsx
+++ b/frontends/main/src/app-pages/OnboardingPage/OnboardingPage.test.tsx
@@ -4,6 +4,7 @@ import { merge, times } from "lodash"
 import {
   renderWithProviders,
   screen,
+  waitFor,
   setMockResponse,
   user,
 } from "../../test-utils"
@@ -18,31 +19,7 @@ import {
   type Profile,
 } from "api/v0"
 
-import { waitFor } from "@testing-library/react"
-
 import OnboardingPage from "./OnboardingPage"
-
-const oldWindowLocation = window.location
-
-beforeAll(() => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  delete (window as any).location
-
-  window.location = Object.defineProperties(
-    {} as unknown as string & Location,
-    {
-      ...Object.getOwnPropertyDescriptors(oldWindowLocation),
-      assign: {
-        configurable: true,
-        value: jest.fn(),
-      },
-    },
-  )
-})
-
-afterAll(() => {
-  window.location = oldWindowLocation as unknown as string & Location
-})
 
 const STEPS_DATA: Partial<Profile>[] = [
   {
@@ -91,9 +68,7 @@ const setup = async (profile: Profile) => {
     ...req,
   }))
 
-  renderWithProviders(<OnboardingPage />, {
-    url: "/onboarding?next=http%3A%2F%2Flearn.mit.edu",
-  })
+  renderWithProviders(<OnboardingPage />)
 }
 
 // this function sets up the test and progresses the UI to the designated step
@@ -132,15 +107,8 @@ describe("OnboardingPage", () => {
       const nextStep = step + 1
       await setupAndProgressToStep(step)
       if (step === STEP_TITLES.length - 1) {
-        const finishButton = await findFinishButton()
-
+        await findFinishButton()
         expect(queryBackButton()).not.toBeNil()
-
-        await user.click(finishButton)
-        await waitFor(() => {
-          expect(window.location).toBe("http://learn.mit.edu")
-        })
-
         return
       }
 

--- a/frontends/main/src/app-pages/OnboardingPage/OnboardingPage.tsx
+++ b/frontends/main/src/app-pages/OnboardingPage/OnboardingPage.tsx
@@ -27,8 +27,6 @@ import { DASHBOARD_HOME } from "@/common/urls"
 import { useFormik } from "formik"
 import { useLearningResourceTopics } from "api/hooks/learningResources"
 import { useUserMe } from "api/hooks/user"
-
-import { useSearchParams } from "next/navigation"
 import {
   CERTIFICATE_CHOICES,
   EDUCATION_LEVEL_OPTIONS,
@@ -158,8 +156,6 @@ const OnboardingPage: React.FC = () => {
   const { isLoading: userLoading, data: user } = useUserMe()
   const [activeStep, setActiveStep] = React.useState<number>(0)
   const router = useRouter()
-  const searchParams = useSearchParams()
-  const nextUrl = searchParams.get("next")
 
   const formik = useFormik({
     enableReinitialize: true,
@@ -175,10 +171,6 @@ const OnboardingPage: React.FC = () => {
       if (activeStep < NUM_STEPS - 1) {
         setActiveStep((prevActiveStep) => prevActiveStep + 1)
       } else {
-        if (nextUrl) {
-          ;(window as Window).location = nextUrl
-          return null
-        }
         router.push(DASHBOARD_HOME)
       }
     },


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/7223

### Description (What does it do?)
<!--- Describe your changes in detail -->

Removes the onboarding finish navigation configurable by a `next` param on the querystring as we always want to go to the dashboard screen.

Previously the backend /login and onboarding handling looked like:

- A user on e.g. the topic page hits "Log in" and requests /learn/login?next=https://learn.mit.edu/topics
- The login handler determines whether they have completed onboarding
- If yes:
   - User redirected to https://learn.mit.edu/topics
- If no:
   - User redirected to https://learn.mit.edu/onboarding?next=https://learn.mit.edu/topics
   - User completes onboarding
   - User is redirected in the frontend to https://learn.mit.edu/topics when they hit "Finish" at the end of onboarding.
 
We instead want the user to always go to the dashboard when they complete the onboarding, irrespective of their starting point prior to login.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

The "Log In" button always links to the login endpoint with the current address as set on a `next` param. Starting from any page as a user that has not completed onboarding (manually set `user.profile.completed_onboarding` to False):
- Log in.
- Step through onboarding and hit "Finish".
- Confirm that you are on the dashboard page at /dashboard.
