### PR TITLE
Minor tweaks to initial setup instructions, add memory env var for web container, note minimum required domain config for things to "work out of box"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ MITOL_WEB_MEM_LIMIT
 ```
 
 If any resource limits are set too low, you may encounter OOMKilled errors in the logs of those services. The primary way this will manifest is that containers may unexpectedly die during operation resulting in 500 errors or unusual celery task execution.
-Given a container that is unexpectedly down, you can verify that it was OOMKilled by running `docker inspect <container_name> -f '{{json .State.OOMKilled}}'`, or by checking the Docker VM kernel message logs for relevant output. 
+Given a container that is unexpectedly down, you can verify that it was OOMKilled by running `docker inspect <container_name> -f '{{json .State.OOMKilled}}'`, or by checking the Docker VM kernel message logs for relevant output.
 
 ### Loading Data
 

--- a/docker-compose.apps.yml
+++ b/docker-compose.apps.yml
@@ -9,7 +9,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: final
-    mem_limit: 1gb
+    mem_limit: ${MITOL_WEB_MEM_LIMIT:-2gb}
     cpus: 2
     command: ./scripts/run-django-dev.sh
     stdin_open: true
@@ -54,7 +54,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: final
-    mem_limit: ${MITOL_CELERY_MEM_LIMIT:-2gb}
+    mem_limit: ${MITOL_CELERY_MEM_LIMIT:-4gb}
     cpus: ${MITOL_CELERY_CPU_LIMIT:-2}
     command: >
       /bin/bash -c '

--- a/docs/how-to/embeddings.md
+++ b/docs/how-to/embeddings.md
@@ -27,7 +27,7 @@ The following embeddings related settings are available in the `settings.py` fil
 
 ## Embeddings for New Content
 
-Embeddings are automatically generated for new conetnt by a periodic celery task. The tasks are defined `vector_search/tasks.py`.
+Embeddings are automatically generated for new content by a periodic celery task. The tasks are defined `vector_search/tasks.py`.
 
 ## Embeddings for Existing Content
 

--- a/env/backend.local.example.env
+++ b/env/backend.local.example.env
@@ -21,7 +21,7 @@ MAILGUN_SENDER_DOMAIN=open.odl.local
 MAILGUN_KEY=fake
 
 # Set this to False if apisix/keycloak are running locally
-DISABLE_APISIX_USER_MIDDLEWARE=True
+DISABLE_APISIX_USER_MIDDLEWARE=False
 
 # APISIX/Keycloak settings
 APISIX_LOGOUT_URL=http://api.open.odl.local:8065/logout/

--- a/env/backend.local.example.env
+++ b/env/backend.local.example.env
@@ -20,9 +20,6 @@
 MAILGUN_SENDER_DOMAIN=open.odl.local
 MAILGUN_KEY=fake
 
-# Set this to False if apisix/keycloak are running locally
-DISABLE_APISIX_USER_MIDDLEWARE=False
-
 # APISIX/Keycloak settings
 APISIX_LOGOUT_URL=http://api.open.odl.local:8065/logout/
 APISIX_SESSION_SECRET_KEY=supertopsecret1234

--- a/env/shared.local.example.env
+++ b/env/shared.local.example.env
@@ -5,4 +5,4 @@
 # EMBEDLY_KEY=
 # Use port 8063 if apisix/keycloak disabled
 MITOL_API_BASE_URL=http://api.open.odl.local:8063
-MITOL_API_DOMAIN = api.open.odl.local # dev only, should match domain of above
+MITOL_API_DOMAIN=api.open.odl.local # dev only, should match domain of above


### PR DESCRIPTION

### Description (What does it do?)
Includes a few small changes to initial setup docs, as well as one or two QoL changes.
- Attempts to clarify that running keycloak and apisix is the "default" supported config for authentication.
- Adds some information about docker resource limits and how to check for OOMKills
- Enumerate the `/etc/hosts` entries required if you're relying on the example env values.
- Adjusts a few default and example values for memory and env vars, adds a new env var for setting web container mem_limit.

### How can this be tested?
Majority of this is documentation, but the memory changes can be observed by running `docker compose up` and observing that the upper limits are reflective of the increased thresholds in the Docker Desktop container stats tab:
<img width="993" height="379" alt="Screenshot 2025-08-25 at 3 30 32 PM" src="https://github.com/user-attachments/assets/2d48a543-0a1c-4337-8baf-a131d5f302f9" />

### Additional Context
Additional context, clarifying questions, ongoing discussion about issues encountered can be found [here](https://mitodl.slack.com/archives/C03K5HYGPT9/p1755872165330549)