### PR TITLE
change problem set list permissions

### DIFF
--- a/learning_resources/permissions.py
+++ b/learning_resources/permissions.py
@@ -6,7 +6,11 @@ from django.http import HttpRequest
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import SAFE_METHODS, BasePermission
 
-from learning_resources.constants import GROUP_STAFF_LISTS_EDITORS, PrivacyLevel
+from learning_resources.constants import (
+    GROUP_STAFF_LISTS_EDITORS,
+    GROUP_TUTOR_PROBLEM_VIEWERS,
+    PrivacyLevel,
+)
 from learning_resources.models import LearningPath, UserList
 from main.permissions import is_admin_user, is_readonly
 
@@ -115,3 +119,13 @@ class HasUserListItemPermissions(BasePermission):
                 or obj.parent.privacy_level == PrivacyLevel.unlisted.value
             )
         return request.user == obj.parent.author
+
+
+class IsAdminOrTutorProblemViewer(BasePermission):
+    def has_permission(self, request, view):  # noqa: ARG002
+        user = request.user
+        if not user or not user.is_authenticated:
+            return False
+        if user.is_staff or user.is_superuser:
+            return True
+        return user.groups.filter(name=GROUP_TUTOR_PROBLEM_VIEWERS).exists()

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -1418,7 +1418,17 @@ def test_learning_resources_summary_listing_endpoint_large_pagesize():
     ],
 )
 def test_course_run_problems_endpoint(client, user_role, django_user_model):
-    """Test course run problems endpoint"""
+    """
+    Test course run problems endpoint.
+
+    All types of users should be able to get a list of problem set titles
+    for a course run from api/v0/tutorproblems/<run_readable_id>
+
+    Only admin and group_tutor_problem_viewer users should be able to get
+    problem and solution content from
+    api/v0/tutorproblems/<run_readable_id>/<problem_set_title>
+    Normal users and anonymous users should receive a 403  response
+    """
     course_run = LearningResourceRunFactory.create(
         learning_resource=CourseFactory.create(
             platform=PlatformType.canvas.name
@@ -1463,20 +1473,7 @@ def test_course_run_problems_endpoint(client, user_role, django_user_model):
         reverse("lr:v0:tutorproblem_api-list-problems", args=[course_run.run_id])
     )
 
-    if user_role in ["admin", "group_tutor_problem_viewer"]:
-        assert resp.json() == {"problem_set_titles": ["Problem Set 1", "Problem Set 2"]}
-    elif user_role == "normal":
-        assert resp.status_code == 403
-        assert resp.json() == {
-            "detail": "You do not have permission to perform this action.",
-            "error_type": "PermissionDenied",
-        }
-    elif user_role == "anonymous":
-        assert resp.status_code == 403
-        assert resp.json() == {
-            "detail": "Authentication credentials were not provided.",
-            "error_type": "NotAuthenticated",
-        }
+    assert resp.json() == {"problem_set_titles": ["Problem Set 1", "Problem Set 2"]}
 
     detail_resp = client.get(
         reverse(


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Currently both the api for listing problem sets for a course run and the api for showing problem set content requires a login and permissions. It will simplify the ui for the canvas tutorbot if the problem set list api was public. The problem set and solution content should still require a login and special permissions.

This would be consistent with how we treat content files too. Content file titles are available to anonymous users/ users without special permissions but content file content requires a login and permissions.

### How can this be tested?
Run docker compose exec web ./manage.py backpopulate_canvas_courses --canvas-ids=14566 --overwrite

As an anonymous user go to 
http://api.open.odl.local:8063/api/v0/tutor/problems/14566-kaleba:20211202+canvas/
you should see results
go to
http://api.open.odl.local:8063/api/v0/tutor/problems/14566-kaleba:20211202+canvas/Problem%20Set%201

you should get NotAuthenticated error,

Log in as an admin

You should see results at both the above urls