### PR TITLE
Allow files from multiple course runs to be indexed

### DIFF
--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -801,7 +801,7 @@ def load_content_files(
 
         if calc_completeness:
             calculate_completeness(course_run, content_tags=content_tags)
-        content_files_loaded_actions(run=course_run, deindex_only=False)
+        content_files_loaded_actions(run=course_run)
 
         return content_files_ids
     return None

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -967,22 +967,19 @@ def test_load_programs(mocker, mock_blocklist, mock_duplicates):
 
 
 @pytest.mark.parametrize("is_published", [True, False])
-@pytest.mark.parametrize("extra_run", [True, False])
 @pytest.mark.parametrize("calc_score", [True, False])
-def test_load_content_files(mocker, is_published, extra_run, calc_score):
+def test_load_content_files(mocker, is_published, calc_score):
     """Test that load_content_files calls the expected functions"""
     course = LearningResourceFactory.create(is_course=True, create_runs=False)
     course_run = LearningResourceRunFactory.create(
         published=is_published, learning_resource=course
     )
-    if extra_run:
-        LearningResourceRunFactory.create(
-            published=is_published,
-            learning_resource=course,
-            start_date=now_in_utc() - timedelta(days=365),
-        )
-    run_count = 2 if extra_run else 1
-    assert course.runs.count() == run_count
+    LearningResourceRunFactory.create(
+        published=is_published,
+        learning_resource=course,
+        start_date=now_in_utc() - timedelta(days=365),
+    )
+    assert course.runs.count() == 2
 
     deleted_content_file = ContentFileFactory.create(run=course_run)
     returned_content_file_id = deleted_content_file.id + 1
@@ -1011,9 +1008,7 @@ def test_load_content_files(mocker, is_published, extra_run, calc_score):
     load_content_files(course_run, content_data, calc_completeness=calc_score)
     assert mock_load_content_file.call_count == len(content_data)
     assert mock_bulk_index.call_count == (1 if is_published else 0)
-    assert mock_bulk_delete.call_count == (
-        run_count if not is_published else run_count - 1
-    )
+    assert mock_bulk_delete.call_count == 0 if is_published else 1
     assert mock_calc_score.call_count == (1 if calc_score else 0)
     deleted_content_file.refresh_from_db()
     assert not deleted_content_file.published
@@ -1044,10 +1039,6 @@ def test_load_test_mode_resource_content_files(
         "learning_resources.etl.edx_shared.load_content_files",
         autospec=True,
         return_value=[],
-    )
-
-    mocker.patch(
-        "learning_resources.etl.edx_shared.content_files_loaded_actions",
     )
     mocker.patch(
         "learning_resources_search.plugins.tasks.deindex_run_content_files",

--- a/learning_resources/hooks.py
+++ b/learning_resources/hooks.py
@@ -81,7 +81,7 @@ class LearningResourceHooks:
         """Trigger actions to delete a learning resource offeror"""
 
     @hookspec
-    def content_files_loaded(self, run, deindex_only):
+    def content_files_loaded(self, run):
         """Trigger actions after content files are loaded for a run"""
 
 

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -322,13 +322,13 @@ def bulk_resources_unpublished_actions(resource_ids: list[int], resource_type: s
     )
 
 
-def content_files_loaded_actions(run: LearningResourceRun, deindex_only):
+def content_files_loaded_actions(run: LearningResourceRun):
     """
     Trigger plugins when content files are loaded for a LearningResourceRun
     """
     pm = get_plugin_manager()
     hook = pm.hook
-    hook.content_files_loaded(run=run, deindex_only=deindex_only)
+    hook.content_files_loaded(run=run)
 
 
 def resource_run_unpublished_actions(run: LearningResourceRun):


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/7505

### Description (What does it do?)
This pr updates the etl to import content files from multiple runs

### How can this be tested?
1. run `docker-compose run web ./manage.py backpopulate_mitxonline_data`
2. find the resource id for "Paradox and Infinity"
3. run `docker-compose run web ./manage.py backpopulate_mitxonline_files --resource-ids=the_id_from_step_2 --overwrite`
4. Check that you have content files from multiple runs from that resource with
`ContentFile.objects.filter(run__learning_resource_id=the_id_from_step_2).values('run_learning_resource_id').annotate(Count('run_id', distinct=True))`
5. Verify that search and the learning_resource apis work correctly
