### PR TITLE
fix popularity for learningpath items

### DIFF
--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -175,7 +175,7 @@ def test_program_detail_endpoint(client, django_assert_num_queries, url):
     """Test program endpoint"""
     program = ProgramFactory.create()
     assert program.learning_resource.children.count() > 0
-    with django_assert_num_queries(18):  # should be same # regardless of child count
+    with django_assert_num_queries(19):  # should be same # regardless of child count
         resp = client.get(reverse(url, args=[program.learning_resource.id]))
     assert resp.data.get("title") == program.learning_resource.title
     assert resp.data.get("resource_type") == LearningResourceType.program.name
@@ -220,7 +220,7 @@ def test_no_excess_queries(rf, user, mocker, django_assert_num_queries, course_c
     request = rf.get("/")
     request.user = user
 
-    with django_assert_num_queries(20):
+    with django_assert_num_queries(21):
         view = CourseViewSet(request=request)
         results = view.get_queryset().all()
         assert len(results) == course_count


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/8278

### Description (What does it do?)
There is currently a bug which causes views to be multiplied by the number of learning paths that a resource is in for learning resources that are part on multiple learning paths. This fixes it


### How can this be tested?
Find a learning resources for which you have LearningResourceViewEvent records. If you don't have any learning resources that have LearningResourceViewEvent records, follow the instructions here https://github.com/mitodl/mit-learn/pull/2436 to create it

If you don't have at least two learning paths, log in as an admin and create some from the dashboard ui. Add the record with views to two learning paths. Assign one or both of the learning paths as a featured list to a channel.

Checkout the main branch main

```
run
from learning_resources.models import *

LearningResource.objects.for_search_serialization().get(id=<id>).views_count
LearningResource.objects.for_serialization().get(id=<id>).views_count
LearningResource.objects.get(id=<id>).views_count
```

`LearningResource.objects.for_search_serialization().get(id=<id>).views_count` will return more results than the other two statements

additionally,
`LearningResource.objects.for_search_serialization().get(id=<id>).in_featured_lists` will return the number of lists assigned to a channel multiplied by the number of views


Checkout this branch. Run

```
from learning_resources.models import *

LearningResource.objects.for_search_serialization().get(id=<id>).views_count
LearningResource.objects.for_serialization().get(id=<id>).views_count
LearningResource.objects.get(id=<id>).views_count

LearningResource.objects.for_search_serialization().get(id=<id>).in_featured_lists
LearningResource.objects.for_serialization().get(id=<id>).in_featured_lists
LearningResource.objects.get(id=<id>).in_featured_lists
```

All three `.views_count` statements and all three `in_featured_lists` statements should be the same and correct


Run
```
docker compose exec web ./manage.py update_index --<the resource type of your resource>
```

Go to `http://api.open.odl.local:8065/api/v1/learning_resources_search/?id=<id>` and `http://api.open.odl.local:8065/api/v1/learning_resources/<id>`

the number of views should be the same