### PR TITLE
ContentFile vector search grouping

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -11020,6 +11020,8 @@ export const VectorContentFilesSearchApiAxiosParamCreator = function (
      * @param {Array<string>} [course_number] Course number of the content file
      * @param {Array<string>} [edx_module_id] The edx_module_id of the content file
      * @param {Array<string>} [file_extension] The extension of the content file.
+     * @param {string} [group_by] The attribute to group results by
+     * @param {number} [group_size] The number of chunks in each group. Only relevant when group_by is used
      * @param {Array<string>} [key] The filename of the content file
      * @param {number} [limit] Number of results to return per page
      * @param {Array<string>} [offered_by] Offeror of the content file
@@ -11038,6 +11040,8 @@ export const VectorContentFilesSearchApiAxiosParamCreator = function (
       course_number?: Array<string>,
       edx_module_id?: Array<string>,
       file_extension?: Array<string>,
+      group_by?: string,
+      group_size?: number,
       key?: Array<string>,
       limit?: number,
       offered_by?: Array<string>,
@@ -11083,6 +11087,14 @@ export const VectorContentFilesSearchApiAxiosParamCreator = function (
 
       if (file_extension) {
         localVarQueryParameter["file_extension"] = file_extension
+      }
+
+      if (group_by !== undefined) {
+        localVarQueryParameter["group_by"] = group_by
+      }
+
+      if (group_size !== undefined) {
+        localVarQueryParameter["group_size"] = group_size
       }
 
       if (key) {
@@ -11156,6 +11168,8 @@ export const VectorContentFilesSearchApiFp = function (
      * @param {Array<string>} [course_number] Course number of the content file
      * @param {Array<string>} [edx_module_id] The edx_module_id of the content file
      * @param {Array<string>} [file_extension] The extension of the content file.
+     * @param {string} [group_by] The attribute to group results by
+     * @param {number} [group_size] The number of chunks in each group. Only relevant when group_by is used
      * @param {Array<string>} [key] The filename of the content file
      * @param {number} [limit] Number of results to return per page
      * @param {Array<string>} [offered_by] Offeror of the content file
@@ -11174,6 +11188,8 @@ export const VectorContentFilesSearchApiFp = function (
       course_number?: Array<string>,
       edx_module_id?: Array<string>,
       file_extension?: Array<string>,
+      group_by?: string,
+      group_size?: number,
       key?: Array<string>,
       limit?: number,
       offered_by?: Array<string>,
@@ -11197,6 +11213,8 @@ export const VectorContentFilesSearchApiFp = function (
           course_number,
           edx_module_id,
           file_extension,
+          group_by,
+          group_size,
           key,
           limit,
           offered_by,
@@ -11253,6 +11271,8 @@ export const VectorContentFilesSearchApiFactory = function (
           requestParameters.course_number,
           requestParameters.edx_module_id,
           requestParameters.file_extension,
+          requestParameters.group_by,
+          requestParameters.group_size,
           requestParameters.key,
           requestParameters.limit,
           requestParameters.offered_by,
@@ -11309,6 +11329,20 @@ export interface VectorContentFilesSearchApiVectorContentFilesSearchRetrieveRequ
    * @memberof VectorContentFilesSearchApiVectorContentFilesSearchRetrieve
    */
   readonly file_extension?: Array<string>
+
+  /**
+   * The attribute to group results by
+   * @type {string}
+   * @memberof VectorContentFilesSearchApiVectorContentFilesSearchRetrieve
+   */
+  readonly group_by?: string
+
+  /**
+   * The number of chunks in each group. Only relevant when group_by is used
+   * @type {number}
+   * @memberof VectorContentFilesSearchApiVectorContentFilesSearchRetrieve
+   */
+  readonly group_size?: number
 
   /**
    * The filename of the content file
@@ -11400,6 +11434,8 @@ export class VectorContentFilesSearchApi extends BaseAPI {
         requestParameters.course_number,
         requestParameters.edx_module_id,
         requestParameters.file_extension,
+        requestParameters.group_by,
+        requestParameters.group_size,
         requestParameters.key,
         requestParameters.limit,
         requestParameters.offered_by,

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -867,6 +867,18 @@ paths:
             minLength: 1
         description: 'The extension of the content file. '
       - in: query
+        name: group_by
+        schema:
+          type: string
+          minLength: 1
+        description: The attribute to group results by
+      - in: query
+        name: group_size
+        schema:
+          type: integer
+        description: The number of chunks in each group. Only relevant when group_by
+          is used
+      - in: query
         name: key
         schema:
           type: array

--- a/vector_search/serializers.py
+++ b/vector_search/serializers.py
@@ -242,7 +242,7 @@ class ContentFileVectorSearchRequestSerializer(serializers.Serializer):
         required=False,
         help_text=("The attribute to group results by"),
     )
-    group_size = serializers.CharField(
+    group_size = serializers.IntegerField(
         required=False,
         help_text=(
             "The number of chunks in each group. Only relevant when group_by is used"

--- a/vector_search/serializers.py
+++ b/vector_search/serializers.py
@@ -238,6 +238,16 @@ class ContentFileVectorSearchRequestSerializer(serializers.Serializer):
         required=False,
         help_text=("Manually specify the name of the Qdrant collection to query"),
     )
+    group_by = serializers.CharField(
+        required=False,
+        help_text=("The attribute to group results by"),
+    )
+    group_size = serializers.CharField(
+        required=False,
+        help_text=(
+            "The number of chunks in each group. Only relevant when group_by is used"
+        ),
+    )
 
 
 class ContentFileVectorSearchResponseSerializer(SearchResponseSerializer):

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -652,8 +652,8 @@ def vector_search(
             for group in group_result.groups:
                 payloads = [hit.payload for hit in group.hits]
                 response_hit = _merge_dicts(payloads)
-                chunks = [payload["chunk_content"] for payload in payloads]
-                response_hit["chunk_content"] = "".join(chunks)
+                chunks = [payload.get("chunk_content") for payload in payloads]
+                response_hit["chunk_content"] = " ".join(chunks)
                 response_hit["chunks"] = chunks
                 response_row = {
                     "id": response_hit[search_params["group_by"]],

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -646,7 +646,7 @@ def vector_search(
         }
         if "group_by" in params:
             search_params["group_by"] = params.get("group_by")
-            search_params["group_size"] = params.get("group_size", 10)
+            search_params["group_size"] = params.get("group_size", 1)
             group_result = client.query_points_groups(**search_params)
             search_result = []
             for group in group_result.groups:

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -587,6 +587,21 @@ def _content_file_vector_hits(search_result):
     return results
 
 
+def _merge_dicts(dicts):
+    """
+    Return a dictionary with keys and values that are common across all input dicts
+    """
+    if not dicts:
+        return {}
+    common_keys = set.intersection(*(set(d.keys()) for d in dicts))
+    result = {}
+    for key in common_keys:
+        values = [d[key] for d in dicts]
+        if all(v == values[0] for v in values):
+            result[key] = values[0]
+    return result
+
+
 def vector_search(
     query_string: str,
     params: dict,
@@ -621,15 +636,35 @@ def vector_search(
         ]
     )
     if query_string:
-        search_result = client.query_points(
-            collection_name=search_collection,
-            using=encoder.model_short_name(),
-            query=encoder.embed_query(query_string),
-            query_filter=search_filter,
-            search_params=models.SearchParams(indexed_only=True),
-            limit=limit,
-            offset=offset,
-        ).points
+        search_params = {
+            "collection_name": search_collection,
+            "using": encoder.model_short_name(),
+            "query": encoder.embed_query(query_string),
+            "query_filter": search_filter,
+            "search_params": models.SearchParams(indexed_only=True),
+            "limit": limit,
+        }
+        if "group_by" in params:
+            search_params["group_by"] = params.get("group_by")
+            search_params["group_size"] = params.get("group_size", 10)
+            group_result = client.query_points_groups(**search_params)
+            search_result = []
+            for group in group_result.groups:
+                payloads = [hit.payload for hit in group.hits]
+                response_hit = _merge_dicts(payloads)
+                chunks = [payload["chunk_content"] for payload in payloads]
+                response_hit["chunk_content"] = "".join(chunks)
+                response_hit["chunks"] = chunks
+                response_row = {
+                    "id": response_hit[search_params["group_by"]],
+                    "payload": response_hit,
+                    "vector": [],
+                }
+                search_result.append(models.PointStruct(**response_row))
+
+        else:
+            search_params["offset"] = offset
+            search_result = client.query_points(**search_params).points
     else:
         search_result = client.scroll(
             collection_name=search_collection,

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -655,7 +655,7 @@ def test_vector_search_group_by(mocker):
     mock_group1_hit1 = mocker.MagicMock()
     mock_group1_hit1.payload = {
         group_by_field: resource_id_1,
-        "chunk_content": "First part. ",
+        "chunk_content": "First part.",
         "common_field": "value1",
     }
     mock_group1_hit2 = mocker.MagicMock()

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -35,6 +35,7 @@ from vector_search.utils import (
     update_content_file_payload,
     update_learning_resource_payload,
     vector_point_id,
+    vector_search,
 )
 
 pytestmark = pytest.mark.django_db
@@ -635,3 +636,85 @@ def test_embed_learning_resources_summarizes_only_contentfiles_with_summary(mock
     # Only contentfiles with summary should be passed
     expected_ids = [cf.id for cf in contentfiles_with_summary]
     summarize_mock.assert_called_once_with(expected_ids, True)  # noqa: FBT003
+
+
+def test_vector_search_group_by(mocker):
+    """
+    Test that vector_search with group_by parameter returns grouped results
+    where chunks are merged on common fields
+    """
+    mock_qdrant = mocker.patch("vector_search.utils.qdrant_client")()
+    mock_encoder = mocker.patch("vector_search.utils.dense_encoder")()
+    mock_encoder.embed_query.return_value = [0.1, 0.2, 0.3]
+    mock_encoder.model_short_name.return_value = "test-encoder"
+
+    group_by_field = "resource_readable_id"
+    resource_id_1 = "resource1"
+    resource_id_2 = "resource2"
+
+    mock_group1_hit1 = mocker.MagicMock()
+    mock_group1_hit1.payload = {
+        group_by_field: resource_id_1,
+        "chunk_content": "First part. ",
+        "common_field": "value1",
+    }
+    mock_group1_hit2 = mocker.MagicMock()
+    mock_group1_hit2.payload = {
+        group_by_field: resource_id_1,
+        "chunk_content": "Second part.",
+        "common_field": "value1",
+    }
+
+    mock_group2_hit1 = mocker.MagicMock()
+    mock_group2_hit1.payload = {
+        group_by_field: resource_id_2,
+        "chunk_content": "Only part.",
+        "common_field": "value2",
+    }
+
+    mock_group1 = mocker.MagicMock()
+    mock_group1.hits = [mock_group1_hit1, mock_group1_hit2]
+    mock_group2 = mocker.MagicMock()
+    mock_group2.hits = [mock_group2_hit1]
+
+    mock_group_result = mocker.MagicMock()
+    mock_group_result.groups = [mock_group1, mock_group2]
+    mock_qdrant.query_points_groups.return_value = mock_group_result
+    mock_qdrant.count.return_value = models.CountResult(count=2)
+
+    mocker.patch(
+        "vector_search.utils._content_file_vector_hits", side_effect=lambda x: x
+    )
+
+    params = {
+        "group_by": group_by_field,
+        "group_size": 2,
+    }
+    results = vector_search(
+        "test query",
+        params,
+        search_collection=CONTENT_FILES_COLLECTION_NAME,
+    )
+
+    assert len(results["hits"]) == 2
+    assert results["total"]["value"] == 2
+
+    hit1 = next(
+        h for h in results["hits"] if h.payload[group_by_field] == resource_id_1
+    )
+    hit2 = next(
+        h for h in results["hits"] if h.payload[group_by_field] == resource_id_2
+    )
+
+    assert hit1.payload["chunk_content"] == "First part. Second part."
+    assert hit1.payload["common_field"] == "value1"
+    assert hit1.payload["chunks"] == ["First part. ", "Second part."]
+
+    assert hit2.payload["chunk_content"] == "Only part."
+    assert hit2.payload["common_field"] == "value2"
+    assert hit2.payload["chunks"] == ["Only part."]
+
+    mock_qdrant.query_points_groups.assert_called_once()
+    call_args = mock_qdrant.query_points_groups.call_args.kwargs
+    assert call_args["group_by"] == group_by_field
+    assert call_args["group_size"] == 2

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -708,7 +708,7 @@ def test_vector_search_group_by(mocker):
 
     assert hit1.payload["chunk_content"] == "First part. Second part."
     assert hit1.payload["common_field"] == "value1"
-    assert hit1.payload["chunks"] == ["First part. ", "Second part."]
+    assert hit1.payload["chunks"] == ["First part.", "Second part."]
 
     assert hit2.payload["chunk_content"] == "Only part."
     assert hit2.payload["common_field"] == "value2"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes  https://github.com/mitodl/hq/issues/6491
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR adds a "group_by" parameter to the vector contentfiles endpoint which uses qdrant's [groupby api](https://api.qdrant.tech/api-reference/search/query-points-groups) to group chunks by a particular payload field. The intended end use of this is for "search in documents" functionality that executes a vector search and returns results where each row corresponds to a single document.


### How can this be tested?
1. checkout this branch
2. ensure you have contentfiles locally and have also generated embeddings. if not, run ```python manage.py generate_embeddings --all```
3. visit the contentfile [vector endpoint](http://open.odl.local:8063/api/v0/vector_content_files_search/?q=testing) with some query (q= parameter). 
4. now group the results by document by adding group_by=key - also add group_size=10 (to make it easier to see the grouping in action). the group_size determines the max number of matches per group (1 is default).  http://open.odl.local:8063/api/v0/vector_content_files_search/?q=testing&group_by=key&group_size=5
5. note that the results now have "chunk_content" which is a concatenation of all the matching chunks and a "chunks" field which is an array of individual matches:
```
{
...
"chunk_content": 'chunk 1 chunk 2 chunk 3 chunk 4 chunk 5',
"chunks":['chunk 1', 'chunk 2', chunk 3', chunk 4', 'chunk 5']
...
}
```

### Additional Context
1. Grouping only works when a query (q= param) is specified since it is not compatable with the qdrant scroll api
2. when grouping, we lose pagination (offset param). We can however specify the number of documents to be returned using the limit= param.

