### PR TITLE
Do not upsert unpublished resources

### DIFF
--- a/learning_resources/etl/posthog.py
+++ b/learning_resources/etl/posthog.py
@@ -282,7 +282,10 @@ def load_posthog_lrd_view_events(
     }
 
     for resource_id in learning_resource_ids:
-        learning_resource = LearningResource.objects.get(id=resource_id)
-        resource_upserted_actions(learning_resource, percolate=False)
+        learning_resource = LearningResource.objects.filter(
+            id=resource_id, published=True
+        ).first()
+        if learning_resource:
+            resource_upserted_actions(learning_resource, percolate=False)
 
     return events


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/8253

### Description (What does it do?)
- Alters the `load_posthog_lrd_view_events` function so it only upserts published resources.
- Fixes the related unit test

### How can this be tested?
- Tests should pass.
- See original PR for further instructions: https://github.com/mitodl/mit-learn/pull/789

