### PR TITLE
raise page size of userlists and learning paths

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/UserListDetailsContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/UserListDetailsContent.tsx
@@ -21,7 +21,11 @@ const UserListDetailsContent: React.FC<UserListDetailsContentProps> = (
 
   const { data: user } = useUserMe()
   const listQuery = useUserListsDetail(userListId)
-  const itemsQuery = useInfiniteUserListItems({ userlist_id: userListId })
+  // Very high limit set here beacuse pagination not implemented on the frontend
+  const itemsQuery = useInfiniteUserListItems({
+    userlist_id: userListId,
+    limit: 1000,
+  })
   const router = useRouter()
 
   const items = useMemo(() => {

--- a/frontends/main/src/app-pages/DashboardPage/UserListDetailsContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/UserListDetailsContent.tsx
@@ -21,7 +21,7 @@ const UserListDetailsContent: React.FC<UserListDetailsContentProps> = (
 
   const { data: user } = useUserMe()
   const listQuery = useUserListsDetail(userListId)
-  // Very high limit set here beacuse pagination not implemented on the frontend
+  // Very high limit set here because pagination is not implemented on the frontend
   const itemsQuery = useInfiniteUserListItems({
     userlist_id: userListId,
     limit: 1000,

--- a/frontends/main/src/app-pages/LearningPathDetailsPage/LearningPathDetailsPage.tsx
+++ b/frontends/main/src/app-pages/LearningPathDetailsPage/LearningPathDetailsPage.tsx
@@ -28,7 +28,7 @@ const LearningPathDetailsPage: React.FC = () => {
   const id = parseInt(params.id)
 
   const pathQuery = useLearningPathsDetail(id)
-  // Very high limit set here beacuse pagination not implemented on the frontend
+  // Very high limit set here because pagination is not implemented on the frontend
   const itemsQuery = useInfiniteLearningPathItems({
     learning_resource_id: id,
     limit: 1000,

--- a/frontends/main/src/app-pages/LearningPathDetailsPage/LearningPathDetailsPage.tsx
+++ b/frontends/main/src/app-pages/LearningPathDetailsPage/LearningPathDetailsPage.tsx
@@ -28,9 +28,10 @@ const LearningPathDetailsPage: React.FC = () => {
   const id = parseInt(params.id)
 
   const pathQuery = useLearningPathsDetail(id)
+  // Very high limit set here beacuse pagination not implemented on the frontend
   const itemsQuery = useInfiniteLearningPathItems({
     learning_resource_id: id,
-    limit: 100,
+    limit: 1000,
   })
   const items = useMemo(() => {
     const pages = itemsQuery.data?.pages


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7972

### Description (What does it do?)
This PR raises the page size in requests to get user list and learning path items. Previously, due to a report about not being able to see all learning path items, we set this limit to 100. A limit was not set on user lists, so that was defaulting to 10 for default pagination. The problem is, we implemented pagination in the API and the frontend queries, but never in the UI itself. This PR sets both limits to 1000, to allow for the size of most reasonable lists to work for now, until we can actually implement pagination on the frontend.

### Screenshots (if appropriate):
<img width="2560" height="1271" alt="image" src="https://github.com/user-attachments/assets/b5b9e99b-e08e-49ab-a727-27a7b91c077b" />
<img width="375" height="667" alt="image" src="https://github.com/user-attachments/assets/ed438ac6-f739-403f-8ba5-4c5fb3a2fb0d" />

### How can this be tested?
- Log in as a superuser and create a UserList
- Add more than 10 items to the UserList
- Visit the My Lists section of the Dashboard and verify that all items are shown
- Test the reorder functionality, dragging items around
- Repeat the process for a Learning Path
