### PR TITLE
prevent hero layout shift

### DIFF
--- a/frontends/main/src/page-components/AiChat/AskTimDrawerButton.tsx
+++ b/frontends/main/src/page-components/AiChat/AskTimDrawerButton.tsx
@@ -1,11 +1,10 @@
 import React from "react"
-import { Typography, styled } from "ol-components"
-import { ButtonLink } from "@mitodl/smoot-design"
+import { Typography, styled, LinkAdapter } from "ol-components"
 import { RiSparkling2Line } from "@remixicon/react"
 import AiRecommendationBotDrawer from "./AiRecommendationBotDrawer"
 import { RECOMMENDER_QUERY_PARAM } from "@/common/urls"
 
-const StyledButton = styled(ButtonLink)(({ theme }) => ({
+const StyledButton = styled(LinkAdapter)(({ theme }) => ({
   display: "flex",
   flexDirection: "row",
   gap: "8px",
@@ -33,12 +32,7 @@ const StyledButton = styled(ButtonLink)(({ theme }) => ({
 const AskTIMButton = () => {
   return (
     <>
-      <StyledButton
-        shallow
-        variant="bordered"
-        edge="rounded"
-        href={`?${RECOMMENDER_QUERY_PARAM}`}
-      >
+      <StyledButton shallow href={`?${RECOMMENDER_QUERY_PARAM}`}>
         <RiSparkling2Line />
         <Typography variant="body1">
           Ask<strong>TIM</strong>

--- a/frontends/main/src/page-components/HeroSearch/HeroSearch.tsx
+++ b/frontends/main/src/page-components/HeroSearch/HeroSearch.tsx
@@ -142,6 +142,10 @@ const ActionStrip = styled.div(({ theme }) => ({
   gap: "24px",
   marginTop: "16px",
   marginBottom: "24px",
+  /**
+   * minHeight 28px avoids layout shift as feature flag for AskTim button loads.
+   */
+  minHeight: "28px",
   [theme.breakpoints.down("sm")]: {
     marginTop: "0",
   },

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -149,6 +149,10 @@ export type {
   SelectFieldProps,
 } from "./components/SelectField/SelectField"
 
+export {
+  LinkAdapter,
+  LinkAdapterProps,
+} from "./components/LinkAdapter/LinkAdapter"
 export { Link, linkStyles } from "./components/Link/Link"
 export type { LinkProps } from "./components/Link/Link"
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7818

### Description (What does it do?)
Fixes min height of AskTim hero area container to prevent layout shift as feature flag loads.

### How can this be tested?
1. Load the homepage with AskTim recommendation bot turned on. There should be no layout shift as hero section loads.
2. Open/close the drawer. It should work same.
3. AskTim button should have same dimensions as RC / Prod

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
