### PR TITLE
fix program collection org filter bug

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
@@ -207,7 +207,7 @@ const OrgProgramDisplay: React.FC<{
   program: DashboardProgram
   courseRunEnrollments?: CourseRunEnrollment[]
   programLoading: boolean
-  orgId?: number
+  orgId: number
 }> = ({ program, courseRunEnrollments, programLoading, orgId }) => {
   const courses = useQuery(
     coursesQueries.coursesList({ id: program.courseIds, org_id: orgId }),
@@ -255,7 +255,7 @@ const OrgProgramDisplay: React.FC<{
 const ProgramCollectionItem: React.FC<{
   program: DashboardProgram
   enrollments?: CourseRunEnrollment[]
-  orgId?: number
+  orgId: number
 }> = ({ program, enrollments, orgId }) => {
   return (
     <ProgramCard program={program} enrollments={enrollments} orgId={orgId} />
@@ -265,7 +265,7 @@ const ProgramCollectionItem: React.FC<{
 const ProgramCard: React.FC<{
   program: DashboardProgram
   enrollments?: CourseRunEnrollment[]
-  orgId?: number
+  orgId: number
 }> = ({ program, enrollments, orgId }) => {
   const courses = useQuery(
     coursesQueries.coursesList({

--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
@@ -194,6 +194,7 @@ const OrgProgramCollectionDisplay: React.FC<{
               key={item.programId}
               program={item.program}
               enrollments={enrollments}
+              orgId={orgId}
             />
           ) : null,
         )}
@@ -254,8 +255,11 @@ const OrgProgramDisplay: React.FC<{
 const ProgramCollectionItem: React.FC<{
   program: DashboardProgram
   enrollments?: CourseRunEnrollment[]
-}> = ({ program, enrollments }) => {
-  return <ProgramCard program={program} enrollments={enrollments} />
+  orgId?: number
+}> = ({ program, enrollments, orgId }) => {
+  return (
+    <ProgramCard program={program} enrollments={enrollments} orgId={orgId} />
+  )
 }
 
 const ProgramCard: React.FC<{


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/8107

### Description (What does it do?)
This PR fixes a bug introduced in https://github.com/mitodl/mit-learn/pull/2427, which ironically was supposed to better handle bad data coming in from the API. The PR added filters to ensure that only courses from the current org are pulled in, but then failed to set the `orgId` parameter on `ProgramCollectionItem`, and then subsequently `ProgramCard`. This PR also makes that argument not optional on `OrganizationContent`, so it's more obvious in the future if the proper filtering is not being applied.

### How can this be tested?
- Follow the instructions in https://github.com/mitodl/mit-learn/pull/2369 to get set up with a Program Collection
- None of the courses in the program collection should have their CTA's greyed out, and you should be able to enroll in a module
