### PR TITLE
Backgrounds for video buttons

### DIFF
--- a/frontends/main/src/app-pages/HomePage/VideoShortsModal.tsx
+++ b/frontends/main/src/app-pages/HomePage/VideoShortsModal.tsx
@@ -19,25 +19,41 @@ const Overlay = styled.div(({ theme }) => ({
   },
 }))
 
-const CloseButton = styled(ActionButton)({
+const BaseButton = styled(ActionButton)(({ theme }) => ({
   position: "absolute",
+  zIndex: 1201,
+  svg: {
+    fill: "white",
+  },
+  [theme.breakpoints.down("md")]: {
+    backgroundColor: "rgba(0, 0, 0, 0.3)",
+    borderRadius: "50%",
+    height: "58px",
+    width: "58px",
+    right: "26px",
+    "&&:hover": {
+      backgroundColor: "rgba(40, 40, 40, 0.6)",
+    },
+  },
+}))
+
+const CloseButton = styled(BaseButton)(({ theme }) => ({
   top: "16px",
   right: "16px",
-  zIndex: 1201,
-  svg: {
-    fill: "white",
+  [theme.breakpoints.down("md")]: {
+    top: "26px",
+    right: "26px",
   },
-})
+}))
 
-const MuteButton = styled(ActionButton)({
-  position: "absolute",
+const MuteButton = styled(BaseButton)(({ theme }) => ({
   right: "16px",
   bottom: "16px",
-  zIndex: 1201,
-  svg: {
-    fill: "white",
+  [theme.breakpoints.down("md")]: {
+    bottom: "26px",
+    right: "26px",
   },
-})
+}))
 
 const CarouselSlide = styled.div<{ width: number }>(({ width, theme }) => ({
   width,

--- a/frontends/main/src/app-pages/HomePage/VideoShortsModal.tsx
+++ b/frontends/main/src/app-pages/HomePage/VideoShortsModal.tsx
@@ -25,7 +25,7 @@ const BaseButton = styled(ActionButton)(({ theme }) => ({
   svg: {
     fill: "white",
   },
-  [theme.breakpoints.down("md")]: {
+  [`${theme.breakpoints.down("md")} and (orientation: portrait)`]: {
     backgroundColor: "rgba(0, 0, 0, 0.3)",
     borderRadius: "50%",
     height: "58px",
@@ -40,7 +40,7 @@ const BaseButton = styled(ActionButton)(({ theme }) => ({
 const CloseButton = styled(BaseButton)(({ theme }) => ({
   top: "16px",
   right: "16px",
-  [theme.breakpoints.down("md")]: {
+  [`${theme.breakpoints.down("md")} and (orientation: portrait)`]: {
     top: "26px",
     right: "26px",
   },
@@ -49,7 +49,7 @@ const CloseButton = styled(BaseButton)(({ theme }) => ({
 const MuteButton = styled(BaseButton)(({ theme }) => ({
   right: "16px",
   bottom: "16px",
-  [theme.breakpoints.down("md")]: {
+  [`${theme.breakpoints.down("md")} and (orientation: portrait)`]: {
     bottom: "26px",
     right: "26px",
   },


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

- https://github.com/mitodl/hq/issues/7824

### Description (What does it do?)
<!--- Describe your changes in detail -->

Following from https://github.com/mitodl/mit-learn/pull/2388, adds a translucent background to close and mute buttons to ensure they are visible if the video playing beneath them is white.

- Applies at <md width breakpoint (900px).
- Button backgrounds have more opacity on hover.
- Backgrounds are applied at portrait orientation on mobile (landscape backgrounds will always be black as the vertical video is centered).


### Screenshots (if appropriate):

<img width="605" height="1074" alt="image" src="https://github.com/user-attachments/assets/f3068b52-735b-4f5a-b4a4-6141a8714137" />

<img width="93" height="91" alt="image" src="https://github.com/user-attachments/assets/984c48dc-1f4c-44cc-97e1-6381264695bc" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- In your PostHog instance, create a feature flag "video-shorts" and set it to 100% rollout. Alternatively, assign videoShortsEnabled in MediaSection.tsx to true.

- Check that the buttons have backgrounds on desktop at window widths < 900px and on mobile while in portrait orientation.
