### PR TITLE
Process pdf problem sets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY apt.txt /tmp/apt.txt
 RUN apt-get update && \
     apt-get install -y --no-install-recommends $(grep -vE "^\s*#" apt.txt | tr "\n" " ") && \
     apt-get install libpq-dev postgresql-client -y --no-install-recommends && \
+    apt-get install poppler-utils -y && \
     apt-get clean && \
     apt-get purge &&  \
     rm -rf /var/lib/apt/lists/*

--- a/learning_resources/etl/canvas.py
+++ b/learning_resources/etl/canvas.py
@@ -13,7 +13,6 @@ from django.conf import settings
 from litellm import completion
 from pdf2image import convert_from_path
 from PIL import Image
-from pydantic import BaseModel
 
 from learning_resources.constants import LearningResourceType, PlatformType
 from learning_resources.etl.constants import ETLSource
@@ -33,10 +32,6 @@ from learning_resources_search.constants import (
 )
 
 log = logging.getLogger(__name__)
-
-
-class TranscribedTutorProblem(BaseModel):
-    markdown_content: str
 
 
 def sync_canvas_archive(bucket, key: str, overwrite):

--- a/learning_resources/etl/canvas_test.py
+++ b/learning_resources/etl/canvas_test.py
@@ -11,6 +11,7 @@ from learning_resources.etl.canvas import (
     parse_module_meta,
     run_for_canvas_archive,
     transform_canvas_content_files,
+    transform_canvas_problem_files,
 )
 from learning_resources.etl.constants import ETLSource
 from learning_resources.etl.utils import get_edx_module_id
@@ -30,6 +31,18 @@ pytestmark = pytest.mark.django_db
 def canvas_platform():
     """Fixture for the canvas platform"""
     return LearningResourcePlatformFactory.create(code=PlatformType.canvas.name)
+
+
+def canvas_zip_with_problem_files(tmp_path, files):
+    """
+    Create a Canvas zip with problem files in the tutorbot folder.
+    `files` is a list of tuples: (filename, content_bytes)
+    """
+    zip_path = tmp_path / "canvas_course_with_problems.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for filename, content in files:
+            zf.writestr(f"tutorbot/{filename}", content)
+    return zip_path
 
 
 @pytest.fixture
@@ -338,3 +351,80 @@ def test_transform_canvas_content_files_removes_unpublished_content(mocker, tmp_
 
     # Ensure unpublished content is deleted and unpublished actions called
     bulk_unpub.assert_called_once_with([unpublished_cf.id], CONTENT_FILE_TYPE)
+
+
+def test_transform_canvas_problem_files_pdf_calls_pdf_to_markdown(
+    tmp_path, mocker, settings
+):
+    """
+    Test that transform_canvas_problem_files calls _pdf_to_markdown for PDF files.
+    """
+
+    settings.CANVAS_TUTORBOT_FOLDER = "tutorbot/"
+    settings.CANVAS_PDF_TRANSCRIPTION_MODEL = "fake-model"
+    pdf_filename = "problemset1/problem.pdf"
+    pdf_content = b"%PDF-1.4 fake pdf content"
+    zip_path = canvas_zip_with_problem_files(tmp_path, [(pdf_filename, pdf_content)])
+
+    # return a file with pdf extension
+    fake_file_data = {
+        "run": "run",
+        "content": "original pdf content",
+        "archive_checksum": "checksum",
+        "source_path": f"tutorbot/{pdf_filename}",
+        "file_extension": ".pdf",
+    }
+    mocker.patch(
+        "learning_resources.etl.canvas._process_olx_path",
+        return_value=iter([fake_file_data]),
+    )
+
+    # Patch _pdf_to_markdown to return a known value
+    pdf_to_md = mocker.patch(
+        "learning_resources.etl.canvas._pdf_to_markdown",
+        return_value="markdown content from pdf",
+    )
+
+    # Patch Path(olx_path) / Path(problem_file_data["source_path"]) to exist
+    run = mocker.Mock()
+
+    results = list(transform_canvas_problem_files(zip_path, run, overwrite=True))
+
+    pdf_to_md.assert_called_once()
+    assert results[0]["content"] == "markdown content from pdf"
+    assert results[0]["problem_title"] == "problemset1"
+
+
+def test_transform_canvas_problem_files_non_pdf_does_not_call_pdf_to_markdown(
+    tmp_path, mocker, settings
+):
+    """
+    Test that transform_canvas_problem_files does not call _pdf_to_markdown for non-PDF files.
+    """
+    settings.CANVAS_TUTORBOT_FOLDER = "tutorbot/"
+    settings.CANVAS_PDF_TRANSCRIPTION_MODEL = "fake-model"
+    html_filename = "problemset2/problem.html"
+    html_content = b"<html>problem</html>"
+    zip_path = canvas_zip_with_problem_files(tmp_path, [(html_filename, html_content)])
+
+    fake_file_data = {
+        "run": "run",
+        "content": "original html content",
+        "archive_checksum": "checksum",
+        "source_path": f"tutorbot/{html_filename}",
+        "file_extension": ".html",
+    }
+    mocker.patch(
+        "learning_resources.etl.canvas._process_olx_path",
+        return_value=iter([fake_file_data]),
+    )
+
+    pdf_to_md = mocker.patch("learning_resources.etl.canvas._pdf_to_markdown")
+
+    run = mocker.Mock()
+
+    results = list(transform_canvas_problem_files(zip_path, run, overwrite=True))
+
+    pdf_to_md.assert_not_called()
+    assert results[0]["content"] == "original html content"
+    assert results[0]["problem_title"] == "problemset2"

--- a/main/settings_course_etl.py
+++ b/main/settings_course_etl.py
@@ -69,8 +69,12 @@ CANVAS_COURSE_BUCKET_PREFIX = get_string(
     "CANVAS_COURSE_BUCKET_PREFIX", "canvas/course_content"
 )
 CANVAS_PDF_TRANSCRIPTION_MODEL = get_string(
-    name="CANVAS_PDF_TRANSCRIPTION_MODEL",
-    default=None,
+    name="CANVAS_PDF_TRANSCRIPTION_MODEL", default=None
+)
+CANVAS_TRANSCRIPTION_PROMPT = get_string(
+    "CANVAS_TRANSCRIPTION_PROMPT",
+    """Transcribe the contents of this file into markdown.
+    Do not include anything but the markdown content in your response""",
 )
 # More MIT URLs
 SEE_API_URL = get_string("SEE_API_URL", None)

--- a/main/settings_course_etl.py
+++ b/main/settings_course_etl.py
@@ -68,6 +68,10 @@ CANVAS_COURSE_BUCKET_NAME = get_string("CANVAS_COURSE_BUCKET_NAME", None)
 CANVAS_COURSE_BUCKET_PREFIX = get_string(
     "CANVAS_COURSE_BUCKET_PREFIX", "canvas/course_content"
 )
+CANVAS_PDF_TRANSCRIPTION_MODEL = get_string(
+    name="CANVAS_PDF_TRANSCRIPTION_MODEL",
+    default=None,
+)
 # More MIT URLs
 SEE_API_URL = get_string("SEE_API_URL", None)
 SEE_API_ACCESS_TOKEN_URL = get_string("SEE_API_ACCESS_TOKEN_URL", None)

--- a/poetry.lock
+++ b/poetry.lock
@@ -5511,6 +5511,21 @@ pygments = "*"
 testing = ["ipython", "pexpect", "pytest", "pytest-cov"]
 
 [[package]]
+name = "pdf2image"
+version = "1.17.0"
+description = "A wrapper around the pdftoppm and pdftocairo command line tools to convert PDF to a PIL Image list."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "pdf2image-1.17.0-py3-none-any.whl", hash = "sha256:ecdd58d7afb810dffe21ef2b1bbc057ef434dabbac6c33778a38a3f7744a27e2"},
+    {file = "pdf2image-1.17.0.tar.gz", hash = "sha256:eaa959bc116b420dd7ec415fcae49b98100dda3dd18cd2fdfa86d09f112f6d57"},
+]
+
+[package.dependencies]
+pillow = "*"
+
+[[package]]
 name = "pexpect"
 version = "4.9.0"
 description = "Pexpect allows easy control of interactive console applications."
@@ -9088,4 +9103,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12"
-content-hash = "5f3bc029ac5f5738e82afac9782fb1199535f8ea69b82c645f89332bd0d5959c"
+content-hash = "e3bcf0ab2a5aa2defcc25d6b58fba52d561c2cfcb58446257f1ee7f7e44879e4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ uwsgi = "^2.0.29"
 uwsgitop = "^0.12"
 wrapt = "^1.14.1"
 youtube-transcript-api = "^1.0.0"
+pdf2image = "^1.17.0"
 
 [tool.poetry.group.dev.dependencies]
 bpython = "^0.25"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/7933
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR lets us process pdf problem sets and solutions (via LLM) from canvas archives


### How can this be tested?
It doesn't seem like we currently have any existing pdf problemsets in the archives on s3 so these instructions but we can test part of this locally

1. checkout this branch
2. make sure you have set main.settings_course_etl.CANVAS_COURSE_BUCKET_NAME
3. set main.settings_course_etl.CANVAS_PDF_TRANSCRIPTION_MODEL to "gpt-4o-mini". Also make sure your OPENAI_API_KEY env var is set to a working key (this must be present in both your settings and in the environment)
4. rebuild your celery and web containers to pick up the new dependencies ```docker compose down web celery && docker compose build web celery```
5. once you rebuild and bring the web and celery containers back up, get into a shell
6. put the attached test_canvas_archive into your "mit-learn" main directory
7. run the following to ingest the problemsets from the test archive:
```python
from pathlib import Path
from learning_resources.models import *
from learning_resources.etl.canvas import transform_canvas_problem_files
run = LearningResourceRun.objects.first()
output = list(transform_canvas_problem_files(Path("test_canvas_archive.zip"), run, overwrite=True))
```

then print the markdown:
```python
print(output[0]['content']
```
8. copy and paste this markdown into a text file along with the included script like so:
```html
<!DOCTYPE html><script src="https://cdn.jsdelivr.net/npm/texme@1.2.2"></script><textarea>

18.06 Problem Set 4 Solution

Total: 100 points

Section 3.5. Problem 2: (Recommended) Find the largest possible number of independent vectors among

\[
v_1 = \begin{bmatrix} 1 \\ -1 \\ 0 \\ 0 \end{bmatrix} \quad
v_2 = \begin{bmatrix} 1 \\ 0 \\ -1 \\ 0 \end{bmatrix} \quad
...
```
9. save this as a .html file and open in browser to view the rendered markdown



### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
