### PR TITLE
Prevent test courses from being overwritten

### DIFF
--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -298,15 +298,6 @@ def load_run(
         LearningResourceRun: the created/updated resource run
     """
     run_id = run_data.pop("run_id")
-    if (
-        LearningResourceRun.objects.filter(
-            run_id=run_id, learning_resource=learning_resource
-        ).exists()
-        and LearningResourceRun.objects.get(
-            run_id=run_id, learning_resource=learning_resource
-        ).learning_resource.test_mode
-    ):
-        return None
 
     image_data = run_data.pop("image", None)
     status = run_data.pop("status", None)
@@ -329,7 +320,9 @@ def load_run(
             run_id=run_id,
             defaults={**run_data},
         )
-
+        if learning_resource_run.learning_resource.test_mode:
+            learning_resource_run.published = True
+            learning_resource_run.save()
         load_instructors(learning_resource_run, instructors_data)
         load_prices(learning_resource_run, resource_prices)
         load_image(learning_resource_run, image_data)

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -311,6 +311,9 @@ def load_run(
         run_data["prices"] = []
         resource_prices = []
 
+    if learning_resource.test_mode:
+        run_data["published"] = True
+
     with transaction.atomic():
         (
             learning_resource_run,
@@ -320,9 +323,6 @@ def load_run(
             run_id=run_id,
             defaults={**run_data},
         )
-        if learning_resource_run.learning_resource.test_mode:
-            learning_resource_run.published = True
-            learning_resource_run.save()
         load_instructors(learning_resource_run, instructors_data)
         load_prices(learning_resource_run, resource_prices)
         load_image(learning_resource_run, image_data)

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -147,7 +147,7 @@ def mock_upsert_tasks(mocker):
 @pytest.mark.parametrize("published", [False, True])
 @pytest.mark.parametrize("test_mode", [False, True])
 @pytest.mark.parametrize("newly_created", [False, True])
-def test_update_index_behavior(
+def test_update_index_test_mode_behavior(
     mocker,
     published,
     test_mode,

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -144,6 +144,28 @@ def mock_upsert_tasks(mocker):
     )
 
 
+@pytest.mark.parametrize("published", [False, True])
+@pytest.mark.parametrize("test_mode", [False, True])
+@pytest.mark.parametrize("newly_created", [False, True])
+def test_update_index_behavior(
+    mocker,
+    published,
+    test_mode,
+    newly_created,
+):
+    """Test update_index does not remove test_mode content files from index"""
+    resource_unpublished_actions = mocker.patch(
+        "learning_resources.etl.loaders.resource_unpublished_actions"
+    )
+    lr = LearningResourceFactory.create(published=published, test_mode=test_mode)
+
+    loaders.update_index(lr, newly_created)
+    if test_mode:
+        resource_unpublished_actions.assert_not_called()
+    elif not published and not newly_created:
+        resource_unpublished_actions.assert_called_once()
+
+
 @pytest.fixture
 def learning_resource_offeror():
     """Return a LearningResourceOfferer"""

--- a/learning_resources/management/commands/mixins.py
+++ b/learning_resources/management/commands/mixins.py
@@ -1,4 +1,4 @@
-from learning_resources.models import LearningResource
+from learning_resources.models import LearningResource, LearningResourceRun
 
 
 class TestResourceConfigurationMixin:
@@ -13,6 +13,9 @@ class TestResourceConfigurationMixin:
         )
         if options.get("test_ids"):
             test_ids = options["test_ids"].split(",")
+            LearningResourceRun.objects.filter(
+                learning_resource__id__in=test_ids
+            ).update(published=True)
             LearningResource.objects.filter(id__in=test_ids).update(
                 test_mode=True, published=False
             )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/7373
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
We have a mechanism for tagging certain courses as being in "test_mode" so that they have their contentfiles ingested into qdrant and opensearch but remain "unpublished". There is an issue where scheduled etl backpopulate tasks overwrite this status and remove contentfiles from the indexes.


### How can this be tested?
1. checkout main
2. make sure you have some courses populated. in this case we will use mitxonline which has a course intended to be a test course ```python manage.py backpopulate_mitxonline_data```
3. see that the test_mode on the learning resource is false. also note the id
```python
LearningResource.objects.get(readable_id='course-v1:UAI_SOURCE+UAI.2').test_mode
print(LearningResource.objects.get(readable_id='course-v1:UAI_SOURCE+UAI.2').id)
```
4. use the id to mark it as test_mode when fetching contentfiles:
```python
python manage.py backpopulate_mitxonline_files --resource-ids <resource_id> --test-ids <resource_id> --overwrite
```
5. note that there are not contentfiles for the course run:
```python
LearningResource.objects.get(readable_id='course-v1:UAI_SOURCE+UAI.2').runs.first().content_files.all()
```
6. manually set the run for that course to published:
```python
run = LearningResource.objects.get(readable_id='course-v1:UAI_SOURCE+UAI.2').runs.first()
run.published = True
run.save()
``` 
and re-run ` backpopulate_mitxonline_files --resource-ids <resource_id> --test-ids <resource_id> --overwrite`

7. re-run `python manage.py backpopulate_mitxonline_data` -> note that the contentfiles for that particular run are gone/removed.
8. re-run above steps on this branch and note that contentfiles for test_mode=True resources are persisted. 
9. You should also be able to manually set test_mode back to false and re-run the pipeline to see them get removed again
10. validate that test_mode=True resources do not show up in the search index http://open.odl.local:8063/api/v1/learning_resources_search/?id=<test resource id>


### Checklist:
- [ ] Validate this behaves as expected for test_mode=True and test_mode=False course
- [ ] go through the changes and make sure there are no unintended side effects or edge cases this could raise

