### PR TITLE
add mitxonline certificate api

### DIFF
--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -30,7 +30,7 @@
     "ol-test-utilities": "0.0.0"
   },
   "dependencies": {
-    "@mitodl/mitxonline-api-axios": "2025.7.28",
+    "@mitodl/mitxonline-api-axios": "git+https://github.com/gumaerc/mitxonline-api-axios.git",
     "@tanstack/react-query": "^5.66.0",
     "axios": "^1.6.3"
   }

--- a/frontends/api/src/mitxonline/clients.ts
+++ b/frontends/api/src/mitxonline/clients.ts
@@ -1,11 +1,13 @@
 import {
   B2bApi,
   CoursesApi,
+  CourseCertificatesApi,
   EnrollmentsApi,
   ProgramCollectionsApi,
   ProgramsApi,
+  ProgramCertificatesApi,
   UsersApi,
-} from "@mitodl/mitxonline-api-axios/v1"
+} from "@mitodl/mitxonline-api-axios/v2"
 import axios from "axios"
 
 const axiosInstance = axios.create({
@@ -29,7 +31,17 @@ const programCollectionsApi = new ProgramCollectionsApi(
   BASE_PATH,
   axiosInstance,
 )
+const programCertificatesApi = new ProgramCertificatesApi(
+  undefined,
+  BASE_PATH,
+  axiosInstance,
+)
 const coursesApi = new CoursesApi(undefined, BASE_PATH, axiosInstance)
+const courseCertificatesApi = new CourseCertificatesApi(
+  undefined,
+  BASE_PATH,
+  axiosInstance,
+)
 
 export {
   usersApi,
@@ -38,5 +50,7 @@ export {
   programsApi,
   programCollectionsApi,
   coursesApi,
+  programCertificatesApi,
+  courseCertificatesApi,
   axiosInstance,
 }

--- a/frontends/api/src/mitxonline/hooks/certificates/index.ts
+++ b/frontends/api/src/mitxonline/hooks/certificates/index.ts
@@ -1,0 +1,3 @@
+import { certificateQueries } from "./queries"
+
+export { certificateQueries }

--- a/frontends/api/src/mitxonline/hooks/certificates/queries.ts
+++ b/frontends/api/src/mitxonline/hooks/certificates/queries.ts
@@ -1,0 +1,45 @@
+import { queryOptions } from "@tanstack/react-query"
+import type {
+  CourseCertificatesApiCourseCertificatesRetrieveRequest,
+  ProgramCertificatesApiProgramCertificatesRetrieveRequest,
+  V2CourseRunCertificate,
+  V2ProgramCertificate,
+} from "@mitodl/mitxonline-api-axios/v2"
+import { courseCertificatesApi, programCertificatesApi } from "../../clients"
+
+const certificateKeys = {
+  root: ["mitxonline", "certificates"],
+  courseCertificatesRetrieve: (
+    opts?: CourseCertificatesApiCourseCertificatesRetrieveRequest,
+  ) => [...certificateKeys.root, "retrieve", opts],
+  programCertificatesRetrieve: (
+    opts?: ProgramCertificatesApiProgramCertificatesRetrieveRequest,
+  ) => [...certificateKeys.root, "retrieve", opts],
+}
+
+const certificateQueries = {
+  courseCertificatesRetrieve: (
+    opts: CourseCertificatesApiCourseCertificatesRetrieveRequest,
+  ) =>
+    queryOptions({
+      queryKey: certificateKeys.courseCertificatesRetrieve(opts),
+      queryFn: async (): Promise<V2CourseRunCertificate> => {
+        return courseCertificatesApi
+          .courseCertificatesRetrieve(opts)
+          .then((res) => res.data)
+      },
+    }),
+  programCertificatesRetrieve: (
+    opts: ProgramCertificatesApiProgramCertificatesRetrieveRequest,
+  ) =>
+    queryOptions({
+      queryKey: certificateKeys.programCertificatesRetrieve(opts),
+      queryFn: async (): Promise<V2ProgramCertificate> => {
+        return programCertificatesApi
+          .programCertificatesRetrieve(opts)
+          .then((res) => res.data)
+      },
+    }),
+}
+
+export { certificateQueries, certificateKeys }

--- a/frontends/api/src/mitxonline/hooks/courses/queries.ts
+++ b/frontends/api/src/mitxonline/hooks/courses/queries.ts
@@ -2,7 +2,7 @@ import { queryOptions } from "@tanstack/react-query"
 import type {
   CoursesApiApiV2CoursesListRequest,
   PaginatedV2CourseWithCourseRunsList,
-} from "@mitodl/mitxonline-api-axios/v1"
+} from "@mitodl/mitxonline-api-axios/v2"
 import { coursesApi } from "../../clients"
 
 const coursesKeys = {

--- a/frontends/api/src/mitxonline/hooks/enrollment/index.ts
+++ b/frontends/api/src/mitxonline/hooks/enrollment/index.ts
@@ -4,7 +4,7 @@ import { b2bApi, enrollmentsApi } from "../../clients"
 import {
   B2bApiB2bEnrollCreateRequest,
   EnrollmentsApiEnrollmentsPartialUpdateRequest,
-} from "@mitodl/mitxonline-api-axios/v1"
+} from "@mitodl/mitxonline-api-axios/v2"
 
 const useCreateEnrollment = (opts: B2bApiB2bEnrollCreateRequest) => {
   const queryClient = useQueryClient()

--- a/frontends/api/src/mitxonline/hooks/enrollment/queries.ts
+++ b/frontends/api/src/mitxonline/hooks/enrollment/queries.ts
@@ -1,5 +1,5 @@
 import { queryOptions } from "@tanstack/react-query"
-import type { CourseRunEnrollment } from "@mitodl/mitxonline-api-axios/v1"
+import type { CourseRunEnrollment } from "@mitodl/mitxonline-api-axios/v2"
 
 import { enrollmentsApi } from "../../clients"
 

--- a/frontends/api/src/mitxonline/hooks/organizations/queries.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/queries.ts
@@ -1,5 +1,5 @@
 import { B2bApiB2bOrganizationsRetrieveRequest } from "@mitodl/mitxonline-api-axios/v0"
-import { OrganizationPage } from "@mitodl/mitxonline-api-axios/v1"
+import { OrganizationPage } from "@mitodl/mitxonline-api-axios/v2"
 import { queryOptions } from "@tanstack/react-query"
 import { b2bApi } from "../../clients"
 

--- a/frontends/api/src/mitxonline/hooks/programs/queries.ts
+++ b/frontends/api/src/mitxonline/hooks/programs/queries.ts
@@ -6,7 +6,7 @@ import type {
   ProgramsApiProgramsListV2Request,
   ProgramsApiProgramsRetrieveV2Request,
   V2Program,
-} from "@mitodl/mitxonline-api-axios/v1"
+} from "@mitodl/mitxonline-api-axios/v2"
 import { programCollectionsApi, programsApi } from "../../clients"
 
 const programsKeys = {

--- a/frontends/api/src/mitxonline/hooks/user/index.ts
+++ b/frontends/api/src/mitxonline/hooks/user/index.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { usersApi } from "../../clients"
-import type { User } from "@mitodl/mitxonline-api-axios/v1"
+import type { User } from "@mitodl/mitxonline-api-axios/v2"
 
 const useMitxOnlineCurrentUser = (opts: { enabled?: boolean } = {}) =>
   useQuery({

--- a/frontends/api/src/mitxonline/test-utils/factories/courses.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/courses.ts
@@ -1,6 +1,6 @@
 import { mergeOverrides, makePaginatedFactory } from "ol-test-utilities"
 import type { PartialFactory } from "ol-test-utilities"
-import type { V2CourseWithCourseRuns } from "@mitodl/mitxonline-api-axios/v1"
+import type { V2CourseWithCourseRuns } from "@mitodl/mitxonline-api-axios/v2"
 import { faker } from "@faker-js/faker/locale/en"
 import { UniqueEnforcer } from "enforce-unique"
 

--- a/frontends/api/src/mitxonline/test-utils/factories/enrollment.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/enrollment.ts
@@ -4,7 +4,7 @@ import type { PartialFactory } from "ol-test-utilities"
 import type {
   CourseRunEnrollment,
   CourseRunGrade,
-} from "@mitodl/mitxonline-api-axios/v1"
+} from "@mitodl/mitxonline-api-axios/v2"
 import { UniqueEnforcer } from "enforce-unique"
 
 const uniqueEnrollmentId = new UniqueEnforcer()

--- a/frontends/api/src/mitxonline/test-utils/factories/organization.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/organization.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker/locale/en"
-import { OrganizationPage } from "@mitodl/mitxonline-api-axios/v1"
+import { OrganizationPage } from "@mitodl/mitxonline-api-axios/v2"
 import { mergeOverrides } from "ol-test-utilities"
 
 const organization = (

--- a/frontends/api/src/mitxonline/test-utils/factories/programs.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/programs.ts
@@ -3,7 +3,7 @@ import type { PartialFactory } from "ol-test-utilities"
 import type {
   V2Program,
   V2ProgramCollection,
-} from "@mitodl/mitxonline-api-axios/v1"
+} from "@mitodl/mitxonline-api-axios/v2"
 import { faker } from "@faker-js/faker/locale/en"
 import { UniqueEnforcer } from "enforce-unique"
 

--- a/frontends/api/src/mitxonline/test-utils/factories/user.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/user.ts
@@ -5,7 +5,7 @@ import type {
   LegalAddress,
   UserProfile,
   UserOrganization,
-} from "@mitodl/mitxonline-api-axios/v1"
+} from "@mitodl/mitxonline-api-axios/v2"
 import { UniqueEnforcer } from "enforce-unique"
 
 const enforcerId = new UniqueEnforcer()

--- a/frontends/api/src/mitxonline/test-utils/urls.ts
+++ b/frontends/api/src/mitxonline/test-utils/urls.ts
@@ -2,7 +2,7 @@ import type {
   CoursesApiApiV2CoursesListRequest,
   ProgramCollectionsApiProgramCollectionsListRequest,
   ProgramsApiProgramsListV2Request,
-} from "@mitodl/mitxonline-api-axios/v1"
+} from "@mitodl/mitxonline-api-axios/v2"
 import { RawAxiosRequestConfig } from "axios"
 import { queryify } from "ol-test-utilities"
 

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -14,7 +14,7 @@
     "@emotion/cache": "^11.13.1",
     "@emotion/styled": "^11.11.0",
     "@mitodl/course-search-utils": "3.3.2",
-    "@mitodl/mitxonline-api-axios": "2025.7.28",
+    "@mitodl/mitxonline-api-axios": "git+https://github.com/gumaerc/mitxonline-api-axios.git",
     "@mitodl/smoot-design": "^6.10.0",
     "@next/bundle-analyzer": "^14.2.15",
     "@remixicon/react": "^4.2.0",

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/transform.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/transform.ts
@@ -9,7 +9,7 @@ import {
   V2CourseWithCourseRuns,
   V2Program,
   V2ProgramCollection,
-} from "@mitodl/mitxonline-api-axios/v1"
+} from "@mitodl/mitxonline-api-axios/v2"
 
 import { DashboardResourceType, EnrollmentStatus } from "./types"
 import type {

--- a/frontends/main/src/app-pages/DashboardPage/DashboardLayout.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/DashboardLayout.test.tsx
@@ -22,7 +22,7 @@ import {
 import { faker } from "@faker-js/faker/locale/en"
 import invariant from "tiny-invariant"
 import { useFeatureFlagEnabled } from "posthog-js/react"
-import { OrganizationPage } from "@mitodl/mitxonline-api-axios/v1"
+import { OrganizationPage } from "@mitodl/mitxonline-api-axios/v2"
 
 jest.mock("posthog-js/react")
 const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)

--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
@@ -22,7 +22,7 @@ import graduateLogo from "@/public/images/dashboard/graduate.png"
 import {
   CourseRunEnrollment,
   OrganizationPage,
-} from "@mitodl/mitxonline-api-axios/v1"
+} from "@mitodl/mitxonline-api-axios/v2"
 import { useMitxOnlineCurrentUser } from "api/mitxonline-hooks/user"
 
 const HeaderRoot = styled.div({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3018,13 +3018,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/mitxonline-api-axios@npm:2025.7.28":
+"@mitodl/mitxonline-api-axios@git+https://github.com/gumaerc/mitxonline-api-axios.git":
   version: 2025.7.28
-  resolution: "@mitodl/mitxonline-api-axios@npm:2025.7.28"
+  resolution: "@mitodl/mitxonline-api-axios@https://github.com/gumaerc/mitxonline-api-axios.git#commit=6a2ec3b55aea52954b39e01d5b9493507b4e906b"
   dependencies:
     "@types/node": "npm:^20.11.19"
     axios: "npm:^1.6.5"
-  checksum: 10/87e696455f1f6555aa40f5e966f34f39484b58953eebc257e0a4e78bc30c9b6dc489577d02213970f72196f725557e53f0986fe32df1d5f44514a64bf5043201
+  checksum: 10/b7925297b6e16ac0691eaff72ea9fa81cd06fb81867e4fc9387a244c432cd40e5be5a5aa0936bc3f01712cca417458b570564c7744f9e90972d83bd39452808f
   languageName: node
   linkType: hard
 
@@ -7356,7 +7356,7 @@ __metadata:
   resolution: "api@workspace:frontends/api"
   dependencies:
     "@faker-js/faker": "npm:^9.9.0"
-    "@mitodl/mitxonline-api-axios": "npm:2025.7.28"
+    "@mitodl/mitxonline-api-axios": "git+https://github.com/gumaerc/mitxonline-api-axios.git"
     "@tanstack/react-query": "npm:^5.66.0"
     "@testing-library/react": "npm:^16.1.0"
     axios: "npm:^1.6.3"
@@ -13931,7 +13931,7 @@ __metadata:
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^9.9.0"
     "@mitodl/course-search-utils": "npm:3.3.2"
-    "@mitodl/mitxonline-api-axios": "npm:2025.7.28"
+    "@mitodl/mitxonline-api-axios": "git+https://github.com/gumaerc/mitxonline-api-axios.git"
     "@mitodl/smoot-design": "npm:^6.10.0"
     "@next/bundle-analyzer": "npm:^14.2.15"
     "@remixicon/react": "npm:^4.2.0"


### PR DESCRIPTION
### What are the relevant tickets?
TBD

### Description (What does it do?)
This PR sets up the `mitxonline` API integration to start using the v2 endpoints, and adds the course and program certificate endpoints

### How can this be tested?
TBD
