### PR TITLE
remove the backend deploy to heroku

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -27,14 +27,6 @@ jobs:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: heroku container:login
 
-      - name: Release Backend on Heroku
-        uses: akhileshns/heroku-deploy@e3eb99d45a8e2ec5dca08735e089607befa4bf28
-        with:
-          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
-          heroku_app_name: mitopen-rc
-          heroku_email: ${{ secrets.HEROKU_EMAIL }}
-          branch: release-candidate
-
       - name: Write commit SHA to file
         run: echo $GITHUB_SHA > frontends/main/public/hash.txt
 


### PR DESCRIPTION
### What are the relevant tickets?
¯\\_(ツ)_/¯

### Description (What does it do?)
This PR removes a step from the Release Candidate Deploy Github action that deploys the backend to Heroku, as we've moved the backend to Kubernetes and the action will fail because the app is in maintenance mode.

### How can this be tested?
Merge this Pr and try a release, I guess?