### PR TITLE
import canvas for single resource

### DIFF
--- a/learning_resources/management/commands/backpopulate_canvas_courses.py
+++ b/learning_resources/management/commands/backpopulate_canvas_courses.py
@@ -20,10 +20,25 @@ class Command(BaseCommand):
             help="Force regenerate existing summaries/flashcards",
         )
 
+        parser.add_argument(
+            "--canvas-ids",
+            dest="canvas_ids",
+            required=False,
+            help="""
+              If set, backpopulate only the canvas courses with these ids.
+              The canvas id is the number in the url for the course on canvas
+              or the numerical part at the start of the readable_id.
+              Example: https://canvas.mit.edu/courses/1234567 -> 1234567
+              Example: readable_id 1234567-foobar -> 1234567
+            """,
+        )
+
     def handle(self, *args, **options):  # noqa: ARG002
         """Populate Canvas courses from S3"""
+        canvas_ids = options["canvas_ids"].split(",") if options["canvas_ids"] else None
 
         task = sync_canvas_courses.delay(
+            canvas_course_ids=canvas_ids,
             overwrite=options["force_overwrite"],
         )
         self.stdout.write(f"Started task {task} to get courses from Canvas")


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/7836

### Description (What does it do?)
This pr adds a filter to the canvas etl to allow filtering by sepecific courses (based on the canvas id)

### How can this be tested?
run
```
from learning_resources.models import *
 r =  LearningResource.objects.filter(readable_id="14566-kaleba:20211202").first()
 c = l.runs.first().content_files.first()
r.title = 'new'
r.save()
c.content='new'
c.save()
```

run `docker compose exec web ./manage.py backpopulate_canvas_courses --canvas-ids=14566 --overwrite`

r and c should have their original title and content. Also you should not see the etl run for any other courses in the logs