### PR TITLE
Shanbady/summary flashcard sync

### DIFF
--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -504,6 +504,7 @@ def embed_learning_resources(ids, resource_type, overwrite):
     else:
         serialized_resources = list(serialize_bulk_content_files(ids))
         # TODO: Pass actual Ids when we want scheduled content file summarization  # noqa: FIX002, TD002, TD003 E501
+        # Currently we only want to summarize content that already has a summary
         existing_summary_content_ids = [
             resource["id"]
             for resource in serialized_resources

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -106,9 +106,7 @@ def create_qdrant_collections(force_recreate):
                     ),
                 ),
             },
-            sparse_vectors_config={
-                "bm25": models.SparseVectorParams(modifier=models.Modifier.IDF)
-            },
+            sparse_vectors_config=client.get_fastembed_sparse_vector_params(),
             optimizers_config=models.OptimizersConfigDiff(default_segment_number=2),
             quantization_config=models.ScalarQuantization(
                 scalar=models.ScalarQuantizationConfig(
@@ -131,9 +129,7 @@ def create_qdrant_collections(force_recreate):
                     size=encoder.dim(), distance=models.Distance.COSINE
                 ),
             },
-            sparse_vectors_config={
-                "bm25": models.SparseVectorParams(modifier=models.Modifier.IDF)
-            },
+            sparse_vectors_config=client.get_fastembed_sparse_vector_params(),
             optimizers_config=models.OptimizersConfigDiff(default_segment_number=2),
             quantization_config=models.ScalarQuantization(
                 scalar=models.ScalarQuantizationConfig(

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -634,4 +634,4 @@ def test_embed_learning_resources_summarizes_only_contentfiles_with_summary(mock
 
     # Only contentfiles with summary should be passed
     expected_ids = [cf.id for cf in contentfiles_with_summary]
-    summarize_mock.assert_called_once_with(expected_ids, overwrite=True)
+    summarize_mock.assert_called_once_with(expected_ids, True)  # noqa: FBT003

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -604,7 +604,7 @@ def test_embed_learning_resources_summarizes_only_contentfiles_with_summary(mock
         2, content="abc", summary="summary text"
     )
     contentfiles_without_summary = ContentFileFactory.create_batch(
-        3, content="def", summary=None
+        3, content="def", summary=""
     )
     all_contentfiles = contentfiles_with_summary + contentfiles_without_summary
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/7714
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR ensures that content that already has an existing summary/flashcard stays in sync when content is updated

### How can this be tested?
1. Checkout this branch
2. make sure QDRANT_ENABLE_INDEXING_PLUGIN_HOOKS is set to True in settings
3. ensure you also have an open ai api key configured.
4. configure a summarizer for an etl source locally (lets pick mitxonline) - you can reference the summarizer currently configured on production here https://api.learn.mit.edu/admin/learning_resources/contentsummarizerconfiguration/1/change/
5. pull down contentfiles ```python manage.py backpopulate_mitxonline_files```
6. note that we dont have summaries for any contentfiles yet:
```python
from learning_resources.models import *
ContentFile.objects.exclude(summary="").all()
```
7. manually set the "summary" field for a contentfile to "test" - also change the checksum for the associated run and contentfile so it thinks we have an update.
```python
from learning_resources.models import *
cf = ContentFile.objects.filter(file_extension=".srt").first()
run = cf.run
lr = run.learning_resource

cf.summary = "test"
cf.checksum = "test"
run.checksum = "test"
cf.save()
run.save()
print(f"resource id - {lr.id}")
```
8. pull down contentfiles for that particular learning resource again ```python manage.py backpopulate_mitxonline_files ---resource-ids {resourceid}```
10. once complete you should see a generated summary populated for just that one contentfile


**note**: Dont forget to unset your openai api key once done testing.


### Additional Context
On live systems, the ETL plugin hooks will call generate_embeddings with the overwrite flag which is what we are testing here.
