### PR TITLE
dashboard email settings dialog functionality

### DIFF
--- a/frontends/api/src/mitxonline/hooks/enrollment/index.ts
+++ b/frontends/api/src/mitxonline/hooks/enrollment/index.ts
@@ -1,6 +1,21 @@
 import { enrollmentQueries, enrollmentKeys } from "./queries"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { enrollmentsApi } from "../../clients"
+import { EnrollmentsApiEnrollmentsPartialUpdateRequest } from "@mitodl/mitxonline-api-axios/v1"
+
+const useUpdateEnrollment = (
+  opts: EnrollmentsApiEnrollmentsPartialUpdateRequest,
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () => enrollmentsApi.enrollmentsPartialUpdate(opts),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: enrollmentKeys.enrollmentsList(),
+      })
+    },
+  })
+}
 
 const useDestroyEnrollment = (enrollmentId: number) => {
   const queryClient = useQueryClient()
@@ -14,4 +29,9 @@ const useDestroyEnrollment = (enrollmentId: number) => {
   })
 }
 
-export { enrollmentQueries, enrollmentKeys, useDestroyEnrollment }
+export {
+  enrollmentQueries,
+  enrollmentKeys,
+  useUpdateEnrollment,
+  useDestroyEnrollment,
+}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -353,7 +353,6 @@ describe.each([
         id: faker.number.int(),
         status: EnrollmentStatus.Completed,
         mode: EnrollmentMode.Verified,
-        receiveEmails: true as boolean,
       }
       renderWithProviders(
         <DashboardCard
@@ -368,10 +367,7 @@ describe.each([
       await user.click(contextMenuButton)
       const expectedMenuItems = [
         ...contextMenuItems,
-        ...getDefaultContextMenuItems(
-          "Test Course",
-          course.enrollment as Required<typeof course.enrollment>,
-        ),
+        ...getDefaultContextMenuItems("Test Course", course.enrollment),
       ]
       const menuItems = screen.getAllByRole("menuitem")
       for (let i = 0; i < expectedMenuItems.length; i++) {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -353,6 +353,7 @@ describe.each([
         id: faker.number.int(),
         status: EnrollmentStatus.Completed,
         mode: EnrollmentMode.Verified,
+        receiveEmails: true as boolean,
       }
       renderWithProviders(
         <DashboardCard
@@ -367,7 +368,10 @@ describe.each([
       await user.click(contextMenuButton)
       const expectedMenuItems = [
         ...contextMenuItems,
-        ...getDefaultContextMenuItems("Test Course", course.enrollment.id),
+        ...getDefaultContextMenuItems(
+          "Test Course",
+          course.enrollment as Required<typeof course.enrollment>,
+        ),
       ]
       const menuItems = screen.getAllByRole("menuitem")
       for (let i = 0; i < expectedMenuItems.length; i++) {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -9,7 +9,7 @@ import {
 } from "ol-components"
 import NextLink from "next/link"
 import { EnrollmentStatus, EnrollmentMode } from "./types"
-import type { DashboardCourse } from "./types"
+import type { DashboardCourse, DashboardCourseEnrollment } from "./types"
 import { ActionButton, Button, ButtonLink } from "@mitodl/smoot-design"
 import {
   RiArrowRightLine,
@@ -78,14 +78,17 @@ const MenuButton = styled(ActionButton)<{
     },
 ])
 
-const getDefaultContextMenuItems = (title: string, enrollmentId: number) => {
+const getDefaultContextMenuItems = (
+  title: string,
+  enrollment: DashboardCourseEnrollment,
+) => {
   return [
     {
       className: "dashboard-card-menu-item",
       key: "email-settings",
       label: "Email Settings",
       onClick: () => {
-        NiceModal.show(EmailSettingsDialog, { title })
+        NiceModal.show(EmailSettingsDialog, { title, enrollment })
       },
     },
     {
@@ -93,7 +96,7 @@ const getDefaultContextMenuItems = (title: string, enrollmentId: number) => {
       key: "unenroll",
       label: "Unenroll",
       onClick: () => {
-        NiceModal.show(UnenrollDialog, { title, enrollmentId })
+        NiceModal.show(UnenrollDialog, { title, enrollment })
       },
     },
   ]
@@ -333,7 +336,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
     <CourseStartCountdown startDate={run.startDate} />
   ) : null
   const menuItems = contextMenuItems.concat(
-    enrollment?.id ? getDefaultContextMenuItems(title, enrollment?.id) : [],
+    enrollment?.id ? getDefaultContextMenuItems(title, enrollment) : [],
   )
   const contextMenu = isLoading ? (
     <Skeleton variant="rectangular" width={12} height={24} />

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
@@ -33,6 +33,60 @@ describe("DashboardDialogs", () => {
     return { enrollments, completed, expired, started, notStarted }
   }
 
+  test("Opening the email settings dialog and submitting it fires the proper API call", async () => {
+    const { enrollments } = setupApis()
+    const enrollment = faker.helpers.arrayElement(enrollments)
+
+    setMockResponse.patch(
+      mitxonline.urls.enrollment.courseEnrollment(enrollment.id),
+      null,
+    )
+    renderWithProviders(<EnrollmentDisplay />)
+
+    await screen.findByRole("heading", { name: "My Learning" })
+
+    const cards = await screen.findAllByTestId("enrollment-card-desktop")
+    expect(cards.length).toBe(enrollments.length)
+
+    const card = cards.find(
+      (c) => !!within(c).queryByText(enrollment.run.title),
+    )
+    invariant(card)
+
+    const contextMenuButton = await within(card).findByLabelText("More options")
+    await user.click(contextMenuButton)
+
+    const emailSettingsButton = await screen.findByRole("menuitem", {
+      name: "Email Settings",
+    })
+    await user.click(emailSettingsButton)
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Email Settings",
+    })
+    expect(dialog).toBeInTheDocument()
+
+    const checkbox = within(dialog).getByRole("checkbox", {
+      name: "Receive course emails",
+    })
+    expect(checkbox).toBeInTheDocument()
+    await user.click(checkbox)
+
+    const confirmButton = within(dialog).getByRole("button", {
+      name: "Save Settings",
+    })
+    expect(confirmButton).toBeEnabled()
+
+    await user.click(confirmButton)
+
+    expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "PATCH",
+        url: mitxonline.urls.enrollment.courseEnrollment(enrollment.id),
+      }),
+    )
+  })
+
   test("Opening the unenroll dialog and confirming the unenroll fires the proper API call", async () => {
     const { enrollments } = setupApis()
     const enrollment = faker.helpers.arrayElement(enrollments)

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
@@ -51,6 +51,7 @@ const EmailSettingsDialogInner: React.FC<DashboardDialogProps> = ({
   const updateEnrollment = useUpdateEnrollment({
     id: enrollment.id,
     PatchedCourseRunEnrollmentRequest: {
+      //@ts-expect-error This will be fixed after https://github.com/mitodl/mitxonline/pull/2737 is released
       receive_emails: formik.values.receive_emails,
     },
   })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
@@ -11,7 +11,11 @@ import { Button, Checkbox, Alert } from "@mitodl/smoot-design"
 
 import NiceModal, { muiDialogV5 } from "@ebay/nice-modal-react"
 import { useFormik } from "formik"
-import { useDestroyEnrollment } from "api/mitxonline-hooks/enrollment"
+import {
+  useDestroyEnrollment,
+  useUpdateEnrollment,
+} from "api/mitxonline-hooks/enrollment"
+import { DashboardCourseEnrollment } from "./types"
 
 const BoldText = styled.span(({ theme }) => ({
   ...theme.typography.subtitle1,
@@ -23,10 +27,11 @@ const SpinnerContainer = styled.div({
 
 type DashboardDialogProps = {
   title: string
-  enrollmentId: number
+  enrollment: DashboardCourseEnrollment
 }
 const EmailSettingsDialogInner: React.FC<DashboardDialogProps> = ({
   title,
+  enrollment,
 }) => {
   const modal = NiceModal.useModal()
   const formik = useFormik({
@@ -34,10 +39,19 @@ const EmailSettingsDialogInner: React.FC<DashboardDialogProps> = ({
     validateOnChange: false,
     validateOnBlur: false,
     initialValues: {
-      recieve_emails: true,
+      receive_emails: enrollment.receiveEmails ?? true,
     },
     onSubmit: async () => {
-      // TODO: Handle form submission
+      await updateEnrollment.mutateAsync()
+      if (!updateEnrollment.isError) {
+        modal.hide()
+      }
+    },
+  })
+  const updateEnrollment = useUpdateEnrollment({
+    id: enrollment.id,
+    PatchedCourseRunEnrollmentRequest: {
+      receive_emails: formik.values.receive_emails,
     },
   })
   return (
@@ -57,8 +71,20 @@ const EmailSettingsDialogInner: React.FC<DashboardDialogProps> = ({
           >
             Cancel
           </Button>
-          <Button variant="primary" type="submit" disabled={!formik.dirty}>
+          <Button
+            variant="primary"
+            type="submit"
+            disabled={!formik.dirty || updateEnrollment.isPending}
+          >
             Save Settings
+            {updateEnrollment.isPending && (
+              <SpinnerContainer>
+                <LoadingSpinner
+                  loading={updateEnrollment.isPending}
+                  size={16}
+                />
+              </SpinnerContainer>
+            )}
           </Button>
         </DialogActions>
       }
@@ -74,11 +100,17 @@ const EmailSettingsDialogInner: React.FC<DashboardDialogProps> = ({
           </Typography>
         </Alert>
         <Checkbox
-          name="recieve_emails"
+          name="receive_emails"
           label="Receive course emails"
-          checked={formik.values.recieve_emails}
+          checked={formik.values.receive_emails}
           onChange={formik.handleChange}
         />
+        {updateEnrollment.isError && (
+          <Alert severity="error">
+            There was a problem updating your email settings. Please try again
+            later.
+          </Alert>
+        )}
       </Stack>
     </FormDialog>
   )
@@ -86,10 +118,10 @@ const EmailSettingsDialogInner: React.FC<DashboardDialogProps> = ({
 
 const UnenrollDialogInner: React.FC<DashboardDialogProps> = ({
   title,
-  enrollmentId,
+  enrollment,
 }) => {
   const modal = NiceModal.useModal()
-  const destroyEnrollment = useDestroyEnrollment(enrollmentId)
+  const destroyEnrollment = useDestroyEnrollment(enrollment.id)
   const formik = useFormik({
     enableReinitialize: true,
     validateOnChange: false,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/transform.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/transform.test.tsx
@@ -45,6 +45,7 @@ describe("Transforming mitxonline enrollment data to DashboardResource", () => {
           id: apiData.id,
           status: enrollmentStatus,
           mode: apiData.enrollment_mode,
+          receiveEmails: apiData.edx_emails_subscription,
         },
       } satisfies DashboardResource)
     },

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/transform.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/transform.ts
@@ -44,6 +44,7 @@ const mitxonlineEnrollment = (raw: CourseRunEnrollment): DashboardCourse => {
       status: raw.grades[0]?.passed
         ? EnrollmentStatus.Completed
         : EnrollmentStatus.Enrolled,
+      receiveEmails: raw.edx_emails_subscription ?? true,
     },
   }
 }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/types.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/types.ts
@@ -42,7 +42,7 @@ type DashboardCourseEnrollment = {
   id: number
   status: EnrollmentStatus
   mode: EnrollmentMode
-  receiveEmails: boolean
+  receiveEmails?: boolean
 }
 
 type DashboardProgram = {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/types.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/types.ts
@@ -34,8 +34,15 @@ type DashboardCourse = {
     id: number
     status: EnrollmentStatus
     mode: EnrollmentMode
+    receiveEmails?: boolean
   }
   marketingUrl: string
+}
+type DashboardCourseEnrollment = {
+  id: number
+  status: EnrollmentStatus
+  mode: EnrollmentMode
+  receiveEmails: boolean
 }
 
 type DashboardProgram = {
@@ -50,4 +57,9 @@ type DashboardProgram = {
 type DashboardResource = DashboardCourse | DashboardProgram
 
 export { DashboardResourceType, EnrollmentStatus, EnrollmentMode }
-export type { DashboardResource, DashboardCourse, DashboardProgram }
+export type {
+  DashboardResource,
+  DashboardCourse,
+  DashboardCourseEnrollment,
+  DashboardProgram,
+}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7637

### Description (What does it do?)
This PR adds the hooks necessary to update email communication settings in MITx Online (and subsequently OpenEdx) and implements them on the email settings dialog in the Dashboard.

### How can this be tested?
In order to test this, you need a basic installation of `mitxonline` up and running with example data in it. You may be able to skip one or more steps if you have already done them:
- Ensure you have local `hosts` redirects for the following domains, replacing the example IP with your __local__ IP address (Google how to get this if unsure, mine is 192.168.1.50)
```
192.168.1.50 open.odl.local
192.168.1.50 api.open.odl.local
192.168.1.50 kc.ol.local
192.168.1.50 mitxonline.odl.local
```
- Clone `mitxonline`: https://github.com/mitodl/mitxonline
- Create a `.env` file with the following values:
```
CELERY_TASK_ALWAYS_EAGER=True
DJANGO_LOG_LEVEL=INFO
LOG_LEVEL=INFO
SENTRY_LOG_LEVEL=ERROR
MAILGUN_KEY=fake
MAILGUN_URL=
MAILGUN_RECIPIENT_OVERRIDE=
MAILGUN_SENDER_DOMAIN=.odl.local
SECRET_KEY=
STATUS_TOKEN=
UWSGI_THREADS=5
SENTRY_DSN=
MITX_ONLINE_BASE_URL=http://open.odl.local:8065/mitxonline
MITX_ONLINE_ADMIN_CLIENT_ID=refine-local-client-id
MITX_ONLINE_ADMIN_BASE_URL=http://mitxonline.odl.local:8016
POSTHOG_PROJECT_API_KEY=
POSTHOG_API_HOST=https://app.posthog.com/
HUBSPOT_HOME_PAGE_FORM_GUID=
HUBSPOT_PORTAL_ID=
APISIX_PORT=9080

# APISIX/Keycloak settings
APISIX_LOGOUT_URL=http://api.open.odl.local:8065/logout/
APISIX_SESSION_SECRET_KEY=supertopsecret1234
KC_SPI_THEME_WELCOME_THEME=scim
KC_SPI_REALM_RESTAPI_EXTENSION_SCIM_LICENSE_KEY=
KEYCLOAK_BASE_URL=http://kc.ol.local:8066
KEYCLOAK_CLIENT_ID=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
KEYCLOAK_CLIENT_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
KEYCLOAK_DISCOVERY_URL=http://kc.ol.local:8066/realms/ol-local/.well-known/openid-configuration
KEYCLOAK_REALM_NAME=ol-local
KEYCLOAK_SCOPES="openid profile ol-profile"
KEYCLOAK_SVC_KEYSTORE_PASSWORD=supertopsecret1234
KEYCLOAK_SVC_HOSTNAME=kc.ol.local
KEYCLOAK_SVC_ADMIN=admin
KEYCLOAK_SVC_ADMIN_PASSWORD=admin
AUTHORIZATION_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/auth
ACCESS_TOKEN_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/token
OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_KEY=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
SOCIAL_AUTH_OL_OIDC_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
USERINFO_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/userinfo
MITOL_APIGATEWAY_DISABLE_MIDDLEWARE=False

FEATURE_IGNORE_EDX_FAILURES=True
OPENEDX_API_CLIENT_ID=fake
OPENEDX_API_CLIENT_SECRET=fake
OPENEDX_SERVICE_WORKER_API_TOKEN=fake

CSRF_COOKIE_DOMAIN=.odl.local
CORS_ALLOWED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
CSRF_TRUSTED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
```
- Spin up `mitxonline` with `docker compose up --build -d`
- Promote the admin user with `docker compose exec web ./manage.py promote_user --promote --superuser admin@odl.local`
- Populate test course data with `docker compose exec web ./manage.py populate_course_data`
- Generate docs with `pants docs ::`
- In `dist/sphinx/index.html`, read the section on generating a B2B organization / contract and create one, adding some of the test courses to it
- In Django admin, create a `Program` and add some courses to the program that are included in your B2B org, making sure to mark the program as "live"
- In the MITx Online Dashboard, enroll the test admin user in the courses you put in your B2B org, making sure you select the course runs generated by the org
- Make sure you have a personal Posthog project configured and have the API key at the ready
- Before we spin up `mit-learn`, we need to set some env variables (note that we are intentionally misconfiguring the cookie domain):
```
.env
...
MITX_ONLINE_UPSTREAM=mitxonline.odl.local:8013
MITX_ONLINE_DOMAIN=mitxonline.odl.local
MITX_ONLINE_BASE_URL=http://mitxonline.odl.local:8065
POSTHOG_ENABLED=True
CSRF_COOKIE_DOMAIN=.odl.local

shared.local.env
POSTHOG_PROJECT_API_KEY=YOUR_API_KEY_HERE
POSTHOG_PROJECT_ID=YOUR_PROJECT_ID_HERE
POSTHOG_TIMEOUT_MS=1500
```
- In your Posthog project, enable the `enrollment-dashboard` and `mitlearn-organization-dashboard` feature flags for all users
- Spin up `MIT Learn`
- Log in with the `admin@odl.local` test user
- Navigate to the Dashboard
- You should see several enrollments pop up under the "My Learning" section
- Click the three dot menu on one of the enrollments, and click Email Settings
- Check (or uncheck) the checkbox, and click Save Settings
- Open a new tab and go to http://mitxonline.odl.local:8065/
- Click your username in the upper right and click Dashboard
- Click the three dots on the same course and click Email Settings
- Verify that the settings match
- Repeat the process and verify that the setting has changed