### PR TITLE
Design QA

### DIFF
--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^11.11.0",
     "@mitodl/course-search-utils": "3.3.2",
     "@mitodl/mitxonline-api-axios": "^2025.6.3",
-    "@mitodl/smoot-design": "0.0.0-0a23f44",
+    "@mitodl/smoot-design": "^6.10.0",
     "@next/bundle-analyzer": "^14.2.15",
     "@remixicon/react": "^4.2.0",
     "@sentry/nextjs": "^9.0.0",

--- a/frontends/main/src/app-pages/DepartmentListingPage/DepartmentListingPage.tsx
+++ b/frontends/main/src/app-pages/DepartmentListingPage/DepartmentListingPage.tsx
@@ -9,7 +9,7 @@ import {
   ListItem,
   ListItemLink,
   ListItemText,
-  Grid,
+  Grid2 as Grid,
   Banner,
   Breadcrumbs,
 } from "ol-components"
@@ -186,15 +186,6 @@ const SchoolDepartments: React.FC<SchoolDepartmentProps> = ({
   )
 }
 
-const SchoolList = styled.div(({ theme }) => ({
-  "> section": {
-    marginTop: "40px",
-    [theme.breakpoints.down("sm")]: {
-      marginTop: "30px",
-    },
-  },
-}))
-
 const DepartmentListingPage: React.FC = () => {
   const channelCountQuery = useChannelCounts("department")
   const courseCounts = channelCountQuery.data
@@ -222,19 +213,28 @@ const DepartmentListingPage: React.FC = () => {
       />
       <Container>
         <Grid container>
-          <Grid item xs={0} sm={1}></Grid>
-          <Grid item xs={12} sm={10}>
-            <SchoolList>
-              {schoolsQuery.data?.results?.map((school) => (
-                <SchoolDepartments
-                  as="li"
-                  key={school.id}
-                  school={school}
-                  courseCounts={courseCounts}
-                  programCounts={programCounts}
-                />
-              ))}
-            </SchoolList>
+          <Grid
+            size={{ xs: 12, sm: 10 }}
+            offset={{ xs: 0, sm: 1 }}
+            sx={(theme) => ({
+              display: "flex",
+              flexDirection: "column",
+              gap: "40px",
+              margin: "80px 0",
+              [theme.breakpoints.down("sm")]: {
+                margin: "20px 0",
+                gap: "30px",
+              },
+            })}
+          >
+            {schoolsQuery.data?.results?.map((school) => (
+              <SchoolDepartments
+                key={school.id}
+                school={school}
+                courseCounts={courseCounts}
+                programCounts={programCounts}
+              />
+            ))}
           </Grid>
         </Grid>
       </Container>

--- a/frontends/main/src/app-pages/DepartmentListingPage/DepartmentListingPage.tsx
+++ b/frontends/main/src/app-pages/DepartmentListingPage/DepartmentListingPage.tsx
@@ -47,6 +47,7 @@ const SCHOOL_ICONS: Record<string, React.ReactNode> = {
 const SchoolTitle = styled.h2(({ theme }) => {
   return {
     marginBottom: "10px",
+    marginTop: "0",
     display: "flex",
     alignItems: "center",
     ...theme.typography.h5,

--- a/frontends/main/src/app-pages/TopicsListingPage/TopicsListingPage.tsx
+++ b/frontends/main/src/app-pages/TopicsListingPage/TopicsListingPage.tsx
@@ -269,7 +269,7 @@ const groupTopics = (
 }
 
 const RootTopicList = styled(PlainList)(({ theme }) => ({
-  "> li": {
+  "> li:not(:last-of-type)": {
     paddingBottom: "32px",
   },
   "> li + li": {

--- a/frontends/main/src/app-pages/TopicsListingPage/TopicsListingPage.tsx
+++ b/frontends/main/src/app-pages/TopicsListingPage/TopicsListingPage.tsx
@@ -5,7 +5,7 @@ import {
   Container,
   Typography,
   styled,
-  Grid,
+  Grid2 as Grid,
   PlainList,
   ChipLink,
   linkStyles,
@@ -269,10 +269,6 @@ const groupTopics = (
 }
 
 const RootTopicList = styled(PlainList)(({ theme }) => ({
-  marginTop: "80px",
-  [theme.breakpoints.down("sm")]: {
-    marginTop: "32px",
-  },
   "> li": {
     paddingBottom: "32px",
   },
@@ -316,8 +312,16 @@ const TopicsListingPage: React.FC = () => {
       />
       <Container>
         <Grid container>
-          <Grid item xs={0} sm={1}></Grid>
-          <Grid item xs={12} sm={10}>
+          <Grid
+            size={{ xs: 12, sm: 10 }}
+            offset={{ xs: 0, sm: 1 }}
+            sx={(theme) => ({
+              margin: "80px 0",
+              [theme.breakpoints.down("sm")]: {
+                margin: "32px 0",
+              },
+            })}
+          >
             <RootTopicList>
               {topicsQuery.isLoading
                 ? Array(10)

--- a/frontends/main/src/app-pages/UnitsListingPage/UnitCard.tsx
+++ b/frontends/main/src/app-pages/UnitsListingPage/UnitCard.tsx
@@ -29,7 +29,7 @@ const LogoContainer = styled.div({
   padding: "40px 32px",
   backgroundColor: theme.custom.colors.white,
   [theme.breakpoints.down("md")]: {
-    padding: "34px 0 14px",
+    padding: "24px 16px",
     ".MuiSkeleton-root": {
       margin: "0 auto",
     },

--- a/frontends/main/src/app-pages/UnitsListingPage/UnitCard.tsx
+++ b/frontends/main/src/app-pages/UnitsListingPage/UnitCard.tsx
@@ -1,14 +1,7 @@
 import React from "react"
 import type { OfferedByEnum } from "api"
 import type { UnitChannel } from "api/v0"
-import {
-  Card,
-  Skeleton,
-  Typography,
-  styled,
-  theme,
-  UnitLogo,
-} from "ol-components"
+import { Card, Skeleton, styled, theme, UnitLogo } from "ol-components"
 import Link from "next/link"
 import { usePostHog } from "posthog-js/react"
 import { PostHogEvents } from "@/common/constants"
@@ -23,9 +16,6 @@ const UnitCardContainer = styled.div({
   alignItems: "center",
   height: "100%",
   backgroundColor: "rgba(243, 244, 248, 0.50)",
-  [theme.breakpoints.down("md")]: {
-    backgroundColor: theme.custom.colors.white,
-  },
 })
 
 const UnitCardContent = styled.div({
@@ -50,6 +40,7 @@ const LogoContainer = styled.div({
       height: "40px",
       margin: "0 auto",
     },
+    maxWidth: "calc(100% - 32px)",
   },
 })
 
@@ -59,49 +50,24 @@ const CardBottom = styled.div({
   display: "flex",
   flexGrow: 1,
   flexDirection: "column",
+  justifyContent: "space-between",
   gap: "24px",
+  ...theme.typography.body1,
   [theme.breakpoints.down("md")]: {
+    ...theme.typography.body2,
     padding: "16px",
-    gap: "10px",
-    borderTop: "none",
+    gap: "16px",
   },
-})
-
-const ValuePropContainer = styled.div({
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "flex-start",
-  justifyContent: "flex-start",
-  flexGrow: 1,
-  paddingBottom: "16px",
 })
 
 const LoadingContent = styled.div({
   padding: "24px",
 })
 
-const HeadingText = styled.span(({ theme }) => ({
-  alignSelf: "stretch",
-  color: theme.custom.colors.darkGray2,
-  ...theme.typography.body2,
-}))
-
 const CountsTextContainer = styled.div({
   display: "flex",
   gap: "10px",
-  [theme.breakpoints.down("md")]: {
-    justifyContent: "flex-end",
-  },
 })
-
-const CountsText = styled(Typography)(({ theme }) => ({
-  color: theme.custom.colors.darkGray2,
-  ...theme.typography.body2,
-  [theme.breakpoints.down("md")]: {
-    ...theme.typography.body3,
-    color: theme.custom.colors.silverGrayDark,
-  },
-}))
 
 interface UnitCardsProps {
   channels: UnitChannel[] | undefined
@@ -144,16 +110,14 @@ const UnitCard: React.FC<UnitCardProps> = (props) => {
               </Link>
             </LogoContainer>
             <CardBottom>
-              <ValuePropContainer>
-                <HeadingText>{channel?.configuration?.heading}</HeadingText>
-              </ValuePropContainer>
+              {channel?.configuration?.heading}
               <CountsTextContainer>
-                <CountsText data-testid={`course-count-${unit.code}`}>
+                <span data-testid={`course-count-${unit.code}`}>
                   {courseCount > 0 ? `Courses: ${courseCount}` : ""}
-                </CountsText>
-                <CountsText data-testid={`program-count-${unit.code}`}>
+                </span>
+                <span data-testid={`program-count-${unit.code}`}>
                   {programCount > 0 ? `Programs: ${programCount}` : ""}
-                </CountsText>
+                </span>
               </CountsTextContainer>
             </CardBottom>
           </UnitCardContent>

--- a/frontends/main/src/page-components/Header/Header.tsx
+++ b/frontends/main/src/page-components/Header/Header.tsx
@@ -14,9 +14,9 @@ import {
   RiVerifiedBadgeLine,
   RiFileAddLine,
   RiTimeLine,
-  RiHeartLine,
   RiPriceTag3Line,
   RiAwardLine,
+  RiThumbUpLine,
 } from "@remixicon/react"
 import { useToggle } from "ol-utilities"
 import MITLogoLink from "@/components/MITLogoLink/MITLogoLink"
@@ -242,16 +242,16 @@ const navData: NavData = {
           posthogEvent: PostHogEvents.ClickedNavBrowseNew,
         },
         {
+          title: "Popular",
+          href: SEARCH_POPULAR,
+          icon: <RiThumbUpLine />,
+          posthogEvent: PostHogEvents.ClickedNavBrowsePopular,
+        },
+        {
           title: "Upcoming",
           icon: <RiTimeLine />,
           href: SEARCH_UPCOMING,
           posthogEvent: PostHogEvents.ClickedNavBrowseUpcoming,
-        },
-        {
-          title: "Popular",
-          href: SEARCH_POPULAR,
-          icon: <RiHeartLine />,
-          posthogEvent: PostHogEvents.ClickedNavBrowsePopular,
         },
         {
           title: "Free",

--- a/frontends/main/src/page-components/HeroSearch/HeroSearch.tsx
+++ b/frontends/main/src/page-components/HeroSearch/HeroSearch.tsx
@@ -24,10 +24,10 @@ import {
 import {
   RiAwardLine,
   RiFileAddLine,
+  RiPriceTag3Line,
   RiSearch2Line,
   RiThumbUpLine,
   RiTimeLine,
-  RiVerifiedBadgeLine,
 } from "@remixicon/react"
 import Image from "next/image"
 import { SearchField } from "@/page-components/SearchField/SearchField"
@@ -63,7 +63,7 @@ const SEARCH_CHIPS: SearchChip[] = [
     label: "Free",
     href: SEARCH_FREE,
     variant: "outlinedWhite",
-    icon: <RiVerifiedBadgeLine />,
+    icon: <RiPriceTag3Line />,
   },
   {
     label: "With Certificate",

--- a/frontends/main/src/page-components/SearchDisplay/ProfessionalToggle.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/ProfessionalToggle.tsx
@@ -12,10 +12,7 @@ const StyledToggleButtonGroup = styled(ToggleButtonGroup)`
   height: 40px;
   border-radius: 4px;
 `
-const StyledButtonGroupContainer = styled.div`
-  margin-top: 10px;
-  margin-bottom: 10px;
-`
+
 const ExplanationContainer = styled.div`
   margin: 10px;
   font-size: 0.875em;
@@ -88,7 +85,7 @@ const ProfessionalToggle: React.FC<{
   }
 
   return (
-    <StyledButtonGroupContainer>
+    <div>
       <StyledToggleButtonGroup
         value={professionalSetting}
         exclusive
@@ -117,7 +114,7 @@ const ProfessionalToggle: React.FC<{
           Content developed from MIT's professional curriculum
         </ExplanationContainer>
       </Collapse>
-    </StyledButtonGroupContainer>
+    </div>
   )
 }
 

--- a/frontends/main/src/page-components/SearchDisplay/ProfessionalToggle.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/ProfessionalToggle.tsx
@@ -47,17 +47,40 @@ const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
     backgroundColor: theme.custom.colors.white,
   },
   ...theme.typography.subtitle3,
+
+  // MUI's ToggleButtonGroup have a -1 margin offset that caused problems for our borders.
+  "&.MuiToggleButtonGroup-middleButton, .MuiToggleButtonGroup-lastButton": {
+    margin: 0,
+  },
+  /**
+   * The goal here is to ensure the icons:
+   * - scale at same rate when container shrinks
+   * - are hidden if container is too small
+   *
+   * NOTE: containerType: size enables the container query but requires setting
+   * a width on the container. We are doing this anyway.
+   */
+  containerType: "size",
+  boxSizing: "border-box",
+  "& > span": {
+    minWidth: "70px",
+  },
+  "@container (max-width: 85px)": {
+    "& > svg": {
+      display: "none",
+    },
+  },
 }))
 
 const ViewAllButton = styled(StyledToggleButton)`
-  border-right: 2px solid;
+  border-right: 1px solid;
   border-color: ${({ theme }) => theme.custom.colors.silverGrayLight};
   width: 20%;
   border-top-left-radius: 4px;
   border-bottom-left-radius: 4px;
 `
 const AcademicButton = styled(StyledToggleButton)`
-  border-right: 2px solid;
+  border-right: 1px solid;
   border-color: ${({ theme }) => theme.custom.colors.silverGrayLight};
   width: 40%;
 `
@@ -93,10 +116,10 @@ const ProfessionalToggle: React.FC<{
       >
         <ViewAllButton value="">All</ViewAllButton>
         <AcademicButton value="false">
-          <StyledRiBookOpenLine /> Academic
+          <StyledRiBookOpenLine /> <span>Academic</span>
         </AcademicButton>
         <ProfesionalButton value="true">
-          <StyledRiBriefcase3Line /> Professional
+          <StyledRiBriefcase3Line /> <span>Professional</span>
         </ProfesionalButton>
       </StyledToggleButtonGroup>
       <Collapse in={professionalSetting === ""}>

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -147,15 +147,6 @@ const FacetStyles = styled.div`
     }
   }
 
-  .facet-visible {
-    margin-top: 6px;
-    margin-bottom: 6px;
-  }
-
-  .facet-visible:last-child {
-    margin-bottom: 8px;
-  }
-
   .facet-list {
     margin-bottom: 8px;
   }
@@ -192,6 +183,12 @@ const FacetStyles = styled.div`
       font-size: 0.875em;
       gap: 4px;
       margin-left: -2px;
+      margin-top: 6px;
+      margin-bottom: 6px;
+
+      &:last-child {
+        margin-bottom: 8px;
+      }
 
       input,
       .facet-label {
@@ -286,16 +283,20 @@ const FacetStyles = styled.div`
     width: 100%;
   }
 
-  .multi-facet-group {
+  .facets.multi-facet-group {
     background: white;
     margin-top: 8px;
     margin-bottom: 8px;
     border-radius: 8px;
     border-bottom: solid 1px ${({ theme }) => theme.custom.colors.lightGray2};
+    padding-top: 12px;
     padding-bottom: 12px;
-    padding-top: 5px;
 
-    /* stylelint-disable no-descending-specificity */
+    .facet-visible {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+
     .facet-visible .facet-label {
       .facet-text,
       .facet-count {
@@ -304,7 +305,6 @@ const FacetStyles = styled.div`
 
       margin-bottom: 0;
     }
-    /* stylelint-enable no-descending-specificity */
   }
 `
 

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -103,6 +103,8 @@ const FacetStyles = styled.div`
     margin-bottom: 16px;
     margin-top: 12px;
     border-radius: 4px;
+    color: ${({ theme }) => theme.custom.colors.darkGray2};
+    ${({ theme }) => css({ ...theme.typography.body2 })}
 
     &:focus-visible {
       outline: solid 2px ${({ theme }) => theme.custom.colors.darkGray2};

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -11,6 +11,7 @@ import {
   css,
   Drawer,
   Stack,
+  Grid2 as Grid,
 } from "ol-components"
 import {
   Button,
@@ -35,7 +36,6 @@ import {
 } from "api"
 import { useLearningResourcesSearch } from "api/hooks/learningResources"
 import { useAdminSearchParams } from "api/hooks/adminSearchParams"
-import { GridColumn, GridContainer } from "@/components/GridLayout/GridLayout"
 import {
   AvailableFacets,
   UseResourceSearchParamsProps,
@@ -367,30 +367,6 @@ const StyledResultsContainer = styled.div<{ fetching: boolean }>(
   }),
 )
 
-const DesktopFiltersColumn = styled(GridColumn)`
-  ${({ theme }) => theme.breakpoints.down("md")} {
-    display: none;
-  }
-
-  padding-left: 0 !important;
-  padding-right: 18px !important;
-  padding-bottom: 25px;
-`
-
-const StyledMainColumn = styled(GridColumn)`
-  ${({ theme }) => theme.breakpoints.up("md")} {
-    padding-left: 6px !important;
-    padding-right: 0 !important;
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-  }
-
-  ${({ theme }) => theme.breakpoints.down("md")} {
-    padding-left: 0 !important;
-  }
-`
-
 const MobileFilter = styled.div`
   ${({ theme }) => theme.breakpoints.up("md")} {
     display: none;
@@ -449,19 +425,6 @@ const MobileFacetsTitleContainer = styled.div`
     margin-right: 10px;
     padding: 10px;
   }
-`
-
-const ReversedGridContainer = styled(GridContainer)`
-  max-width: 1272px !important;
-  margin-left: 0 !important;
-  width: 100% !important;
-
-  /**
-  We want the facets to be visually on left, but occur second in the DOM / tab
-  order. This makes it easier for keyboard navigators to get directly to the
-  search results.
-  */
-  flex-direction: row-reverse;
 `
 
 const ExplanationContainer = styled.div`
@@ -859,9 +822,17 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
 
   return (
     <Container>
-      <ReversedGridContainer>
+      <Grid container columnSpacing="24px" flexDirection="row-reverse">
         <ResourceCategoryTabs.Context activeTabName={activeTab.name}>
-          <StyledMainColumn component="section" variant="main-2">
+          <Grid
+            component="section"
+            size={{ xs: 12, md: 9 }}
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "16px",
+            }}
+          >
             <VisuallyHidden as={resultsHeadingEl}>
               Search Results
             </VisuallyHidden>
@@ -984,10 +955,15 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                 />
               </PaginationContainer>
             </ResourceCategoryTabs.TabPanels>
-          </StyledMainColumn>
-          <DesktopFiltersColumn
+          </Grid>
+          <Grid
             component="section"
-            variant="sidebar-2"
+            size={{ xs: 12, md: 3 }}
+            sx={(theme) => ({
+              [theme.breakpoints.down("md")]: {
+                display: "none",
+              },
+            })}
             data-testid="facets-container"
           >
             <FacetsTitleContainer>
@@ -1009,9 +985,9 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
               ) : null}
             </FacetsTitleContainer>
             {filterContents}
-          </DesktopFiltersColumn>
+          </Grid>
         </ResourceCategoryTabs.Context>
-      </ReversedGridContainer>
+      </Grid>
     </Container>
   )
 }

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -355,8 +355,6 @@ const PaginationContainer = styled.div`
 
 const StyledResultsContainer = styled.div<{ fetching: boolean }>(
   ({ fetching }) => ({
-    marginTop: "16px",
-
     "ul > li + li": {
       marginTop: "8px",
     },
@@ -379,6 +377,9 @@ const StyledMainColumn = styled(GridColumn)`
   ${({ theme }) => theme.breakpoints.up("md")} {
     padding-left: 6px !important;
     padding-right: 0 !important;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
   }
 
   ${({ theme }) => theme.breakpoints.down("md")} {
@@ -393,15 +394,12 @@ const MobileFilter = styled.div`
 
   color: ${({ theme }) => theme.custom.colors.darkGray2};
   margin-top: 20px;
-
-  button {
-    svg {
-      margin-left: 8px;
-    }
-
-    margin-bottom: 10px;
-  }
+  margin-bottom: 16px;
 `
+const FilterButton = styled(Button)({
+  marginLeft: "-8px",
+  minWidth: 0,
+})
 
 const StyledDrawer = styled(Drawer)`
   .MuiPaper-root {
@@ -886,10 +884,14 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
             </Stack>
             <ResourceCategoryTabs.TabPanels tabs={TABS}>
               <MobileFilter>
-                <Button variant="text" onClick={toggleMobileDrawer(true)}>
-                  <Typography variant="subtitle1">Filter</Typography>
-                  <RiEqualizerLine fontSize="medium" />
-                </Button>
+                <FilterButton
+                  size="small"
+                  variant="text"
+                  startIcon={<RiEqualizerLine />}
+                  onClick={toggleMobileDrawer(true)}
+                >
+                  Filter
+                </FilterButton>
 
                 <StyledDrawer
                   anchor="left"

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -80,6 +80,8 @@ const SearchModeDropdownContainer = styled.div`
 `
 
 const FacetStyles = styled.div`
+  margin-top: 8px;
+
   div.facets:last-child {
     border-bottom-right-radius: 8px;
     border-bottom-left-radius: 8px;
@@ -834,25 +836,23 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   }
 
   const filterContents = (
-    <>
-      <FacetStyles>
-        {showProfessionalToggle && (
-          <ProfessionalToggle
-            professionalSetting={requestParams.professional}
-            setParamValue={setParamValue}
-          />
-        )}
-        <AvailableFacets
-          facetManifest={facetManifest}
-          activeFacets={requestParams}
-          onFacetChange={toggleParamValue}
-          facetOptions={data?.metadata.aggregations ?? {}}
+    <FacetStyles>
+      {showProfessionalToggle && (
+        <ProfessionalToggle
+          professionalSetting={requestParams.professional}
+          setParamValue={setParamValue}
         />
-        {user?.is_learning_path_editor
-          ? AdminOptions(expandAdminOptions, setExpandAdminOptions, adminParams)
-          : null}
-      </FacetStyles>
-    </>
+      )}
+      <AvailableFacets
+        facetManifest={facetManifest}
+        activeFacets={requestParams}
+        onFacetChange={toggleParamValue}
+        facetOptions={data?.metadata.aggregations ?? {}}
+      />
+      {user?.is_learning_path_editor
+        ? AdminOptions(expandAdminOptions, setExpandAdminOptions, adminParams)
+        : null}
+    </FacetStyles>
   )
 
   return (

--- a/frontends/main/src/page-components/UserListCard/UserListCardCondensed.tsx
+++ b/frontends/main/src/page-components/UserListCard/UserListCardCondensed.tsx
@@ -29,10 +29,17 @@ const ItemsText = styled(Typography)(({ theme }) => ({
 const IconContainer = styled.div(({ theme }) => ({
   display: "flex",
   alignItems: "center",
+  justifyContent: "center",
   gap: "8px",
   borderRadius: "4px",
   color: theme.custom.colors.silverGrayDark,
   background: theme.custom.colors.lightGray1,
+  width: "48px",
+  height: "48px",
+  svg: {
+    width: "32px",
+    height: "32px",
+  },
   [theme.breakpoints.down("sm")]: {
     display: "none",
   },
@@ -66,7 +73,7 @@ const UserListCardCondensed = ({
           </ItemsText>
         </TextContainer>
         <IconContainer>
-          <RiListCheck3 size="48" />
+          <RiListCheck3 />
         </IconContainer>
       </ListCardCondensed.Content>
     </StyledCard>

--- a/frontends/ol-components/src/components/Card/ListCard.tsx
+++ b/frontends/ol-components/src/components/Card/ListCard.tsx
@@ -96,7 +96,7 @@ export const Title: React.FC<TitleProps> = styled(Linkable)`
   ${{ ...theme.typography.subtitle1 }}
   height: ${theme.typography.pxToRem(40)};
   ${theme.breakpoints.down("md")} {
-    ${{ ...theme.typography.subtitle2 }}
+    ${{ ...theme.typography.subtitle3 }}
     height: ${theme.typography.pxToRem(32)};
   }
 

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -77,7 +77,7 @@ const Info = ({
       <span>{getReadableResourceType(resource.resource_type)}</span>
       <PriceContainer size={size}>
         {resource.certification && (
-          <Certificate>
+          <Certificate size={size}>
             {size === "small" ? (
               <Tooltip title="Certificate">
                 <RiAwardFill />
@@ -105,8 +105,8 @@ const PriceContainer = styled.div<{ size: Size }>(({ size }) => ({
   gap: size === "small" ? "4px" : "8px",
 }))
 
-const Certificate = styled.div`
-  padding: 2px 4px;
+const Certificate = styled.div<{ size: Size }>`
+  padding: ${({ size }) => (size === "small" ? "2px" : "2px 4px")};
   border-radius: 4px;
   color: ${theme.custom.colors.silverGrayDark};
   background-color: ${theme.custom.colors.lightGray1};

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -75,7 +75,7 @@ const Info = ({
   return (
     <>
       <span>{getReadableResourceType(resource.resource_type)}</span>
-      <PriceContainer>
+      <PriceContainer size={size}>
         {resource.certification && (
           <Certificate>
             {size === "small" ? (
@@ -86,9 +86,11 @@ const Info = ({
               <RiAwardFill />
             )}
             {size === "small" ? "" : "Certificate"}
-            <CertificatePrice>
-              {certificatePrice ? `${separator}${certificatePrice}` : ""}
-            </CertificatePrice>
+            {certificatePrice ? (
+              <CertificatePrice>
+                {`${separator}${certificatePrice}`}
+              </CertificatePrice>
+            ) : null}
           </Certificate>
         )}
         <Price>{prices.course.display}</Price>
@@ -97,11 +99,11 @@ const Info = ({
   )
 }
 
-const PriceContainer = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 12px;
-`
+const PriceContainer = styled.div<{ size: Size }>(({ size }) => ({
+  display: "flex",
+  alignItems: "center",
+  gap: size === "small" ? "4px" : "8px",
+}))
 
 const Certificate = styled.div`
   padding: 2px 4px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2732,9 +2732,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/smoot-design@npm:0.0.0-0a23f44":
-  version: 0.0.0-0a23f44
-  resolution: "@mitodl/smoot-design@npm:0.0.0-0a23f44"
+"@mitodl/smoot-design@npm:^6.10.0":
+  version: 6.10.0
+  resolution: "@mitodl/smoot-design@npm:6.10.0"
   dependencies:
     "@ai-sdk/react": "npm:1.2.12"
     "@emotion/cache": "npm:^11.14.0"
@@ -2758,7 +2758,7 @@ __metadata:
     "@remixicon/react": ^4.2.0
     react: ^18 || ^19
     react-dom: ^18 || ^19
-  checksum: 10/46302fdf2f064a361b4bb2e9de9ea24ffc557df41e1f52ef19da17fbb2033e94fd9da01c998c83c093295bb6b45a4f918d2d0643f4a0f223d9c78de195250baa
+  checksum: 10/d68ee7336f7102ceea562d6695ea9a2174f586d5ca36518f09bfa912c702c1493fa74146e413dedadecb8532412dfc35684b19e9143744723de8c88e90cb7ad4
   languageName: node
   linkType: hard
 
@@ -13350,7 +13350,7 @@ __metadata:
     "@faker-js/faker": "npm:^9.0.0"
     "@mitodl/course-search-utils": "npm:3.3.2"
     "@mitodl/mitxonline-api-axios": "npm:^2025.6.3"
-    "@mitodl/smoot-design": "npm:0.0.0-0a23f44"
+    "@mitodl/smoot-design": "npm:^6.10.0"
     "@next/bundle-analyzer": "npm:^14.2.15"
     "@remixicon/react": "npm:^4.2.0"
     "@sentry/nextjs": "npm:^9.0.0"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7572

### Description (What does it do?)
Fixes several design discrepancies.

### How can this be tested?
View the changed areas. See below.

## Screenshots

### 1. Resource Card Certificate / Price Spacing

Now looks like:
<img width="200" alt="new_medium" src="https://github.com/user-attachments/assets/e1652881-3aec-413c-93d1-4689eff50dbc" /> / <img width="130" alt="new_small" src="https://github.com/user-attachments/assets/c24634f8-0250-43c5-a057-63796c9e26ae" />

Diff (bottom is new version):
<img width="204" alt="diff_medium" src="https://github.com/user-attachments/assets/c4ec0891-65e8-49d2-a2a4-5ce95e4f4cdd" /> <img width="132" alt="diff_small" src="https://github.com/user-attachments/assets/85de0e6d-5a00-41e3-b312-12fc45d0c657" />

### 2. Explore MIT Filter / Hero Filter

The order and icons are now the same. Hero icon for "Free" changed to pricetag.

<img width="600" alt="Screenshot 2025-06-17 at 2 50 43 PM" src="https://github.com/user-attachments/assets/48f8bd4e-d974-44f6-9800-6d94b2bd4fde" />

### 3. Search page filter spacing updates (mobile), Mobile ListRowCard title size decrease

<img width="461" alt="Screenshot 2025-06-17 at 2 52 42 PM" src="https://github.com/user-attachments/assets/3821e5dd-0a49-4221-bee1-4424e005d589" />

### 4. Unit Page Changes (mostly mobile):

**Changes:**
- desktop: font size `body1`
- mobile: font size `body2` for count and text, two-tone cards,
- both: count and text same color

<img width="600" alt="Screenshot 2025-06-17 at 2 53 37 PM" src="https://github.com/user-attachments/assets/19911f0a-720b-4e28-9262-77131a808564" />

**Mobile** (right hand is extra narrow, svg shrinks now)
<img width="300" alt="Screenshot 2025-06-20 at 10 47 18 AM" src="https://github.com/user-attachments/assets/7d235e42-14e1-48f4-98c7-dabfbad096c3" /> <img width="300" alt="Screenshot 2025-06-20 at 10 47 30 AM" src="https://github.com/user-attachments/assets/f35bf92e-88e4-41f2-9a71-1fd09a40a879" />


### 5. Search Page (and some channel pages)

Free checkbox is now centered:


**BEFORE** / **AFTER**

<img width="266" alt="Screenshot 2025-06-18 at 5 20 46 PM" src="https://github.com/user-attachments/assets/de480447-818c-4ddd-a13e-920669d84319" /> / <img width="290" alt="Screenshot 2025-06-18 at 5 21 22 PM" src="https://github.com/user-attachments/assets/2e04ff1c-bc63-4988-8cbe-214797c4b971" />


### 6. My Lists icon sizing

**BEFORE** / **AFTER**
<img width="138" alt="Screenshot 2025-06-18 at 5 22 50 PM" src="https://github.com/user-attachments/assets/d20c9854-2667-44dd-ba3e-2e24cdcb3f5b" /> /  <img width="144" alt="Screenshot 2025-06-18 at 5 27 12 PM" src="https://github.com/user-attachments/assets/a191e069-2723-4251-aa0d-5a9dc5f3cdd4" />


### 7. Profile Page Font Sizing

No change. Handled in a separate PR. (#2304 )

### 8. Topic Page Spacing

Matches [Figma](https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=2197-31349&m=dev) ... Top/bottom spacing changed to be symmetric, 80px on desktop 32px on mobile:

<img width="600" alt="Screenshot 2025-06-20 at 10 52 20 AM" src="https://github.com/user-attachments/assets/a57e6b40-86a0-45ae-8102-02c23b730f83" />
<img width="600" alt="Screenshot 2025-06-20 at 10 52 15 AM" src="https://github.com/user-attachments/assets/dc9876ca-69b2-4eae-a41b-eb7287f82de8" />

<img width="300" alt="Screenshot 2025-06-20 at 10 52 30 AM" src="https://github.com/user-attachments/assets/aee2c556-f3be-44ae-8b81-d7c1616f260c" />
<br>
<img width="300" alt="Screenshot 2025-06-20 at 10 52 33 AM" src="https://github.com/user-attachments/assets/27aa9a24-172d-4528-9d44-cacfb3bb0f66" />


Should otherwise look same as RC.

### 9. Departments Page Spacing 

Matches [Figma](https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=2197-31367&m=dev) ... Top/bottom spacing changed to be symmetric, 80px on desktop 20px on mobile:

<img width="600" alt="Screenshot 2025-06-20 at 10 58 34 AM" src="https://github.com/user-attachments/assets/0aa9f21a-67a2-4c49-8840-1fde9be88955" />
<img width="600" alt="Screenshot 2025-06-20 at 10 58 28 AM" src="https://github.com/user-attachments/assets/9bc6a3ea-db83-4f08-aef1-691581396213" />


<img width="400" alt="Screenshot 2025-06-20 at 10 58 08 AM" src="https://github.com/user-attachments/assets/cad6d6c0-c194-4df4-9b42-719a0855f580" />
<br>
<img width="400" alt="Screenshot 2025-06-20 at 10 58 14 AM" src="https://github.com/user-attachments/assets/a415c5c8-2801-47c6-9279-87a3e7e7a778" />


### 10. Search Display Filter Alignment

The first facet should now always align with the top of the search results:

BEFORE / AFTER

<img width="800" alt="Screenshot 2025-06-18 at 5 35 24 PM" src="https://github.com/user-attachments/assets/cea1b3d1-8bcf-4330-8661-926114e54641" />

<img width="800" alt="Screenshot 2025-06-18 at 5 35 24 PM" src="https://github.com/user-attachments/assets/1d4497f5-6767-48d7-9511-264ec2c4e131" />

<img width="800" alt="Screenshot 2025-06-18 at 5 37 05 PM" src="https://github.com/user-attachments/assets/53969891-1fc9-49b8-a0ea-2ac9f66d4b0c" />

### 11. Search Page Facet Filter Text

Now Neue-haas-grotesk and dark gray 2. 

BEFORE / AFTER

<img width="426" alt="Screenshot 2025-06-18 at 5 42 06 PM" src="https://github.com/user-attachments/assets/b1ed3013-7f18-4e12-ad9d-1ec4798b57d5" />

### 12. Academic and Professional Icon Scaling

See code comment for more details. Behavior updated so that the icons scale at same rate then disappear.