### PR TITLE
remove unpublished canvas content

### DIFF
--- a/learning_resources/etl/canvas.py
+++ b/learning_resources/etl/canvas.py
@@ -11,11 +11,19 @@ from django.conf import settings
 
 from learning_resources.constants import LearningResourceType, PlatformType
 from learning_resources.etl.constants import ETLSource
-from learning_resources.etl.utils import _process_olx_path, calc_checksum
+from learning_resources.etl.utils import (
+    _process_olx_path,
+    calc_checksum,
+    get_edx_module_id,
+)
 from learning_resources.models import (
     LearningResource,
     LearningResourcePlatform,
     LearningResourceRun,
+)
+from learning_resources.utils import bulk_resources_unpublished_actions
+from learning_resources_search.constants import (
+    CONTENT_FILE_TYPE,
 )
 
 log = logging.getLogger(__name__)
@@ -119,17 +127,27 @@ def transform_canvas_content_files(
     published_items = [
         Path(item["path"]).resolve() for item in module_metadata["active"]
     ]
+    published_keys = []
     with (
         TemporaryDirectory(prefix=basedir) as olx_path,
         zipfile.ZipFile(course_zipfile.absolute(), "r") as course_archive,
     ):
         for member in course_archive.infolist():
             if Path(member.filename).resolve() in published_items:
+                published_keys.append(
+                    get_edx_module_id(Path(olx_path) / Path(member.filename), run)
+                )
                 course_archive.extract(member, path=olx_path)
                 log.debug("processing active file %s", member.filename)
             else:
                 log.debug("skipping unpublished file %s", member.filename)
         yield from _process_olx_path(olx_path, run, overwrite=overwrite)
+
+    unpublished_content = run.content_files.exclude(key__in=published_keys)
+    bulk_resources_unpublished_actions(
+        unpublished_content.values_list("id", flat=True), CONTENT_FILE_TYPE
+    )
+    unpublished_content.delete()
 
 
 def transform_canvas_problem_files(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/7895
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR makes it so that when we receive a new canvas archive, any existing content that is now set to unpublished or no longer exists gets removed.


### How can this be tested?
1. Checkout this branch and restart celery
2. do an initial backpopulate of canvas courses to populate the database ```python manage.py backpopulate_canvas_courses```
3. To simulate a file that no longer exists in the archive, grab a canvas contentfile and modify the "key" attribute and note the new value:
```python
from learning_resources.models import *
cf = ContentFile.objects.filter(run__learning_resource__etl_source="canvas").first()
cf.key = cf.key + "test"
cf.save()
print(cf.key)
```
4. rerun the backpopulate command and note that the modified content file no longer exists and is also not in the indexes
