### PR TITLE
check that page exists before using it

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/transform.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/transform.test.tsx
@@ -33,7 +33,7 @@ describe("Transforming mitxonline enrollment data to DashboardResource", () => {
         coursewareId: apiData.run.courseware_id ?? null,
         type: DashboardResourceType.Course,
         title: apiData.run.title,
-        marketingUrl: apiData.run.course.page.page_url,
+        marketingUrl: apiData.run.course.page?.page_url,
         run: {
           startDate: apiData.run.start_date,
           endDate: apiData.run.end_date,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/transform.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/transform.ts
@@ -30,7 +30,7 @@ const mitxonlineEnrollment = (raw: CourseRunEnrollment): DashboardCourse => {
     coursewareId: raw.run.courseware_id ?? null,
     type: DashboardResourceType.Course,
     title: course.title,
-    marketingUrl: course.page.page_url,
+    marketingUrl: course.page?.page_url,
     run: {
       startDate: raw.run.start_date,
       endDate: raw.run.end_date,
@@ -61,7 +61,7 @@ const mitxonlineUnenrolledCourse = (
     coursewareId: run?.courseware_id ?? null,
     type: DashboardResourceType.Course,
     title: course.title,
-    marketingUrl: course.page.page_url,
+    marketingUrl: course.page?.page_url,
     run: {
       startDate: run?.start_date,
       endDate: run?.end_date,


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7838

### Description (What does it do?)
This is a small PR that makes sure we check if the `page` property of a `CourseRun` returned from the MITx Online API exists before accessing its `marketingUrl` property. This prevents an error in the instance that a `CourseRun` does not have a `CoursePage` associated with it.

### How can this be tested?
- In order to test this PR, you should have a running instance of MITx Online that is using the same Keycloak / APISIX as MIT Learn
- Follow the MITx Online docs to create a B2B contract
- Add your user to the Organization created for the contract
- Assuming you are using the default local domains (`open.odl.local` and `mitxonline.odl.local`) access Learn at http://open.odl.local:8062/ and Log In using Keycloak as a superuser
- Open a new tab and browse to http://mitxonline.odl.local:8065/admin
- Create a `Course` object, followed by a `CourseRun` that references that (adding it to the contract created earlier), followed by a `Product` that references the `CourseRun`, creating basically the bare minimum for a course to be enrollable
- Browse to the Learn dashboard at http://open.odl.local:8062/dashboard
- Go to the Organization's tab
- Verify that there are no errors, and click the Enroll button on the course you created
- Go back to the dashboard home and verify there are also no errors there
