### PR TITLE
org dashboard design updates

### DIFF
--- a/frontends/api/src/mitxonline/clients.ts
+++ b/frontends/api/src/mitxonline/clients.ts
@@ -24,20 +24,28 @@ const BASE_PATH =
 
 const usersApi = new UsersApi(undefined, BASE_PATH, axiosInstance)
 const b2bApi = new B2bApi(undefined, BASE_PATH, axiosInstance)
-const enrollmentsApi = new EnrollmentsApi(undefined, BASE_PATH, axiosInstance)
 const programsApi = new ProgramsApi(undefined, BASE_PATH, axiosInstance)
 const programCollectionsApi = new ProgramCollectionsApi(
   undefined,
   BASE_PATH,
   axiosInstance,
 )
+
 const programCertificatesApi = new ProgramCertificatesApi(
   undefined,
   BASE_PATH,
   axiosInstance,
 )
+
 const coursesApi = new CoursesApi(undefined, BASE_PATH, axiosInstance)
+
 const courseCertificatesApi = new CourseCertificatesApi(
+  undefined,
+  BASE_PATH,
+  axiosInstance,
+)
+
+const courseRunEnrollmentsApi = new EnrollmentsApi(
   undefined,
   BASE_PATH,
   axiosInstance,
@@ -46,7 +54,7 @@ const courseCertificatesApi = new CourseCertificatesApi(
 export {
   usersApi,
   b2bApi,
-  enrollmentsApi,
+  courseRunEnrollmentsApi,
   programsApi,
   programCollectionsApi,
   coursesApi,

--- a/frontends/api/src/mitxonline/hooks/enrollment/index.ts
+++ b/frontends/api/src/mitxonline/hooks/enrollment/index.ts
@@ -1,6 +1,6 @@
 import { enrollmentQueries, enrollmentKeys } from "./queries"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { b2bApi, enrollmentsApi } from "../../clients"
+import { b2bApi, courseRunEnrollmentsApi } from "../../clients"
 import {
   B2bApiB2bEnrollCreateRequest,
   EnrollmentsApiEnrollmentsPartialUpdateRequest,
@@ -12,7 +12,7 @@ const useCreateEnrollment = (opts: B2bApiB2bEnrollCreateRequest) => {
     mutationFn: () => b2bApi.b2bEnrollCreate(opts),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: enrollmentKeys.enrollmentsList(),
+        queryKey: enrollmentKeys.courseRunEnrollmentsList(),
       })
     },
   })
@@ -23,10 +23,10 @@ const useUpdateEnrollment = (
 ) => {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: () => enrollmentsApi.enrollmentsPartialUpdate(opts),
+    mutationFn: () => courseRunEnrollmentsApi.enrollmentsPartialUpdate(opts),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: enrollmentKeys.enrollmentsList(),
+        queryKey: enrollmentKeys.courseRunEnrollmentsList(),
       })
     },
   })
@@ -35,10 +35,11 @@ const useUpdateEnrollment = (
 const useDestroyEnrollment = (enrollmentId: number) => {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: () => enrollmentsApi.enrollmentsDestroy({ id: enrollmentId }),
+    mutationFn: () =>
+      courseRunEnrollmentsApi.enrollmentsDestroy({ id: enrollmentId }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: enrollmentKeys.enrollmentsList(),
+        queryKey: enrollmentKeys.courseRunEnrollmentsList(),
       })
     },
   })

--- a/frontends/api/src/mitxonline/hooks/enrollment/queries.ts
+++ b/frontends/api/src/mitxonline/hooks/enrollment/queries.ts
@@ -1,19 +1,28 @@
 import { queryOptions } from "@tanstack/react-query"
 import type { CourseRunEnrollment } from "@mitodl/mitxonline-api-axios/v2"
 
-import { enrollmentsApi } from "../../clients"
+import { courseRunEnrollmentsApi } from "../../clients"
 
 const enrollmentKeys = {
   root: ["mitxonline", "enrollments"],
-  enrollmentsList: () => [...enrollmentKeys.root, "programEnrollments", "list"],
+  courseRunEnrollmentsList: () => [
+    ...enrollmentKeys.root,
+    "courseRunEnrollments",
+    "list",
+  ],
+  programEnrollmentsList: () => [
+    ...enrollmentKeys.root,
+    "programEnrollments",
+    "list",
+  ],
 }
 
 const enrollmentQueries = {
-  enrollmentsList: () =>
+  courseRunEnrollmentsList: () =>
     queryOptions({
-      queryKey: enrollmentKeys.enrollmentsList(),
+      queryKey: enrollmentKeys.courseRunEnrollmentsList(),
       queryFn: async (): Promise<CourseRunEnrollment[]> => {
-        return enrollmentsApi.enrollmentsList().then((res) => res.data)
+        return courseRunEnrollmentsApi.enrollmentsList().then((res) => res.data)
       },
     }),
 }

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -22,6 +22,7 @@
     "@tanstack/react-query": "^5.66",
     "api": "workspace:*",
     "classnames": "^2.5.1",
+    "dompurify": "^3.2.6",
     "formik": "^2.4.6",
     "iso-639-1": "^3.1.4",
     "lodash": "^4.17.21",

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -132,7 +132,7 @@ const getCoursewareText = ({
   courseNoun: string
 }) => {
   if (!enrollmentStatus || enrollmentStatus === EnrollmentStatus.NotEnrolled) {
-    return "Enroll"
+    return `Start ${courseNoun}`
   }
   if (!endDate) return `Continue ${courseNoun}`
   if (isInPast(endDate)) {
@@ -398,7 +398,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   )
   const contextMenu = isLoading ? (
     <Skeleton variant="rectangular" width={12} height={24} />
-  ) : menuItems.length > 0 ? (
+  ) : (
     <SimpleMenu
       items={menuItems}
       trigger={
@@ -407,12 +407,13 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
           variant="text"
           aria-label="More options"
           status={enrollment?.status}
+          hidden={menuItems.length === 0}
         >
           <RiMore2Line />
         </MenuButton>
       }
     />
-  ) : null
+  )
   const desktopLayout = (
     <CardRoot
       screenSize="desktop"

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -175,7 +175,7 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
 
 const EnrollmentDisplay = () => {
   const { data: enrolledCourses, isLoading } = useQuery({
-    ...enrollmentQueries.enrollmentsList(),
+    ...enrollmentQueries.courseRunEnrollmentsList(),
     select: mitxonlineEnrollments,
     throwOnError: (error) => {
       const err = error as MaybeHasStatusAndDetail

--- a/yarn.lock
+++ b/yarn.lock
@@ -6212,6 +6212,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/trusted-types@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 10/8e4202766a65877efcf5d5a41b7dd458480b36195e580a3b1085ad21e948bc417d55d6f8af1fd2a7ad008015d4117d5fdfe432731157da3c68678487174e4ba3
+  languageName: node
+  linkType: hard
+
 "@types/unist@npm:*, @types/unist@npm:^3.0.0":
   version: 3.0.3
   resolution: "@types/unist@npm:3.0.3"
@@ -9416,6 +9423,18 @@ __metadata:
   dependencies:
     domelementtype: "npm:^2.2.0"
   checksum: 10/e0d2af7403997a3ca040a9ace4a233b75ebe321e0ef628b417e46d619d65d47781b2f2038b6c2ef6e56e73e66aec99caf6a12c7e687ecff18ef74af6dfbde5de
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.2.6":
+  version: 3.2.6
+  resolution: "dompurify@npm:3.2.6"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10/b91631ed0e4d17fae950ef53613cc009ed7e73adc43ac94a41dd52f35483f7538d13caebdafa7626e0da145fc8184e7ac7935f14f25b7e841b32fda777e40447
   languageName: node
   linkType: hard
 
@@ -13949,6 +13968,7 @@ __metadata:
     "@types/slick-carousel": "npm:^1"
     api: "workspace:*"
     classnames: "npm:^2.5.1"
+    dompurify: "npm:^3.2.6"
     eslint: "npm:8.57.1"
     eslint-config-next: "npm:^14.2.7"
     formik: "npm:^2.4.6"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/mit-learn/issues/2424

### Description (What does it do?)
This PR makes several styling adjustments to the org dashboard, listed in the above issue. In addition to style adjustments, the HTML description for programs and program collections coming from Wagtail is now being rendered using `dompurify` in conjunction with `dangerouslySetInnerHtml`. 

### Screenshots (if appropriate):
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/1c36dc41-be3e-40e1-9157-89405fe33594" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/9fb59cd7-9acf-4d71-8419-4f498da02853" />

### How can this be tested?
In order to test this, you need a basic installation of `mitxonline` up and running with example data in it. You may be able to skip one or more steps if you have already done them:
- Ensure you have local `hosts` redirects for the following domains, replacing the example IP with your __local__ IP address (Google how to get this if unsure, mine is 192.168.1.50)
```
192.168.1.50 open.odl.local
192.168.1.50 api.open.odl.local
192.168.1.50 kc.ol.local
192.168.1.50 mitxonline.odl.local
```
- Clone `mitxonline`: https://github.com/mitodl/mitxonline
- Create a `.env` file with the following values:
```
CELERY_TASK_ALWAYS_EAGER=True
DJANGO_LOG_LEVEL=INFO
LOG_LEVEL=INFO
SENTRY_LOG_LEVEL=ERROR
MAILGUN_KEY=fake
MAILGUN_URL=
MAILGUN_RECIPIENT_OVERRIDE=
MAILGUN_SENDER_DOMAIN=.odl.local
SECRET_KEY=
STATUS_TOKEN=
UWSGI_THREADS=5
SENTRY_DSN=
MITX_ONLINE_BASE_URL=http://open.odl.local:8065/mitxonline
MITX_ONLINE_ADMIN_CLIENT_ID=refine-local-client-id
MITX_ONLINE_ADMIN_BASE_URL=http://mitxonline.odl.local:8016
POSTHOG_PROJECT_API_KEY=
POSTHOG_API_HOST=https://app.posthog.com/
HUBSPOT_HOME_PAGE_FORM_GUID=
HUBSPOT_PORTAL_ID=
APISIX_PORT=9080

# APISIX/Keycloak settings
APISIX_LOGOUT_URL=http://api.open.odl.local:8065/logout/
APISIX_SESSION_SECRET_KEY=supertopsecret1234
KC_SPI_THEME_WELCOME_THEME=scim
KC_SPI_REALM_RESTAPI_EXTENSION_SCIM_LICENSE_KEY=
KEYCLOAK_BASE_URL=http://kc.ol.local:8066
KEYCLOAK_CLIENT_ID=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
KEYCLOAK_CLIENT_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
KEYCLOAK_DISCOVERY_URL=http://kc.ol.local:8066/realms/ol-local/.well-known/openid-configuration
KEYCLOAK_REALM_NAME=ol-local
KEYCLOAK_SCOPES="openid profile ol-profile"
KEYCLOAK_SVC_KEYSTORE_PASSWORD=supertopsecret1234
KEYCLOAK_SVC_HOSTNAME=kc.ol.local
KEYCLOAK_SVC_ADMIN=admin
KEYCLOAK_SVC_ADMIN_PASSWORD=admin
AUTHORIZATION_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/auth
ACCESS_TOKEN_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/token
OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_KEY=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
SOCIAL_AUTH_OL_OIDC_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
USERINFO_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/userinfo
MITOL_APIGATEWAY_DISABLE_MIDDLEWARE=False

FEATURE_IGNORE_EDX_FAILURES=True
OPENEDX_API_CLIENT_ID=fake
OPENEDX_API_CLIENT_SECRET=fake
OPENEDX_SERVICE_WORKER_API_TOKEN=fake

CSRF_COOKIE_DOMAIN=.odl.local
CORS_ALLOWED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
CSRF_TRUSTED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
```
- Spin up `mitxonline` with `docker compose up --build -d`
- Promote the admin user with `docker compose exec web ./manage.py promote_user promote --superuser --email admin@odl.local`
- Populate test course data with `docker compose exec web ./manage.py populate_course_data`
- Navigate to the MITx Online catalog and enroll in a few courses
- In Django admin, create a `Program` and add some courses to the program that are included in your B2B org, making sure to mark the program as "live"
- Create a few more programs with different courses in them that are also part of the B2B org
- Navigate to Wagtail at http://mitxonline.odl.local:8065/cms
- Browse to Home Page -> Program Collections
- Create a new program collection, but only add some of the programs
- Set a description on the program collection, making sure to format some of the text bold / italic
- Browse to Home Page -> Programs
- Make sure there is a Program Page for your program that is *not* part of the collection, and make sure you also set a formatted description on it
- Make sure you have a personal Posthog project configured and have the API key at the ready
- Before we spin up `mit-learn`, we need to set some env variables:
```
.env
...
MITX_ONLINE_UPSTREAM=mitxonline.odl.local:8013
MITX_ONLINE_DOMAIN=mitxonline.odl.local
MITX_ONLINE_BASE_URL=http://mitxonline.odl.local:8065
POSTHOG_ENABLED=True
CSRF_COOKIE_DOMAIN=.odl.local

shared.local.env
POSTHOG_PROJECT_API_KEY=YOUR_API_KEY_HERE
POSTHOG_PROJECT_ID=YOUR_PROJECT_ID_HERE
POSTHOG_TIMEOUT_MS=1500
```
- In your Posthog project, enable the `enrollment-dashboard` and `mitlearn-organization-dashboard` feature flags for all users
- Spin up `MIT Learn`
- Log in with the `admin@odl.local` test user
- Navigate to the org dashboard
- Make sure the appearance matches the Figma design
- Enroll / Unenroll from courses and ensure that the CTA language is as expected and that unenrolled courses have their CTA's properly offset