### PR TITLE
tutorbot problems api

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -4316,6 +4316,19 @@ export interface PreferencesSearch {
   delivery?: Array<string>
 }
 /**
+ *
+ * @export
+ * @interface ProblemListResponse
+ */
+export interface ProblemListResponse {
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof ProblemListResponse
+   */
+  problem_set_titles: Array<string>
+}
+/**
  * Serializer for Profile
  * @export
  * @interface Profile
@@ -5046,6 +5059,25 @@ export const ResourceTypeEnum = {
 export type ResourceTypeEnum =
   (typeof ResourceTypeEnum)[keyof typeof ResourceTypeEnum]
 
+/**
+ *
+ * @export
+ * @interface RetrieveProblemResponse
+ */
+export interface RetrieveProblemResponse {
+  /**
+   *
+   * @type {string}
+   * @memberof RetrieveProblemResponse
+   */
+  problem_set: string
+  /**
+   *
+   * @type {string}
+   * @memberof RetrieveProblemResponse
+   */
+  solution_set: string
+}
 /**
  * * `facebook` - facebook * `linkedin` - linkedin * `personal` - personal * `twitter` - twitter
  * @export
@@ -9801,6 +9833,323 @@ export class TestimonialsApi extends BaseAPI {
   ) {
     return TestimonialsApiFp(this.configuration)
       .testimonialsRetrieve(requestParameters.id, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+}
+
+/**
+ * TutorApi - axios parameter creator
+ * @export
+ */
+export const TutorApiAxiosParamCreator = function (
+  configuration?: Configuration,
+) {
+  return {
+    /**
+     * Retrieve a list of problem names for a course run
+     * @summary Retrieve problem list
+     * @param {string} run_readable_id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    listProblems: async (
+      run_readable_id: string,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'run_readable_id' is not null or undefined
+      assertParamExists("listProblems", "run_readable_id", run_readable_id)
+      const localVarPath = `/api/v0/tutor/problems/{run_readable_id}/`.replace(
+        `{${"run_readable_id"}}`,
+        encodeURIComponent(String(run_readable_id)),
+      )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "GET",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     * Retrieve a specific problem and its solution for a course run
+     * @summary Retrieve Problem
+     * @param {string} problem_title
+     * @param {string} run_readable_id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    retrieveProblem: async (
+      problem_title: string,
+      run_readable_id: string,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'problem_title' is not null or undefined
+      assertParamExists("retrieveProblem", "problem_title", problem_title)
+      // verify required parameter 'run_readable_id' is not null or undefined
+      assertParamExists("retrieveProblem", "run_readable_id", run_readable_id)
+      const localVarPath =
+        `/api/v0/tutor/problems/{run_readable_id}/{problem_title}/`
+          .replace(
+            `{${"problem_title"}}`,
+            encodeURIComponent(String(problem_title)),
+          )
+          .replace(
+            `{${"run_readable_id"}}`,
+            encodeURIComponent(String(run_readable_id)),
+          )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "GET",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+  }
+}
+
+/**
+ * TutorApi - functional programming interface
+ * @export
+ */
+export const TutorApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator = TutorApiAxiosParamCreator(configuration)
+  return {
+    /**
+     * Retrieve a list of problem names for a course run
+     * @summary Retrieve problem list
+     * @param {string} run_readable_id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async listProblems(
+      run_readable_id: string,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<ProblemListResponse>
+    > {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.listProblems(
+        run_readable_id,
+        options,
+      )
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap["TutorApi.listProblems"]?.[index]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+    /**
+     * Retrieve a specific problem and its solution for a course run
+     * @summary Retrieve Problem
+     * @param {string} problem_title
+     * @param {string} run_readable_id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async retrieveProblem(
+      problem_title: string,
+      run_readable_id: string,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<RetrieveProblemResponse>
+    > {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.retrieveProblem(
+        problem_title,
+        run_readable_id,
+        options,
+      )
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap["TutorApi.retrieveProblem"]?.[index]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+  }
+}
+
+/**
+ * TutorApi - factory interface
+ * @export
+ */
+export const TutorApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance,
+) {
+  const localVarFp = TutorApiFp(configuration)
+  return {
+    /**
+     * Retrieve a list of problem names for a course run
+     * @summary Retrieve problem list
+     * @param {TutorApiListProblemsRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    listProblems(
+      requestParameters: TutorApiListProblemsRequest,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<ProblemListResponse> {
+      return localVarFp
+        .listProblems(requestParameters.run_readable_id, options)
+        .then((request) => request(axios, basePath))
+    },
+    /**
+     * Retrieve a specific problem and its solution for a course run
+     * @summary Retrieve Problem
+     * @param {TutorApiRetrieveProblemRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    retrieveProblem(
+      requestParameters: TutorApiRetrieveProblemRequest,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<RetrieveProblemResponse> {
+      return localVarFp
+        .retrieveProblem(
+          requestParameters.problem_title,
+          requestParameters.run_readable_id,
+          options,
+        )
+        .then((request) => request(axios, basePath))
+    },
+  }
+}
+
+/**
+ * Request parameters for listProblems operation in TutorApi.
+ * @export
+ * @interface TutorApiListProblemsRequest
+ */
+export interface TutorApiListProblemsRequest {
+  /**
+   *
+   * @type {string}
+   * @memberof TutorApiListProblems
+   */
+  readonly run_readable_id: string
+}
+
+/**
+ * Request parameters for retrieveProblem operation in TutorApi.
+ * @export
+ * @interface TutorApiRetrieveProblemRequest
+ */
+export interface TutorApiRetrieveProblemRequest {
+  /**
+   *
+   * @type {string}
+   * @memberof TutorApiRetrieveProblem
+   */
+  readonly problem_title: string
+
+  /**
+   *
+   * @type {string}
+   * @memberof TutorApiRetrieveProblem
+   */
+  readonly run_readable_id: string
+}
+
+/**
+ * TutorApi - object-oriented interface
+ * @export
+ * @class TutorApi
+ * @extends {BaseAPI}
+ */
+export class TutorApi extends BaseAPI {
+  /**
+   * Retrieve a list of problem names for a course run
+   * @summary Retrieve problem list
+   * @param {TutorApiListProblemsRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof TutorApi
+   */
+  public listProblems(
+    requestParameters: TutorApiListProblemsRequest,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return TutorApiFp(this.configuration)
+      .listProblems(requestParameters.run_readable_id, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   * Retrieve a specific problem and its solution for a course run
+   * @summary Retrieve Problem
+   * @param {TutorApiRetrieveProblemRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof TutorApi
+   */
+  public retrieveProblem(
+    requestParameters: TutorApiRetrieveProblemRequest,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return TutorApiFp(this.configuration)
+      .retrieveProblem(
+        requestParameters.problem_title,
+        requestParameters.run_readable_id,
+        options,
+      )
       .then((request) => request(this.axios, this.basePath))
   }
 }

--- a/learning_resources/constants.py
+++ b/learning_resources/constants.py
@@ -338,3 +338,4 @@ CURRENCY_USD = "USD"
 
 
 GROUP_CONTENT_FILE_CONTENT_VIEWERS = "content_file_viewers"
+GROUP_TUTOR_PROBLEM_VIEWERS = "tutor_problem_viewers"

--- a/learning_resources/migrations/0093_tutorproblem_view_group.py
+++ b/learning_resources/migrations/0093_tutorproblem_view_group.py
@@ -1,0 +1,28 @@
+from django.contrib.auth.models import Group
+from django.db import migrations
+
+from learning_resources import constants
+
+
+def add_tutor_problem_viewers(apps, schema_editor):
+    """
+    Create group that can view tutor problems from the APIs
+    """
+    Group.objects.get_or_create(name=constants.GROUP_TUTOR_PROBLEM_VIEWERS)
+
+
+def remove_tutor_problem_viewers(apps, schema_editor):
+    """
+    Delete the tutor problem viewers group
+    """
+    Group.objects.filter(name=constants.GROUP_TUTOR_PROBLEM_VIEWERS).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("learning_resources", "0092_tutorproblemfile"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_tutor_problem_viewers, remove_tutor_problem_viewers),
+    ]

--- a/learning_resources/urls.py
+++ b/learning_resources/urls.py
@@ -132,8 +132,16 @@ v1_urls = [
     ),
 ]
 
+v0_router = SimpleRouter()
+v0_router.register(
+    r"tutor/problems", views.CourseRunProblemsViewSet, basename="tutorproblem_api"
+)
+
+v0_urls = v0_router.urls
+
 app_name = "lr"
 urlpatterns = [
     re_path(r"^api/v1/", include((v1_urls, "v1"))),
+    re_path(r"^api/v0/", include((v0_urls, "v0"))),
     path("podcasts/rss_feed", views.podcast_rss_feed, name="podcast-rss-feed"),
 ]

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -621,6 +621,54 @@ paths:
               schema:
                 $ref: '#/components/schemas/Attestation'
           description: ''
+  /api/v0/tutor/problems/{run_readable_id}/:
+    get:
+      operationId: list_problems
+      description: Retrieve a list of problem names for a course run
+      summary: Retrieve problem list
+      parameters:
+      - in: path
+        name: run_readable_id
+        schema:
+          type: string
+          pattern: ^[^/]+$
+        required: true
+      tags:
+      - tutor
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemListResponse'
+          description: ''
+  /api/v0/tutor/problems/{run_readable_id}/{problem_title}/:
+    get:
+      operationId: retrieve_problem
+      description: Retrieve a specific problem and its solution for a course run
+      summary: Retrieve Problem
+      parameters:
+      - in: path
+        name: problem_title
+        schema:
+          type: string
+          pattern: ^[^/]+$
+        required: true
+      - in: path
+        name: run_readable_id
+        schema:
+          type: string
+          pattern: ^[^/]+$
+        required: true
+      tags:
+      - tutor
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetrieveProblemResponse'
+          description: ''
   /api/v0/users/:
     get:
       operationId: users_list
@@ -4463,6 +4511,15 @@ components:
           type: array
           items:
             type: string
+    ProblemListResponse:
+      type: object
+      properties:
+        problem_set_titles:
+          type: array
+          items:
+            type: string
+      required:
+      - problem_set_titles
     Profile:
       type: object
       description: Serializer for Profile
@@ -5024,6 +5081,16 @@ components:
       x-enum-descriptions:
       - news
       - events
+    RetrieveProblemResponse:
+      type: object
+      properties:
+        problem_set:
+          type: string
+        solution_set:
+          type: string
+      required:
+      - problem_set
+      - solution_set
     SiteTypeEnum:
       enum:
       - facebook


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/7891

### Description (What does it do?)
This pr adds apis to retrieve all problem sets available for a canvas course and also the problem and solution text for a problem set

### How can this be tested?
Run docker compose exec web ./manage.py backpopulate_canvas_courses --canvas-ids=14566 --overwrite to get TutorProblemFiles

Log in as an admin:
Go to http://api.open.odl.local:8065/api/v0/tutorproblems/14566-kaleba:20211202+canvas you should see:
`
{
    "problem_set_titles": [
        "Problem Set 1",
        "Problem Set 2"
    ]
}
`

Go to http://api.open.odl.local:8065/api/v0/tutorproblems/14566-kaleba:20211202+canvas/Problem%20Set%201/

you should see

```
{
    "problem_set": "1. Predicting Life Expectancy in the United States...",
    "solution_set": "1. Predicting Life Expectancy in the United States ..."
}

```

Log out (or log in as a non-admin)

You should see NotAuthenticated or PermissionDenied messages at those urls
