### PR TITLE
Disable Pagination on UserList and LearningPath items

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -4025,37 +4025,6 @@ export interface PaginatedUserListList {
 /**
  *
  * @export
- * @interface PaginatedUserListRelationshipList
- */
-export interface PaginatedUserListRelationshipList {
-  /**
-   *
-   * @type {number}
-   * @memberof PaginatedUserListRelationshipList
-   */
-  count: number
-  /**
-   *
-   * @type {string}
-   * @memberof PaginatedUserListRelationshipList
-   */
-  next?: string | null
-  /**
-   *
-   * @type {string}
-   * @memberof PaginatedUserListRelationshipList
-   */
-  previous?: string | null
-  /**
-   *
-   * @type {Array<UserListRelationship>}
-   * @memberof PaginatedUserListRelationshipList
-   */
-  results: Array<UserListRelationship>
-}
-/**
- *
- * @export
  * @interface PaginatedVideoPlaylistResourceList
  */
 export interface PaginatedVideoPlaylistResourceList {
@@ -26649,15 +26618,11 @@ export const UserlistsApiAxiosParamCreator = function (
      * Viewset for UserListRelationships
      * @summary User List Resources List
      * @param {number} userlist_id id of the parent user list
-     * @param {number} [limit] Number of results to return per page.
-     * @param {number} [offset] The initial index from which to return the results.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     userlistsItemsList: async (
       userlist_id: number,
-      limit?: number,
-      offset?: number,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       // verify required parameter 'userlist_id' is not null or undefined
@@ -26680,14 +26645,6 @@ export const UserlistsApiAxiosParamCreator = function (
       }
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
-
-      if (limit !== undefined) {
-        localVarQueryParameter["limit"] = limit
-      }
-
-      if (offset !== undefined) {
-        localVarQueryParameter["offset"] = offset
-      }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
       let headersFromBaseOptions =
@@ -27140,29 +27097,20 @@ export const UserlistsApiFp = function (configuration?: Configuration) {
      * Viewset for UserListRelationships
      * @summary User List Resources List
      * @param {number} userlist_id id of the parent user list
-     * @param {number} [limit] Number of results to return per page.
-     * @param {number} [offset] The initial index from which to return the results.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async userlistsItemsList(
       userlist_id: number,
-      limit?: number,
-      offset?: number,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PaginatedUserListRelationshipList>
+      ) => AxiosPromise<Array<UserListRelationship>>
     > {
       const localVarAxiosArgs =
-        await localVarAxiosParamCreator.userlistsItemsList(
-          userlist_id,
-          limit,
-          offset,
-          options,
-        )
+        await localVarAxiosParamCreator.userlistsItemsList(userlist_id, options)
       const index = configuration?.serverIndex ?? 0
       const operationBasePath =
         operationServerMap["UserlistsApi.userlistsItemsList"]?.[index]?.url
@@ -27459,14 +27407,9 @@ export const UserlistsApiFactory = function (
     userlistsItemsList(
       requestParameters: UserlistsApiUserlistsItemsListRequest,
       options?: RawAxiosRequestConfig,
-    ): AxiosPromise<PaginatedUserListRelationshipList> {
+    ): AxiosPromise<Array<UserListRelationship>> {
       return localVarFp
-        .userlistsItemsList(
-          requestParameters.userlist_id,
-          requestParameters.limit,
-          requestParameters.offset,
-          options,
-        )
+        .userlistsItemsList(requestParameters.userlist_id, options)
         .then((request) => request(axios, basePath))
     },
     /**
@@ -27659,20 +27602,6 @@ export interface UserlistsApiUserlistsItemsListRequest {
    * @memberof UserlistsApiUserlistsItemsList
    */
   readonly userlist_id: number
-
-  /**
-   * Number of results to return per page.
-   * @type {number}
-   * @memberof UserlistsApiUserlistsItemsList
-   */
-  readonly limit?: number
-
-  /**
-   * The initial index from which to return the results.
-   * @type {number}
-   * @memberof UserlistsApiUserlistsItemsList
-   */
-  readonly offset?: number
 }
 
 /**
@@ -27876,12 +27805,7 @@ export class UserlistsApi extends BaseAPI {
     options?: RawAxiosRequestConfig,
   ) {
     return UserlistsApiFp(this.configuration)
-      .userlistsItemsList(
-        requestParameters.userlist_id,
-        requestParameters.limit,
-        requestParameters.offset,
-        options,
-      )
+      .userlistsItemsList(requestParameters.userlist_id, options)
       .then((request) => request(this.axios, this.basePath))
   }
 

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -3529,37 +3529,6 @@ export interface PaginatedCourseResourceList {
 /**
  *
  * @export
- * @interface PaginatedLearningPathRelationshipList
- */
-export interface PaginatedLearningPathRelationshipList {
-  /**
-   *
-   * @type {number}
-   * @memberof PaginatedLearningPathRelationshipList
-   */
-  count: number
-  /**
-   *
-   * @type {string}
-   * @memberof PaginatedLearningPathRelationshipList
-   */
-  next?: string | null
-  /**
-   *
-   * @type {string}
-   * @memberof PaginatedLearningPathRelationshipList
-   */
-  previous?: string | null
-  /**
-   *
-   * @type {Array<LearningPathRelationship>}
-   * @memberof PaginatedLearningPathRelationshipList
-   */
-  results: Array<LearningPathRelationship>
-}
-/**
- *
- * @export
  * @interface PaginatedLearningPathResourceList
  */
 export interface PaginatedLearningPathResourceList {
@@ -20510,16 +20479,12 @@ export const LearningpathsApiAxiosParamCreator = function (
     /**
      * Viewset for LearningPath related resources
      * @param {number} learning_resource_id The learning resource id of the learning path
-     * @param {number} [limit] Number of results to return per page.
-     * @param {number} [offset] The initial index from which to return the results.
      * @param {string} [sortby] Which field to use when ordering the results.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     learningpathsItemsList: async (
       learning_resource_id: number,
-      limit?: number,
-      offset?: number,
       sortby?: string,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
@@ -20548,14 +20513,6 @@ export const LearningpathsApiAxiosParamCreator = function (
       }
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
-
-      if (limit !== undefined) {
-        localVarQueryParameter["limit"] = limit
-      }
-
-      if (offset !== undefined) {
-        localVarQueryParameter["offset"] = offset
-      }
 
       if (sortby !== undefined) {
         localVarQueryParameter["sortby"] = sortby
@@ -21126,29 +21083,23 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
     /**
      * Viewset for LearningPath related resources
      * @param {number} learning_resource_id The learning resource id of the learning path
-     * @param {number} [limit] Number of results to return per page.
-     * @param {number} [offset] The initial index from which to return the results.
      * @param {string} [sortby] Which field to use when ordering the results.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async learningpathsItemsList(
       learning_resource_id: number,
-      limit?: number,
-      offset?: number,
       sortby?: string,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PaginatedLearningPathRelationshipList>
+      ) => AxiosPromise<Array<LearningPathRelationship>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.learningpathsItemsList(
           learning_resource_id,
-          limit,
-          offset,
           sortby,
           options,
         )
@@ -21511,12 +21462,10 @@ export const LearningpathsApiFactory = function (
     learningpathsItemsList(
       requestParameters: LearningpathsApiLearningpathsItemsListRequest,
       options?: RawAxiosRequestConfig,
-    ): AxiosPromise<PaginatedLearningPathRelationshipList> {
+    ): AxiosPromise<Array<LearningPathRelationship>> {
       return localVarFp
         .learningpathsItemsList(
           requestParameters.learning_resource_id,
-          requestParameters.limit,
-          requestParameters.offset,
           requestParameters.sortby,
           options,
         )
@@ -21727,20 +21676,6 @@ export interface LearningpathsApiLearningpathsItemsListRequest {
    * @memberof LearningpathsApiLearningpathsItemsList
    */
   readonly learning_resource_id: number
-
-  /**
-   * Number of results to return per page.
-   * @type {number}
-   * @memberof LearningpathsApiLearningpathsItemsList
-   */
-  readonly limit?: number
-
-  /**
-   * The initial index from which to return the results.
-   * @type {number}
-   * @memberof LearningpathsApiLearningpathsItemsList
-   */
-  readonly offset?: number
 
   /**
    * Which field to use when ordering the results.
@@ -22060,8 +21995,6 @@ export class LearningpathsApi extends BaseAPI {
     return LearningpathsApiFp(this.configuration)
       .learningpathsItemsList(
         requestParameters.learning_resource_id,
-        requestParameters.limit,
-        requestParameters.offset,
         requestParameters.sortby,
         options,
       )

--- a/frontends/api/src/hooks/learningPaths/index.test.ts
+++ b/frontends/api/src/hooks/learningPaths/index.test.ts
@@ -1,5 +1,4 @@
 import { renderHook, waitFor } from "@testing-library/react"
-import { faker } from "@faker-js/faker/locale/en"
 import { UseQueryResult } from "@tanstack/react-query"
 import { LearningResource } from "../../generated/v1"
 import * as factories from "../../test-utils/factories"
@@ -9,7 +8,6 @@ import { learningResourceKeys } from "../learningResources/queries"
 import {
   useLearningPathsDetail,
   useLearningPathsList,
-  useInfiniteLearningPathItems,
   useLearningPathCreate,
   useLearningPathDestroy,
   useLearningPathUpdate,
@@ -53,46 +51,6 @@ describe("useLearningPathsList", () => {
       await assertApiCalled(result, url, "GET", data)
     },
   )
-})
-
-describe("useInfiniteLearningPathItems", () => {
-  it("Calls the correct API and can fetch next page", async () => {
-    const parentId = faker.number.int()
-    const url1 = urls.learningPaths.resources({
-      learning_resource_id: parentId,
-    })
-    const url2 = urls.learningPaths.resources({
-      learning_resource_id: parentId,
-      offset: 5,
-    })
-    const response1 = factory.learningPathRelationships({
-      count: 7,
-      parent: parentId,
-      next: url2,
-      pageSize: 5,
-    })
-    const response2 = factory.learningPathRelationships({
-      count: 7,
-      pageSize: 2,
-      parent: parentId,
-    })
-    setMockResponse.get(url1, response1)
-    setMockResponse.get(url2, response2)
-    const useTestHook = () =>
-      useInfiniteLearningPathItems({ learning_resource_id: parentId })
-
-    const { wrapper } = setupReactQueryTest()
-
-    // First page
-    const { result } = renderHook(useTestHook, { wrapper })
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(makeRequest).toHaveBeenCalledWith("get", url1, undefined)
-
-    // Second page
-    result.current.fetchNextPage()
-    await waitFor(() => expect(result.current.isFetching).toBe(false))
-    expect(makeRequest).toHaveBeenCalledWith("get", url2, undefined)
-  })
 })
 
 describe("useLearningPathsRetrieve", () => {

--- a/frontends/api/src/test-utils/factories/learningResources.ts
+++ b/frontends/api/src/test-utils/factories/learningResources.ts
@@ -21,7 +21,6 @@ import type {
   LearningResourceSchool,
   LearningResourceTopic,
   MicroLearningPathRelationship,
-  PaginatedLearningPathRelationshipList,
   PodcastResource,
   PodcastEpisodeResource,
   ProgramResource,
@@ -419,17 +418,11 @@ const learningResourceRelationship: Factory<LearningResourceRelationship> = (
 const learningResourceRelationships = ({
   count,
   parent,
-  pageSize,
-  next = null,
-  previous = null,
 }: {
   count: number
   parent: number
-  pageSize?: number
-  next?: string | null
-  previous?: string | null
 }) => {
-  const results: LearningPathRelationship[] = Array(pageSize ?? count)
+  return Array(count)
     .fill(null)
     .map((_val, index) => {
       return learningResourceRelationship({
@@ -437,12 +430,6 @@ const learningResourceRelationships = ({
         parent,
       })
     })
-  return {
-    count,
-    next,
-    previous,
-    results,
-  } satisfies PaginatedLearningPathRelationshipList
 }
 
 const learningPathRelationship: Factory<LearningPathRelationship> = (

--- a/frontends/api/src/test-utils/factories/learningResources.ts
+++ b/frontends/api/src/test-utils/factories/learningResources.ts
@@ -464,17 +464,11 @@ const learningPathRelationship: Factory<LearningPathRelationship> = (
 const learningPathRelationships = ({
   count,
   parent,
-  pageSize,
-  next = null,
-  previous = null,
 }: {
   count: number
   parent: number
-  pageSize?: number
-  next?: string | null
-  previous?: string | null
 }) => {
-  const results: LearningPathRelationship[] = Array(pageSize ?? count)
+  return Array(count)
     .fill(null)
     .map((_val, index) => {
       return learningPathRelationship({
@@ -482,12 +476,6 @@ const learningPathRelationships = ({
         parent,
       })
     })
-  return {
-    count,
-    next,
-    previous,
-    results,
-  } satisfies PaginatedLearningPathRelationshipList
 }
 
 const podcast: LearningResourceFactory<PodcastResource> = (overrides = {}) => {

--- a/frontends/api/src/test-utils/factories/userLists.ts
+++ b/frontends/api/src/test-utils/factories/userLists.ts
@@ -1,7 +1,6 @@
 import { Factory, makePaginatedFactory } from "ol-test-utilities"
 import {
   MicroUserListRelationship,
-  PaginatedUserListRelationshipList,
   PrivacyLevelEnum,
   UserList,
   UserListRelationship,
@@ -58,17 +57,11 @@ const userListRelationship: Factory<UserListRelationship> = (
 const userListRelationships = ({
   count,
   parent,
-  pageSize,
-  next = null,
-  previous = null,
 }: {
   count: number
   parent: number
-  pageSize?: number
-  next?: string | null
-  previous?: string | null
 }) => {
-  const results: UserListRelationship[] = Array(pageSize ?? count)
+  return Array(count)
     .fill(null)
     .map((_val, index) => {
       return userListRelationship({
@@ -76,12 +69,6 @@ const userListRelationships = ({
         parent,
       })
     })
-  return {
-    count,
-    next,
-    previous,
-    results,
-  } satisfies PaginatedUserListRelationshipList
 }
 
 export {

--- a/frontends/main/src/app-pages/DashboardPage/UserListDetailsContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/UserListDetailsContent.tsx
@@ -1,5 +1,5 @@
 "use client"
-import React, { useMemo } from "react"
+import React from "react"
 import {
   useInfiniteUserListItems,
   useUserListsDetail,
@@ -9,6 +9,7 @@ import { ListType } from "api/constants"
 import { useUserMe } from "api/hooks/user"
 import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
 import ItemsListingComponent from "@/page-components/ItemsListing/ItemsListingComponent"
+import { LearningResourceListItem } from "@/page-components/ItemsListing/ItemsListing"
 
 interface UserListDetailsContentProps {
   userListId: number
@@ -24,11 +25,6 @@ const UserListDetailsContent: React.FC<UserListDetailsContentProps> = (
   const itemsQuery = useInfiniteUserListItems({ userlist_id: userListId })
   const router = useRouter()
 
-  const items = useMemo(() => {
-    const pages = itemsQuery.data?.pages
-    return pages?.flatMap((p) => p.results ?? []) ?? []
-  }, [itemsQuery.data])
-
   const onDestroyUserList = () => {
     router.push("/dashboard/my-lists")
   }
@@ -37,7 +33,13 @@ const UserListDetailsContent: React.FC<UserListDetailsContentProps> = (
     <ItemsListingComponent
       listType={ListType.UserList}
       list={listQuery.data}
-      items={items}
+      items={
+        itemsQuery.data
+          ? itemsQuery.data.pages.flatMap(
+              (page: LearningResourceListItem[]) => page,
+            )
+          : []
+      }
       isLoading={itemsQuery.isLoading}
       isFetching={itemsQuery.isFetching}
       showSort={!!user?.is_authenticated}

--- a/frontends/main/src/app-pages/LearningPathDetailsPage/LearningPathDetailsPage.tsx
+++ b/frontends/main/src/app-pages/LearningPathDetailsPage/LearningPathDetailsPage.tsx
@@ -30,12 +30,7 @@ const LearningPathDetailsPage: React.FC = () => {
   const pathQuery = useLearningPathsDetail(id)
   const itemsQuery = useInfiniteLearningPathItems({
     learning_resource_id: id,
-    limit: 100,
   })
-  const items = useMemo(() => {
-    const pages = itemsQuery.data?.pages
-    return pages?.flatMap((p) => p.results ?? []) ?? []
-  }, [itemsQuery.data])
   const list = useMemo(() => {
     if (!pathQuery.data) {
       return undefined
@@ -53,7 +48,7 @@ const LearningPathDetailsPage: React.FC = () => {
       <ListDetailsPage
         listType={ListType.LearningPath}
         list={list}
-        items={items}
+        items={itemsQuery.data?.pages?.flatMap((p) => p ?? []) ?? []}
         showSort={!!user?.is_authenticated}
         canEdit={!!user?.is_learning_path_editor}
         isLoading={itemsQuery.isLoading}

--- a/frontends/main/src/page-components/ItemsListing/ItemsListing.test.tsx
+++ b/frontends/main/src/page-components/ItemsListing/ItemsListing.test.tsx
@@ -49,11 +49,7 @@ const spySortableItem = jest.mocked(SortableItem)
 const learningResourcesFactory = factories.learningResources
 const userListsFactory = factories.userLists
 
-const getPaginatedRelationships = (
-  listType: string,
-  count: number,
-  parent: number,
-) => {
+const getRelationships = (listType: string, count: number, parent: number) => {
   if (listType === ListType.LearningPath) {
     return learningResourcesFactory.learningPathRelationships({
       count,
@@ -109,7 +105,7 @@ describe("ItemsListing", () => {
       setMockResponse.get(urls.userLists.membershipList(), [])
       setMockResponse.get(urls.learningPaths.membershipList(), [])
       const emptyMessage = faker.lorem.sentence()
-      const paginatedRelationships = getPaginatedRelationships(
+      const paginatedRelationships = getRelationships(
         listType,
         count,
         faker.number.int(),
@@ -118,7 +114,7 @@ describe("ItemsListing", () => {
         <ItemsListing
           listType={listType}
           emptyMessage={emptyMessage}
-          items={paginatedRelationships.results as LearningResourceListItem[]}
+          items={paginatedRelationships as LearningResourceListItem[]}
         />,
       )
       const emptyMessageElement = screen.queryByText(emptyMessage)
@@ -161,12 +157,12 @@ describe("ItemsListing", () => {
     "Shows a list of $listType LearningResourceCards with sortable=$sortable and condensed=$condensed",
     ({ listType, sortable, condensed, cardProps }) => {
       const emptyMessage = faker.lorem.sentence()
-      const paginatedRelationships = getPaginatedRelationships(
+      const paginatedRelationships = getRelationships(
         listType,
         faker.number.int({ min: 2, max: 4 }),
         faker.number.int(),
       )
-      const items = paginatedRelationships.results as LearningResourceListItem[]
+      const items = paginatedRelationships as LearningResourceListItem[]
       const user = factories.user.user()
       setMockResponse.get(urls.userMe.get(), user)
       setMockResponse.get(urls.userLists.membershipList(), [])
@@ -212,12 +208,8 @@ describe.each([ListType.LearningPath, ListType.UserList])(
       const listType = props.listType || ""
       const emptyMessage = faker.lorem.sentence()
       const parentId = faker.number.int()
-      const paginatedRelationships = getPaginatedRelationships(
-        listType,
-        5,
-        parentId,
-      )
-      const items = paginatedRelationships.results as LearningResourceListItem[]
+      const paginatedRelationships = getRelationships(listType, 5, parentId)
+      const items = paginatedRelationships as LearningResourceListItem[]
       const defaultProps: ItemsListingProps = {
         listType: listType,
         items: items,

--- a/frontends/main/src/page-components/ItemsListing/ItemsListing.tsx
+++ b/frontends/main/src/page-components/ItemsListing/ItemsListing.tsx
@@ -149,6 +149,7 @@ const ItemsListing: React.FC<ItemsListingProps> = ({
   sortable = false,
   condensed = false,
 }) => {
+  console.log(items)
   return (
     <>
       {isLoading ? (

--- a/frontends/main/src/page-components/ItemsListing/ItemsListing.tsx
+++ b/frontends/main/src/page-components/ItemsListing/ItemsListing.tsx
@@ -149,7 +149,6 @@ const ItemsListing: React.FC<ItemsListingProps> = ({
   sortable = false,
   condensed = false,
 }) => {
-  console.log(items)
   return (
     <>
       {isLoading ? (

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -741,6 +741,7 @@ class LearningPathItemsViewSet(ResourceListItemsViewSet, viewsets.ModelViewSet):
 
     serializer_class = LearningPathRelationshipSerializer
     permission_classes = (permissions.HasLearningPathItemPermissions,)
+    pagination_class = None
     http_method_names = VALID_HTTP_METHODS
 
     @method_decorator(

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -938,7 +938,7 @@ class UserListItemViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
         "position"
     )
     serializer_class = UserListRelationshipSerializer
-    pagination_class = DefaultPagination
+    pagination_class = None
     permission_classes = (HasUserListItemPermissions,)
     http_method_names = VALID_HTTP_METHODS
     parent_lookup_kwargs = {"userlist_id": "parent"}

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -8230,18 +8230,6 @@ paths:
       description: Viewset for UserListRelationships
       summary: User List Resources List
       parameters:
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
       - in: path
         name: userlist_id
         schema:
@@ -8255,7 +8243,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedUserListRelationshipList'
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserListRelationship'
           description: ''
     post:
       operationId: userlists_items_create
@@ -12238,29 +12228,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/UserList'
-    PaginatedUserListRelationshipList:
-      type: object
-      required:
-      - count
-      - results
-      properties:
-        count:
-          type: integer
-          example: 123
-        next:
-          type: string
-          nullable: true
-          format: uri
-          example: http://api.example.org/accounts/?offset=400&limit=100
-        previous:
-          type: string
-          nullable: true
-          format: uri
-          example: http://api.example.org/accounts/?offset=200&limit=100
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/UserListRelationship'
     PaginatedVideoPlaylistResourceList:
       type: object
       required:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -6423,18 +6423,6 @@ paths:
           type: integer
         description: The learning resource id of the learning path
         required: true
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
       - name: sortby
         required: false
         in: query
@@ -6448,7 +6436,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedLearningPathRelationshipList'
+                type: array
+                items:
+                  $ref: '#/components/schemas/LearningPathRelationship'
           description: ''
     post:
       operationId: learningpaths_items_create
@@ -11860,29 +11850,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CourseResource'
-    PaginatedLearningPathRelationshipList:
-      type: object
-      required:
-      - count
-      - results
-      properties:
-        count:
-          type: integer
-          example: 123
-        next:
-          type: string
-          nullable: true
-          format: uri
-          example: http://api.example.org/accounts/?offset=400&limit=100
-        previous:
-          type: string
-          nullable: true
-          format: uri
-          example: http://api.example.org/accounts/?offset=200&limit=100
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/LearningPathRelationship'
     PaginatedLearningPathResourceList:
       type: object
       required:


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7972

### Description (What does it do?)
This PR disables pagination on the UserList and LearningPath item API endpoints, enabling users to see all of the items in their UserList or LearningPath. 

### Screenshots (if appropriate):
<img width="2560" height="1271" alt="image" src="https://github.com/user-attachments/assets/82c55066-69f3-4dca-b3a4-c370fa248c5e" />
<img width="375" height="667" alt="image" src="https://github.com/user-attachments/assets/8715d133-d3f9-4fc0-8824-addcbf07350d" />

### How can this be tested?
- Log in as a superuser and create a UserList
- Add more than 10 items to the UserList
- Visit the My Lists section of the Dashboard and verify that all items are shown
- Test the reorder functionality, dragging items around
- Repeat the process for a Learning Path
