### PR TITLE
Use the org slug in the URL instead of the ID

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/DashboardLayout.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/DashboardLayout.tsx
@@ -267,8 +267,8 @@ const getTabData = (
       },
     },
     ...orgs.map((org) => ({
-      value: organizationView(org.id),
-      href: organizationView(org.id),
+      value: organizationView(org.slug.replace("org-", "")),
+      href: organizationView(org.slug.replace("org-", "")),
       label: {
         mobile: org.name,
         desktop: <DesktopTabLabel icon={<RiBuilding2Line />} text={org.name} />,
@@ -315,7 +315,7 @@ const DashboardPage: React.FC<{
   const tabData = useMemo(
     () =>
       isLoadingMitxOnlineUser ? [] : getTabData(orgsEnabled, mitxOnlineUser),
-    [isLoadingMitxOnlineUser, mitxOnlineUser],
+    [isLoadingMitxOnlineUser, orgsEnabled, mitxOnlineUser],
   )
 
   const tabValue = useMemo(() => {

--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.test.tsx
@@ -28,7 +28,7 @@ describe("OrganizationContent", () => {
     const { orgX, programA, programB, coursesA, coursesB } =
       setupProgramsAndCourses()
     setMockResponse.get(urls.enrollment.courseEnrollment({}), [])
-    renderWithProviders(<OrganizationContent orgId={orgX.id} />)
+    renderWithProviders(<OrganizationContent orgSlug={orgX.slug} />)
 
     await screen.findByRole("heading", {
       name: `Your ${orgX.name} Home`,
@@ -61,7 +61,7 @@ describe("OrganizationContent", () => {
       }),
     ]
     setMockResponse.get(urls.enrollment.courseEnrollment({}), enrollments)
-    renderWithProviders(<OrganizationContent orgId={orgX.id} />)
+    renderWithProviders(<OrganizationContent orgSlug={orgX.slug} />)
 
     const [programElA] = await screen.findAllByTestId("org-program-root")
     const cards = await within(programElA).findAllByTestId(

--- a/frontends/main/src/app/dashboard/organization/[slug]/page.tsx
+++ b/frontends/main/src/app/dashboard/organization/[slug]/page.tsx
@@ -3,12 +3,12 @@ import OrganizationContent from "@/app-pages/DashboardPage/OrganizationContent"
 import { PageParams } from "@/app/types"
 import invariant from "tiny-invariant"
 
-const Page: React.FC<PageParams<object, { id: string }>> = async ({
+const Page: React.FC<PageParams<object, { slug: string }>> = async ({
   params,
 }) => {
   const resolved = await params
-  invariant(resolved?.id, "id is required")
-  return <OrganizationContent orgId={Number(resolved.id)} />
+  invariant(resolved?.slug, "slug is required")
+  return <OrganizationContent orgSlug={resolved?.slug} />
 }
 
 export default Page

--- a/frontends/main/src/common/urls.ts
+++ b/frontends/main/src/common/urls.ts
@@ -95,9 +95,9 @@ export const SETTINGS = dashboardView("settings")
 export const USERLIST_VIEW = "/dashboard/my-lists/[id]"
 export const userListView = (id: number) =>
   generatePath(USERLIST_VIEW, { id: String(id) })
-export const ORGANIZATION_VIEW = "/dashboard/organization/[id]"
-export const organizationView = (id: number) =>
-  generatePath(ORGANIZATION_VIEW, { id: String(id) })
+export const ORGANIZATION_VIEW = "/dashboard/organization/[slug]"
+export const organizationView = (slug: string) =>
+  generatePath(ORGANIZATION_VIEW, { slug: slug })
 
 export const SEARCH = "/search"
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7324

### Description (What does it do?)
This PR moves the organization dashboard pages to use a URL scheme using the org's slug property instead of the ID.

### How can this be tested?
In order to test this, you need a basic installation of `mitxonline` up and running with example data in it. You may be able to skip one or more steps if you have already done them:
- Ensure you have local `hosts` redirects for the following domains, replacing the example IP with your __local__ IP address (Google how to get this if unsure, mine is 192.168.1.50)
```
192.168.1.50 open.odl.local
192.168.1.50 api.open.odl.local
192.168.1.50 kc.ol.local
192.168.1.50 learn.odl.local
192.168.1.50 mitxonline.odl.local
```
- Clone `mitxonline`: https://github.com/mitodl/mitxonline
- Create a `.env` file with the following values:
```
COMPOSE_PROFILES=apisix
CELERY_TASK_ALWAYS_EAGER=True
DJANGO_LOG_LEVEL=INFO
LOG_LEVEL=INFO
SENTRY_LOG_LEVEL=ERROR
MAILGUN_KEY=fake
MAILGUN_URL=
MAILGUN_RECIPIENT_OVERRIDE=
MAILGUN_SENDER_DOMAIN=mitxonline.odl.local
SECRET_KEY=
STATUS_TOKEN=
UWSGI_THREADS=5
SENTRY_DSN=
MITX_ONLINE_BASE_URL=http://learn.odl.local:8065/mitxonline
MITX_ONLINE_ADMIN_CLIENT_ID=refine-local-client-id
MITX_ONLINE_ADMIN_BASE_URL=http://mitxonline.odl.local:8016
POSTHOG_PROJECT_API_KEY=
POSTHOG_API_HOST=https://app.posthog.com/
HUBSPOT_HOME_PAGE_FORM_GUID=
HUBSPOT_PORTAL_ID=
APISIX_PORT=9080

# APISIX/Keycloak settings
APISIX_LOGOUT_URL=http://api.open.odl.local:8065/logout/
APISIX_SESSION_SECRET_KEY=supertopsecret1234
KC_SPI_THEME_WELCOME_THEME=scim
KC_SPI_REALM_RESTAPI_EXTENSION_SCIM_LICENSE_KEY=
KEYCLOAK_BASE_URL=http://kc.ol.local:8066
KEYCLOAK_CLIENT_ID=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
KEYCLOAK_CLIENT_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
KEYCLOAK_DISCOVERY_URL=http://kc.ol.local:8066/realms/ol-local/.well-known/openid-configuration
KEYCLOAK_REALM_NAME=ol-local
KEYCLOAK_SCOPES="openid profile ol-profile"
KEYCLOAK_SVC_KEYSTORE_PASSWORD=supertopsecret1234
KEYCLOAK_SVC_HOSTNAME=kc.ol.local
KEYCLOAK_SVC_ADMIN=admin
KEYCLOAK_SVC_ADMIN_PASSWORD=admin
AUTHORIZATION_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/auth
ACCESS_TOKEN_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/token
OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_KEY=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
SOCIAL_AUTH_OL_OIDC_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
USERINFO_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/userinfo
MITOL_APIGATEWAY_DISABLE_MIDDLEWARE=False

FEATURE_IGNORE_EDX_FAILURES=True
OPENEDX_API_CLIENT_ID=fake
OPENEDX_API_CLIENT_SECRET=fake
OPENEDX_SERVICE_WORKER_API_TOKEN=fake

CSRF_COOKIE_DOMAIN=.odl.local
CORS_ALLOWED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
CSRF_TRUSTED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
```
- Spin up `mitxonline` with `docker compose up --build -d`
- Promote the admin user with `docker compose exec web ./manage.py promote_user --promote --superuser admin@odl.local`
- Populate test course data with `docker compose exec web ./manage.py populate_course_data`
- Generate docs with `pants docs ::`
- In `dist/sphinx/index.html`, read the section on generating a B2B organization / contract and create one, adding some of the test courses to it
- In Django admin, create a `Program` and add some courses to the program that are included in your B2B org, making sure to mark the program as "live"
- In the MITx Online Dashboard, enroll the test admin user in the courses you put in your B2B org, making sure you select the course runs generated by the org
- Make sure you have a personal Posthog project configured and have the API key at the ready
- Before we spin up `mit-learn`, we need to set some env variables:
```
.env
...
MITX_ONLINE_UPSTREAM=mitxonline.odl.local:8013
MITX_ONLINE_DOMAIN=mitxonline.odl.local
MITX_ONLINE_BASE_URL=http://mitxonline.odl.local:8065
POSTHOG_ENABLED=True

shared.local.env
POSTHOG_PROJECT_API_KEY=YOUR_API_KEY_HERE
POSTHOG_PROJECT_ID=YOUR_PROJECT_ID_HERE
POSTHOG_TIMEOUT_MS=1500
```
- In your Posthog project, enable the `enrollment-dashboard` and `mitlearn-organization-dashboard` feature flags for all users
- Spin up `MIT Learn`
- Log in with the `admin@odl.local` test user
- Verify that you see a tab for the organization you created on the left and click it
- Verify that the URL you are navigated to has the org's slug (minus the `org-` prefix) at the end of the URL instead of the integer ID
- Verify that you see the courses you added to your org
