### PR TITLE
Feature flag syllabus chat for programs

### DIFF
--- a/frontends/main/src/common/feature_flags.ts
+++ b/frontends/main/src/common/feature_flags.ts
@@ -4,6 +4,7 @@
 export enum FeatureFlags {
   EnableEcommerce = "enable-ecommerce",
   LrDrawerChatbot = "lr-drawer-chatbot",
+  PrDrawerChatbot = "pr-drawer-chatbot",
   RecommendationBot = "recommendation-bot",
   HomePageRecommendationBot = "home-page-recommendation-bot",
   EnrollmentDashboard = "enrollment-dashboard",

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
@@ -240,7 +240,7 @@ describe("LearningResourceDrawer", () => {
       mockedUseFeatureFlagEnabled.mockReturnValue(true)
       const { resource } = setupApis({
         resource: {
-          // Chat is only enabled for courses
+          // Chat is only enabled for courses or programs
           resource_type: ResourceTypeEnum.Course,
         },
       })

--- a/frontends/main/src/page-components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
@@ -361,7 +361,7 @@ describe.each([true, false])(
     })
 
     test.each(RESOURCE_TYPES)(
-      "Chat button visible only on courses ($resourceType)",
+      "Chat button visible only on courses or programs ($resourceType)",
       ({ resourceType }) => {
         const resource = factories.learningResources.resource({
           resource_type: resourceType,

--- a/frontends/main/src/page-components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -143,9 +143,16 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
     initialChatExpanded ? ChatTransitionState.Open : ChatTransitionState.Closed,
   )
 
+  const LrDrawerChatbotEnabled = useFeatureFlagEnabled(
+    FeatureFlags.LrDrawerChatbot,
+  )
+  const PrDrawerChatbotEnabled = useFeatureFlagEnabled(
+    FeatureFlags.PrDrawerChatbot,
+  )
   const chatEnabled =
-    useFeatureFlagEnabled(FeatureFlags.LrDrawerChatbot) &&
-    (resource?.resource_type === ResourceTypeEnum.Course ||
+    (LrDrawerChatbotEnabled &&
+      resource?.resource_type === ResourceTypeEnum.Course) ||
+    (PrDrawerChatbotEnabled &&
       resource?.resource_type === ResourceTypeEnum.Program)
 
   useEffect(() => {

--- a/frontends/main/src/page-components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -143,16 +143,16 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
     initialChatExpanded ? ChatTransitionState.Open : ChatTransitionState.Closed,
   )
 
-  const LrDrawerChatbotEnabled = useFeatureFlagEnabled(
+  const learningResourceChatbotEnabled = useFeatureFlagEnabled(
     FeatureFlags.LrDrawerChatbot,
   )
-  const PrDrawerChatbotEnabled = useFeatureFlagEnabled(
+  const programChatbotEnabled = useFeatureFlagEnabled(
     FeatureFlags.PrDrawerChatbot,
   )
   const chatEnabled =
-    (LrDrawerChatbotEnabled &&
+    (learningResourceChatbotEnabled &&
       resource?.resource_type === ResourceTypeEnum.Course) ||
-    (PrDrawerChatbotEnabled &&
+    (programChatbotEnabled &&
       resource?.resource_type === ResourceTypeEnum.Program)
 
   useEffect(() => {


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Related to https://github.com/mitodl/hq/issues/7370
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR makes it so that the Syllabus chat for programs have a separate feature flag than the flag used for courses.


### How can this be tested?
1. Checkout this branch.
2. Note that the syllabus bot is disabled by default on program resource drawers
3. If you have a local posthob setup - enable/add a "pr-drawer-chatbot" - otherwise you can short-circuit it by manually setting programChatbotEnabled in LearningResourceExpanded.tsx to true
4. note that the chatbot is visible.
