### PR TITLE
properly mock posthog.capture

### DIFF
--- a/frontends/main/src/app-pages/HomePage/HomePage.test.tsx
+++ b/frontends/main/src/app-pages/HomePage/HomePage.test.tsx
@@ -17,10 +17,16 @@ import {
 import invariant from "tiny-invariant"
 import * as routes from "@/common/urls"
 import { assertHeadings } from "ol-test-utilities"
-import { useFeatureFlagEnabled } from "posthog-js/react"
+import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react"
 
 jest.mock("posthog-js/react")
 const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
+const mockedPostHogCapture = jest.fn()
+jest.mock("posthog-js/react")
+jest.mocked(usePostHog).mockReturnValue(
+  // @ts-expect-error Not mocking all of posthog
+  { capture: mockedPostHogCapture },
+)
 
 const assertLinksTo = (
   el: HTMLElement,


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7983

### Description (What does it do?)
The frontend tests are failing because the `HomePage` implements `SearchField`, which has a `posthog.capture` call. Tests are run against `HomePage`, which renders `SearchField` and since the call to `posthog.capture` is not mocked, you end up getting an error.

### How can this be tested?
- Spin up `mit-learn`
- Run `docker compose exec watch yarn test`
- Expect the tests to pass
