### PR TITLE
Canonical URLs for resource drawer

### DIFF
--- a/frontends/main/src/common/urls.ts
+++ b/frontends/main/src/common/urls.ts
@@ -121,6 +121,9 @@ export const RESOURCE_DRAWER_PARAMS = {
   syllabus: "syllabus",
 } as const
 
+export const canonicalResourceDrawerUrl = (resourceId: number) =>
+  `${process.env.NEXT_PUBLIC_ORIGIN}/search?${RESOURCE_DRAWER_PARAMS.resource}=${resourceId}`
+
 export const querifiedSearchUrl = (
   params:
     | string

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
@@ -7,7 +7,10 @@ import type {
 } from "ol-components"
 import { useLearningResourcesDetail } from "api/hooks/learningResources"
 
-import { RESOURCE_DRAWER_PARAMS } from "@/common/urls"
+import {
+  canonicalResourceDrawerUrl,
+  RESOURCE_DRAWER_PARAMS,
+} from "@/common/urls"
 import { useUserMe } from "api/hooks/user"
 import NiceModal from "@ebay/nice-modal-react"
 import {
@@ -214,7 +217,7 @@ const DrawerContent: React.FC<{
         bottomCarousels={bottomCarousels}
         chatExpanded={chatExpanded}
         user={user}
-        shareUrl={`${window.location.origin}/search?${RESOURCE_DRAWER_PARAMS.resource}=${resourceId}`}
+        shareUrl={canonicalResourceDrawerUrl(resourceId)}
         inLearningPath={inLearningPath}
         inUserList={inUserList}
         onAddToLearningPathClick={handleAddToLearningPathClick}


### PR DESCRIPTION
### What are the relevant tickets?

- https://github.com/mitodl/hq/issues/7426

### Description (What does it do?)
Adds a canonical URL for resource drawer.

### Screenshots (if appropriate):
<img width="1788" alt="Screenshot 2025-06-23 at 5 07 59 PM" src="https://github.com/user-attachments/assets/82f591f4-dfdf-45ac-8168-c4308b4cd13b" />


### How can this be tested?
1. Open the resource drawer by any means. 
2. Reload the page. Inspect network request for initial HTML document. You should see a `<link rel="canonical" />` metadata tag with same `href` as the drawer's Share URL.

### Additional Context
A quirk / drawback of how we currently handle drawer metadata is that the drawer's metadata is only included on a hard reload. See https://github.com/mitodl/hq/issues/7426#issuecomment-2997970301 for more.

While this is a drawback, I'd like to merge this as-is (pending no other issues), so that we can turn off the noindex tag on prod (we'd like this canonicalization in before that) and then can re-assess
