### PR TITLE
Set card link on org dashboard pages to courseware url

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -263,6 +263,8 @@ type DashboardCardProps = {
   offerUpgrade?: boolean
   contextMenuItems?: SimpleMenuItem[]
   isLoading?: boolean
+  titleHref?: string | null
+  buttonHref?: string | null
 }
 const DashboardCard: React.FC<DashboardCardProps> = ({
   dashboardResource,
@@ -273,6 +275,8 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   offerUpgrade = true,
   contextMenuItems = [],
   isLoading = false,
+  titleHref,
+  buttonHref,
 }) => {
   const { title, marketingUrl, enrollment, run } = dashboardResource
   const titleSection = isLoading ? (
@@ -283,7 +287,11 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
     </>
   ) : (
     <>
-      <TitleLink size="medium" color="black" href={marketingUrl}>
+      <TitleLink
+        size="medium"
+        color="black"
+        href={titleHref ? titleHref : marketingUrl}
+      >
         {title}
       </TitleLink>
       {enrollment?.status === EnrollmentStatus.Completed ? (
@@ -313,7 +321,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
       <CoursewareButton
         data-testid="courseware-button"
         startDate={run.startDate}
-        href={run.coursewareUrl}
+        href={buttonHref ? buttonHref : run.coursewareUrl}
         endDate={run.endDate}
         courseNoun={courseNoun}
       />

--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
@@ -153,6 +153,8 @@ const OrgProgramDisplay: React.FC<{
             dashboardResource={course}
             courseNoun="Module"
             offerUpgrade={false}
+            titleHref={course.run.coursewareUrl}
+            buttonHref={course.run.coursewareUrl}
           />
         ))}
       </PlainList>

--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
@@ -153,8 +153,8 @@ const OrgProgramDisplay: React.FC<{
             dashboardResource={course}
             courseNoun="Module"
             offerUpgrade={false}
-            titleHref={course.run.coursewareUrl}
-            buttonHref={course.run.coursewareUrl}
+            titleHref={course.run?.coursewareUrl}
+            buttonHref={course.run?.coursewareUrl}
           />
         ))}
       </PlainList>


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7255

### Description (What does it do?)
This PR alters `DashboardCard` to allow optionally specifying a URL for either the title or button. On organization dashboard pages, the title link is set to the same courseware URL that the button is set to, as requested in the above issue.

### How can this be tested?
- Ensure that you have a Posthog project configured and have run the basic setup for `mit-learn`
- Enable both the `enrollment-dashboard` and `mitlearn-organization-dashboard` feature flags
- Visit the dashboard at http://open.odl.local:8062/dashboard (or wherever your site is hosted), logging in if necessary
- The "My Learning" dashboard should be unchanged by this PR
- Click either "Organization X" or Organization Y" to open the UAI dashboard
- Ensure that the title link points to the courseware URL, the same as the button
