### PR TITLE
Fix for absolute certificate signature URLs

### DIFF
--- a/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
@@ -363,9 +363,6 @@ const CertificatePage: React.FC = () => {
     uuid: string
   }>()
 
-  console.log("certificateType", certificateType)
-  console.log("uuid", uuid)
-
   const { data: courseCertData, isLoading: isCourseLoading } = useQuery({
     ...certificateQueries.courseCertificatesRetrieve({
       cert_uuid: uuid,
@@ -470,7 +467,11 @@ const CertificatePage: React.FC = () => {
             {signatories?.map((signatory, index) => (
               <Signatory key={index}>
                 <Signature
-                  src={`${process.env.NEXT_PUBLIC_MITX_ONLINE_BASE_URL}${signatory.signature_image}`}
+                  src={
+                    signatory.signature_image.startsWith("http")
+                      ? signatory.signature_image
+                      : `${process.env.NEXT_PUBLIC_MITX_ONLINE_BASE_URL}${signatory.signature_image}`
+                  }
                   alt={signatory.name}
                 />
                 <SignatoryName variant="h3">{signatory.name}</SignatoryName>


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Relates to https://github.com/mitodl/hq/issues/8009

### Description (What does it do?)
<!--- Describe your changes in detail -->

When running mitxonline locally, the API provides a relative signature image path, so we were prefixing with the base URL.

Once deployed, we get absolute URLs to the S3 bucket, so were ending up with e.g. `https://api.rc.learn.mit.edu/mitxonlinehttps://ol-mitxonline-app-qa.s3.amazonaws.com/original_images/Dimitris_Bertsimas_Signature.original.png`.

This change renders the URL unmodified if it is absolute (starts with "http").



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Modify the value of `signatory.signature_image` in /app-pages/CertificatePage/CertificatePage.tsx to test locally.
