### PR TITLE
Set first run language on drawer and card titles and description

### DIFF
--- a/frontends/main/src/page-components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
@@ -114,6 +114,25 @@ describe("Learning Resource Expanded", () => {
     screen.getByText(resource.title)
   })
 
+  test("Sets lang attribute on title and description", () => {
+    const resource = factories.learningResources.resource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [
+        factories.learningResources.run({
+          languages: ["en-us"],
+        }),
+      ],
+    })
+
+    setup({ resource })
+
+    const title = screen.getByText(resource.title)
+    expect(title).toHaveAttribute("lang", "en-us")
+
+    const description = screen.getByText(resource.description!)
+    expect(description).toHaveAttribute("lang", "en-us")
+  })
+
   test.each([ResourceTypeEnum.Program, ResourceTypeEnum.LearningPath])(
     'Renders CTA button for resource type "%s"',
     (resourceType) => {

--- a/frontends/main/src/page-components/LearningResourceExpanded/ResourceDescription.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/ResourceDescription.tsx
@@ -83,6 +83,7 @@ const ResourceDescription = ({ resource }: { resource?: LearningResource }) => {
          * backend during ETL. This is safe to render.
          */
         dangerouslySetInnerHTML={{ __html: resource.description || "" }}
+        lang={resource.runs?.[0]?.languages?.[0]}
       />
       {(isClamped || clampedOnFirstRender.current) && (
         <Link

--- a/frontends/main/src/page-components/LearningResourceExpanded/TitleSection.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/TitleSection.tsx
@@ -82,7 +82,7 @@ const TitleSection: React.FC<{
         >
           {type}
         </Typography>
-        {title}
+        <span lang={resource?.runs?.[0]?.languages?.[0]}>{title}</span>
       </Typography>
       <CloseButton
         variant="text"

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -230,6 +230,7 @@ type TitleProps = {
   href?: string
   lines?: number
   style?: CSSProperties
+  lang?: string
 }
 
 type SlotProps = { children?: ReactNode; style?: CSSProperties }

--- a/frontends/ol-components/src/components/Card/ListCard.tsx
+++ b/frontends/ol-components/src/components/Card/ListCard.tsx
@@ -88,6 +88,7 @@ export const Info = styled.div`
 export type TitleProps = {
   children?: ReactNode
   href?: string
+  lang?: string
 }
 export const Title: React.FC<TitleProps> = styled(Linkable)`
   flex-grow: 1;
@@ -247,8 +248,10 @@ const ListCard: Card = ({
       <Body>
         <Info>{info}</Info>
         {title && (
-          <Title data-card-link={!!title.href} {...title} href={title.href}>
-            <TruncateText lineClamp={2}>{title.children}</TruncateText>
+          <Title data-card-link={!!title.href} href={title.href}>
+            <TruncateText lineClamp={2} lang={title.lang}>
+              {title.children}
+            </TruncateText>
           </Title>
         )}
         <Bottom>

--- a/frontends/ol-components/src/components/Card/ListCardCondensed.tsx
+++ b/frontends/ol-components/src/components/Card/ListCardCondensed.tsx
@@ -159,7 +159,9 @@ const ListCardCondensed: Card = ({
       <Body>
         <Info>{info}</Info>
         <Title data-card-link={!!title.href} href={title.href}>
-          <TruncateText lineClamp={4}>{title.children}</TruncateText>
+          <TruncateText lineClamp={4} lang={title.lang}>
+            {title.children}
+          </TruncateText>
         </Title>
         <Bottom>
           <Footer>{footer}</Footer>

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.test.tsx
@@ -38,6 +38,22 @@ describe("Learning Resource Card", () => {
     },
   )
 
+  test("Sets lang attribute on title and description", () => {
+    const resource = factories.learningResources.resource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [
+        factories.learningResources.run({
+          languages: ["en-us"],
+        }),
+      ],
+    })
+
+    setup({ resource })
+
+    const title = screen.getByText(resource.title)
+    expect(title).toHaveAttribute("lang", "en-us")
+  })
+
   test("Displays run start date", () => {
     const resource = factories.learningResources.resource({
       resource_type: ResourceTypeEnum.Course,

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -241,7 +241,9 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
       <Card.Info>
         <Info resource={resource} size={size} />
       </Card.Info>
-      <Card.Title href={href}>{resource.title}</Card.Title>
+      <Card.Title href={href} lang={resource.runs?.[0]?.languages?.[0]}>
+        {resource.title}
+      </Card.Title>
       <Card.Actions>
         {onAddToLearningPathClick && (
           <CardActionButton

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
@@ -37,6 +37,22 @@ describe("Learning Resource List Card", () => {
     },
   )
 
+  test.only("Sets lang attribute on title and description", () => {
+    const resource = factories.learningResources.resource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [
+        factories.learningResources.run({
+          languages: ["pt-pt"],
+        }),
+      ],
+    })
+
+    setup({ resource })
+
+    const title = screen.getByText(resource.title)
+    expect(title).toHaveAttribute("lang", "pt-pt")
+  })
+
   test("Displays run start date", () => {
     const resource = factories.learningResources.resource({
       resource_type: ResourceTypeEnum.Course,

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -319,7 +319,9 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
       <ListCard.Info>
         <Info resource={resource} />
       </ListCard.Info>
-      <ListCard.Title href={href}>{resource.title}</ListCard.Title>
+      <ListCard.Title href={href} lang={resource.runs?.[0]?.languages?.[0]}>
+        {resource.title}
+      </ListCard.Title>
       <ListCard.Actions>
         {onAddToLearningPathClick && (
           <CardActionButton

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.tsx
@@ -128,7 +128,10 @@ const LearningResourceListCardCondensed: React.FC<
       <ListCardCondensed.Info>
         <Info resource={resource} />
       </ListCardCondensed.Info>
-      <ListCardCondensed.Title href={href}>
+      <ListCardCondensed.Title
+        href={href}
+        lang={resource.runs?.[0]?.languages?.[0]}
+      >
         {resource.title}
       </ListCardCondensed.Title>
       <ListCardCondensed.Actions>


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Closes https://github.com/mitodl/hq/issues/6831

### Description (What does it do?)
<!--- Describe your changes in detail -->

Sets a lang attribute on the learning drawer title and description and resource card titles for where available to improve machine readability.

This will provide occasional benefit, though we currently have limited data on the API:

- We have a `resource.language` attribute, though I haven't come across any resources where this is not null. This course has `resource.language` null and a title and description in Turkish: https://api.learn.mit.edu/api/v1/learning_resources/3048/.

- I'm using the value on `resource.runs[0].languages.[0]`, the first language on the fist run. This is also what we're using for the languages in the drawer info section (though listing all languages for all runs). If a course has runs in several languages, this may not be the language of the parent title and description and in any case there's not guarantee the course title and description are in the same language as the first run.

- Some of our data is missing or incorrect. This course offered in Spanish does not have languages set on its run: https://api.learn.mit.edu/api/v1/learning_resources/16541/. This course offered in Mandarin has "en-us" set on its run languages: https://api.learn.mit.edu/api/v1/learning_resources/2911/

The fix needed, if available on the source data, is to ensure that the language of the course title and description is always set on the on the resource so we're not selecting from the runs in hope of a match. An example of a _good_ resource where the title matches the run language: https://api.learn.mit.edu/api/v1/learning_resources/2908/. Side note: It would be really useful to provide a language filter on the search for foreign language learners.


### How can this be tested?

- Search for some foreign language courses. Some searches:
  - "Kullanıcıdan" (Turkish / tr)
  - "스타트업 기업가정신" (Korean / ko)

- Confirm that the list card titles have a `lang` attribute set to the first run language.

- Open the resource drawer and confirm that both the title and description have a `lang` attribute set.



### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
