### PR TITLE
add a healthcheck route

### DIFF
--- a/frontends/main/src/app/healthcheck/route.ts
+++ b/frontends/main/src/app/healthcheck/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+  return Response.json({ status: "ok" }, { status: 200 })
+}


### PR DESCRIPTION
### What are the relevant tickets?
None (?)

### Description (What does it do?)
Adds a healthcheck endpoint for use in our kubernetes deployments

### How can this be tested?
With docker up, `curl -v http://learn.odl.local:8062/healthcheck`. You should get a 200 response.
