### PR TITLE
About page copy edit - add missing space

### DIFF
--- a/frontends/main/src/app-pages/AboutPage/AboutPage.tsx
+++ b/frontends/main/src/app-pages/AboutPage/AboutPage.tsx
@@ -191,7 +191,7 @@ const AboutPage: React.FC = () => {
               of MIT's non-degree learning resources. This includes courses,
               programs, and various educational materials from different MIT
               units such as MIT Open Learning — including MITx, MIT
-              OpenCourseWare, and MIT xPRO — MIT Professional Education,MIT
+              OpenCourseWare, and MIT xPRO — MIT Professional Education, MIT
               Sloan Executive Education, and other departments across the
               Institute.
             </Typography>


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/7448

### Description (What does it do?)
Adds a missing space before "and" on the about page

### How can this be tested?
Validate this copy change and reference https://github.com/mitodl/hq/issues/7448 to make sure anything else has not been missed.
