### PR TITLE
fix price separator display

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -65,13 +65,18 @@ const Info = ({
   size: Size
 }) => {
   const prices = getLearningResourcePrices(resource)
-  const certificatePrice =
-    size === "small" && prices.certificate.display?.includes("–")
-      ? ""
-      : prices.certificate.display
-        ? prices.certificate.display
-        : ""
-  const separator = size === "small" ? "" : ": "
+  const getCertPriceAndLabel = () => {
+    if (size === "small") {
+      const label = ""
+      const hasRange = prices.course.display?.includes("–")
+      const certificatePrice = hasRange ? "" : prices.certificate.display
+      return { certificatePrice, label }
+    }
+    const certificatePrice = prices.certificate.display
+    const label = certificatePrice ? "Certificate:" : "Certificate"
+    return { certificatePrice, label }
+  }
+  const { certificatePrice, label } = getCertPriceAndLabel()
   return (
     <>
       <span>{getReadableResourceType(resource.resource_type)}</span>
@@ -83,14 +88,14 @@ const Info = ({
                 <RiAwardFill />
               </Tooltip>
             ) : (
-              <RiAwardFill />
+              <>
+                <RiAwardFill />
+                {label}
+                {certificatePrice ? (
+                  <CertificatePrice>{certificatePrice}</CertificatePrice>
+                ) : null}
+              </>
             )}
-            {size === "small" ? "" : "Certificate"}
-            {certificatePrice ? (
-              <CertificatePrice>
-                {`${separator}${certificatePrice}`}
-              </CertificatePrice>
-            ) : null}
           </Certificate>
         )}
         <Price>{prices.course.display}</Price>


### PR DESCRIPTION
### What are the relevant tickets?
- https://github.com/mitodl/hq/issues/7572

### Description (What does it do?)
Fixes the colon display on resource cards.

### Screenshots (if appropriate):

Previously the colon between certificate and price displayed poorly:

#### OLD
<img width="300"  alt="Screenshot 2025-07-11 at 11 41 28 AM" src="https://github.com/user-attachments/assets/ad3cb52e-d01a-4cd4-8a10-4824f501d49b" /> <img width="300" alt="Screenshot 2025-07-11 at 11 41 38 AM" src="https://github.com/user-attachments/assets/ddc5d005-4645-435a-bfa9-498635201dc5" />



#### Free, but offers paid certificate, single price (NEW)
<img width="647" height="399" alt="Screenshot 2025-07-11 at 11 35 05 AM" src="https://github.com/user-attachments/assets/f37fb69a-9b7b-4be1-9e1d-2c56714210a2" />
<img width="471" height="303" alt="Screenshot 2025-07-11 at 11 35 10 AM" src="https://github.com/user-attachments/assets/56247c15-dc7e-4534-8d01-aee009a2e630" />

#### Free, but offers paid certificate, multiple price (UNCHANGED)
<img width="570" height="388" alt="Screenshot 2025-07-11 at 11 35 17 AM" src="https://github.com/user-attachments/assets/328fe874-689b-4aac-aa75-5114bc89a509" />
<img width="499" height="343" alt="Screenshot 2025-07-11 at 11 35 24 AM" src="https://github.com/user-attachments/assets/332bdc81-1003-4383-99a5-739e3fafecc1" />

#### Must Paid, Single Price (UNCHANGED)
<img width="635" height="385" alt="Screenshot 2025-07-11 at 11 35 31 AM" src="https://github.com/user-attachments/assets/4234eb77-514a-425a-ab6a-e05ecf24cfc0" />
<img width="609" height="334" alt="Screenshot 2025-07-11 at 11 35 38 AM" src="https://github.com/user-attachments/assets/8d9b6dd8-8f3e-4c53-b125-18b42c6b823d" />

#### Must Paid, Multi Price (UNCHANGED)
<img width="620" height="423" alt="Screenshot 2025-07-11 at 11 35 42 AM" src="https://github.com/user-attachments/assets/a5a75619-ec71-4413-a9ba-61336b7e1a91" />
<img width="548" height="370" alt="Screenshot 2025-07-11 at 11 35 48 AM" src="https://github.com/user-attachments/assets/64fb28b0-6be9-4f13-9e6c-9dfd3d1e15d9" />


### How can this be tested?
View courses with optional, paid certificate (most mitxonline courses)