### PR TITLE
Disallow robot crawlers outside of Prod

### DIFF
--- a/frontends/main/src/app/robots.ts
+++ b/frontends/main/src/app/robots.ts
@@ -5,22 +5,29 @@ invariant(process.env.NEXT_PUBLIC_ORIGIN, "NEXT_PUBLIC_ORIGIN must be defined")
 const BASE_URL: string = process.env.NEXT_PUBLIC_ORIGIN
 
 export default function robots(): MetadataRoute.Robots {
-  const sitemap =
-    process.env.MITOL_NOINDEX === "false"
-      ? `${BASE_URL}/sitemaps/sitemap-index.xml`
-      : undefined
-  return {
-    rules: {
-      userAgent: "*",
-      allow: "/",
-      disallow: [
-        "/dashboard/",
-        "/learningpaths/",
-        "/onboarding/",
-        "/cart/",
-        "/program_letter/",
-      ],
-    },
-    sitemap,
+  const shouldIndex = process.env.MITOL_NOINDEX === "false"
+
+  if (shouldIndex) {
+    return {
+      rules: {
+        userAgent: "*",
+        allow: "/",
+        disallow: [
+          "/dashboard/",
+          "/learningpaths/",
+          "/onboarding/",
+          "/cart/",
+          "/program_letter/",
+        ],
+      },
+      sitemap: `${BASE_URL}/sitemaps/sitemap-index.xml`,
+    }
+  } else {
+    return {
+      rules: {
+        userAgent: "*",
+        disallow: "/",
+      },
+    }
   }
 }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

https://github.com/mitodl/hq/issues/7866

### Description (What does it do?)
<!--- Describe your changes in detail -->

Disallow search crawlers outside of Prod.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

With `MITOL_NOINDEX` set to false on the environment, you should see the [Prod robots.txt](https://learn.mit.edu/robots.txt):

```
User-Agent: *
Allow: /
Disallow: /dashboard/
Disallow: /learningpaths/
Disallow: /onboarding/
Disallow: /cart/
Disallow: /program_letter/

Sitemap: https://learn.mit.edu/sitemaps/sitemap-index.xml
```

With `MITOL_NOINDEX` unset or set to "true" or any other value, we should see:

```
User-Agent: *
Disallow: /
```
