### PR TITLE
remove unused MITOL_NOINDEX from django settings [Only used on nextjs]

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -747,9 +747,6 @@ POSTHOG_PROJECT_ID = get_int(
     default=None,
 )
 
-# Enable or disable search engine indexing
-MITOL_NOINDEX = get_bool("MITOL_NOINDEX", True)  # noqa: FBT003
-
 # Search defaults settings - adjustable throught the admin ui
 DEFAULT_SEARCH_MODE = get_string(name="DEFAULT_SEARCH_MODE", default="phrase")
 DEFAULT_SEARCH_SLOP = get_int(name="DEFAULT_SEARCH_SLOP", default=6)


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Removes an unused django setting.

### How can this be tested?
Tests should pass. Search `MITOL_NOINDEX` in codebase; only used in NextJS app.


### Additional Context
Noticed this while working on https://github.com/mitodl/ol-infrastructure/pull/3380; the backend env var that was setting this value is reoved in that PR.
