### PR TITLE
dialing back get youtube data task

### DIFF
--- a/main/settings_celery.py
+++ b/main/settings_celery.py
@@ -81,8 +81,8 @@ CELERY_BEAT_SCHEDULE = {
     "update-youtube-videos": {
         "task": "learning_resources.tasks.get_youtube_data",
         "schedule": get_int(
-            "YOUTUBE_FETCH_SCHEDULE_SECONDS", 60 * 30
-        ),  # default is every 30 minutes
+            "YOUTUBE_FETCH_SCHEDULE_SECONDS", 60 * 30 * 4
+        ),  # default is every 4 hours
     },
     "update-youtube-transcripts": {
         "task": "learning_resources.tasks.get_youtube_transcripts",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/7487
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR dials back the get youtube data task from 30 minutes to 4 hours

### How can this be tested?
Verify the schedule in celery_settings.py and make sure it is set to 4 hours.

### Additional Context
This was a change that was previously in place but appears to have been reverted at some point.
