### PR TITLE
Regenerate course metadata when course information updates

### DIFF
--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -3,7 +3,6 @@
 import uuid
 from abc import abstractmethod
 from functools import cached_property
-from hashlib import md5
 from typing import TYPE_CHECKING, Optional
 
 from django.conf import settings
@@ -25,6 +24,7 @@ from learning_resources.constants import (
     PrivacyLevel,
 )
 from main.models import TimestampedModel, TimestampedModelQuerySet
+from main.utils import checksum_for_content
 
 if TYPE_CHECKING:
     from django.contrib.auth import get_user_model
@@ -942,15 +942,8 @@ class ContentFile(TimestampedModel):
     summary = models.TextField(blank=True, default="")
     flashcards = models.JSONField(blank=True, default=list)
 
-    def content_checksum(self):
-        hasher = md5()  # noqa: S324
-        if self.content:
-            hasher.update(self.content.encode("utf-8"))
-            return hasher.hexdigest()
-        return None
-
     def save(self, **kwargs):
-        self.checksum = self.content_checksum()
+        self.checksum = checksum_for_content(self.content)
         super().save(**kwargs)
 
     class Meta:

--- a/main/utils.py
+++ b/main/utils.py
@@ -367,7 +367,7 @@ def clear_search_cache():
     return cleared
 
 
-def checksum_for_content(content):
+def checksum_for_content(content: str) -> str:
     """
     Generate a checksum based on the provided content string
     """

--- a/main/utils.py
+++ b/main/utils.py
@@ -368,6 +368,9 @@ def clear_search_cache():
 
 
 def checksum_for_content(content):
+    """
+    Generate a checksum based on the provided content string
+    """
     hasher = md5()  # noqa: S324
     if content:
         hasher.update(content.encode("utf-8"))

--- a/main/utils.py
+++ b/main/utils.py
@@ -5,6 +5,7 @@ import logging
 import os
 from enum import Flag, auto
 from functools import wraps
+from hashlib import md5
 from itertools import islice
 from urllib.parse import urljoin
 
@@ -364,3 +365,11 @@ def clear_search_cache():
         search_keys = cache.keys("views.decorators.cache.cache_header.search.*")
         cleared += cache.delete_many(search_keys) or 0
     return cleared
+
+
+def checksum_for_content(content):
+    hasher = md5()  # noqa: S324
+    if content:
+        hasher.update(content.encode("utf-8"))
+        return hasher.hexdigest()
+    return None

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -254,11 +254,13 @@ def update_learning_resource_payload(serialized_document):
 
 
 def update_content_file_payload(serialized_document):
-    params = {
-        "resource_readable_id": serialized_document["resource_readable_id"],
-        "key": serialized_document["key"],
-        "run_readable_id": serialized_document["run_readable_id"],
-    }
+    search_keys = ["resource_readable_id", "key", "run_readable_id"]
+    params = {}
+    for key in search_keys:
+        if key in serialized_document:
+            params[key] = serialized_document[key]
+    if not params:
+        return
     points = [
         point.id
         for point in retrieve_points_matching_params(
@@ -380,6 +382,7 @@ def _embed_course_metadata_as_contentfile(serialized_resources):
                 "chunk_number": chunk_id,
                 "chunk_content": chunk_content,
                 "resource_readable_id": doc["readable_id"],
+                "run_readable_id": doc["readable_id"],
                 "file_extension": ".txt",
                 "file_type": "course_metadata",
                 "key": key,

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from typing import Optional
 
 from django.conf import settings
 from langchain.text_splitter import RecursiveCharacterTextSplitter
@@ -322,7 +323,9 @@ def should_generate_resource_embeddings(serialized_document):
     return True
 
 
-def should_generate_content_embeddings(serialized_document, point_id=None):
+def should_generate_content_embeddings(
+    serialized_document: dict, point_id: Optional[str] = None
+) -> bool:
     """
     Determine if we should generate embeddings for a content file
     """

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -359,7 +359,9 @@ def _embed_course_metadata_as_contentfile(serialized_resources):
         serializer = LearningResourceMetadataDisplaySerializer(doc)
         serialized_document = serializer.render_document()
         checksum = checksum_for_content(str(serialized_document))
+        key = f"{doc['readable_id']}.course_metadata"
         serialized_document["checksum"] = checksum
+        serialized_document["key"] = key
         document_point_id = vector_point_id(
             f"{doc['readable_id']}.course_information.0"
         )
@@ -367,6 +369,10 @@ def _embed_course_metadata_as_contentfile(serialized_resources):
             serialized_document, document_point_id
         ):
             continue
+        # remove existing course info docs
+        remove_points_matching_params(
+            {"key": key}, collection_name=CONTENT_FILES_COLLECTION_NAME
+        )
         split_texts = serializer.render_chunks()
         split_metadatas = [
             {
@@ -375,6 +381,8 @@ def _embed_course_metadata_as_contentfile(serialized_resources):
                 "chunk_content": chunk_content,
                 "resource_readable_id": doc["readable_id"],
                 "file_extension": ".txt",
+                "file_type": "course_metadata",
+                "key": key,
                 "checksum": checksum,
                 **{key: doc[key] for key in ["offered_by", "platform"]},
             }

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -12,10 +12,12 @@ from learning_resources.factories import (
     LearningResourceRunFactory,
 )
 from learning_resources.models import LearningResource
+from learning_resources.serializers import LearningResourceMetadataDisplaySerializer
 from learning_resources_search.serializers import (
     serialize_bulk_content_files,
     serialize_bulk_learning_resources,
 )
+from main.utils import checksum_for_content
 from vector_search.constants import (
     CONTENT_FILES_COLLECTION_NAME,
     QDRANT_CONTENT_FILE_PARAM_MAP,
@@ -635,3 +637,48 @@ def test_embed_learning_resources_summarizes_only_contentfiles_with_summary(mock
     # Only contentfiles with summary should be passed
     expected_ids = [cf.id for cf in contentfiles_with_summary]
     summarize_mock.assert_called_once_with(expected_ids, True)  # noqa: FBT003
+
+
+@pytest.mark.django_db
+def test_embed_course_metadata_as_contentfile_uploads_points_on_change(mocker):
+    """
+    Test that _embed_course_metadata_as_contentfile uploads points to Qdrant
+    if any property of a serialized_resource has changed
+    """
+
+    mock_client = mocker.patch("vector_search.utils.qdrant_client").return_value
+    mock_encoder = mocker.patch("vector_search.utils.dense_encoder").return_value
+    mock_encoder.model_short_name.return_value = "test-model"
+    mock_encoder.embed_documents.return_value = [[0.1, 0.2, 0.3]]
+    resource = LearningResourceFactory.create()
+    serialized_resource = next(serialize_bulk_learning_resources([resource.id]))
+    serializer = LearningResourceMetadataDisplaySerializer(serialized_resource)
+    rendered_document = serializer.render_document()
+    resource_checksum = checksum_for_content(str(rendered_document))
+
+    """
+    Simulate qdrant returning a checksum for existing
+    record that matches the checksum of metadata doc
+    """
+    mock_point = mocker.Mock()
+    mock_point.payload = {"checksum": "checksum2"}
+    mock_client.retrieve.return_value = [mock_point]
+
+    _embed_course_metadata_as_contentfile([serialized_resource])
+
+    # Assert upload_points was called
+    assert mock_client.upload_points.called
+    args, kwargs = mock_client.upload_points.call_args
+    assert args[0] == CONTENT_FILES_COLLECTION_NAME
+    points = list(kwargs["points"])
+    assert len(points) == 1
+    assert points[0].payload["resource_readable_id"] == resource.readable_id
+    assert points[0].payload["checksum"] == resource_checksum
+
+    # simulate qdrant returning the same checksum for the metadata doc
+    mock_point.payload = {"checksum": resource_checksum}
+    mock_client.upload_points.reset_mock()
+    _embed_course_metadata_as_contentfile([serialized_resource])
+
+    # nothing has changed - no updates to make
+    assert not mock_client.upload_points.called


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/7986
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR fixes an issue where the course metadata document that we generate and embed does not get updated when course info is updated or when an etl runs for updated/upserted courses. 


### How can this be tested?
1. checkout this branch
2. restart celery
3. generate embeddings for some existing course
```bash
python manage.py generate_embeddings --resource-ids 12 --overwrite
```
4. go to your local qdrant dashboard and into the contentfiles collection and search for a key:{readable_id}.course_metadata
<img width="400" height="81" alt="Screenshot 2025-08-05 at 3 59 16 PM" src="https://github.com/user-attachments/assets/cc3cb67e-8203-4735-a83c-281ff6951a30" />

5. make note of the "checksum" 
6. go into the shell and change any property of the resource that shows up in the display of the learning resource drawer (ex:location) and save it.
7. go and re-run the embedding generation ```python manage.py generate_embeddings --resource-ids 12 --overwrite```
8. reload you qdrant dashboard page and search for that key again and see there is a new checksum (you can also compare the "content" field.


### Other Notes
Currently the course metadata doc is a special case and is not stored as an actual contentfile object (which we do with other similar documents we embed to add context like the scraped marketing pages for courses). We should probably change this at some point but that is a separate effort since there are caveats to it (we need to append the "# course information headers to each chunk etc)

