### PR TITLE
navigate to course after one click enroll

### DIFF
--- a/frontends/api/src/mitxonline/hooks/enrollment/index.ts
+++ b/frontends/api/src/mitxonline/hooks/enrollment/index.ts
@@ -6,11 +6,12 @@ import {
   EnrollmentsApiEnrollmentsPartialUpdateRequest,
 } from "@mitodl/mitxonline-api-axios/v2"
 
-const useCreateEnrollment = (opts: B2bApiB2bEnrollCreateRequest) => {
+const useCreateEnrollment = () => {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: () => b2bApi.b2bEnrollCreate(opts),
-    onSuccess: () => {
+    mutationFn: (opts: B2bApiB2bEnrollCreateRequest) =>
+      b2bApi.b2bEnrollCreate(opts),
+    onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: enrollmentKeys.courseRunEnrollmentsList(),
       })
@@ -18,13 +19,12 @@ const useCreateEnrollment = (opts: B2bApiB2bEnrollCreateRequest) => {
   })
 }
 
-const useUpdateEnrollment = (
-  opts: EnrollmentsApiEnrollmentsPartialUpdateRequest,
-) => {
+const useUpdateEnrollment = () => {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: () => courseRunEnrollmentsApi.enrollmentsPartialUpdate(opts),
-    onSuccess: () => {
+    mutationFn: (opts: EnrollmentsApiEnrollmentsPartialUpdateRequest) =>
+      courseRunEnrollmentsApi.enrollmentsPartialUpdate(opts),
+    onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: enrollmentKeys.courseRunEnrollmentsList(),
       })
@@ -32,12 +32,12 @@ const useUpdateEnrollment = (
   })
 }
 
-const useDestroyEnrollment = (enrollmentId: number) => {
+const useDestroyEnrollment = () => {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: () =>
+    mutationFn: (enrollmentId: number) =>
       courseRunEnrollmentsApi.enrollmentsDestroy({ id: enrollmentId }),
-    onSuccess: () => {
+    onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: enrollmentKeys.courseRunEnrollmentsList(),
       })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -28,6 +28,7 @@ import { EnrollmentStatusIndicator } from "./EnrollmentStatusIndicator"
 import { EmailSettingsDialog, UnenrollDialog } from "./DashboardDialogs"
 import NiceModal from "@ebay/nice-modal-react"
 import { useCreateEnrollment } from "api/mitxonline-hooks/enrollment"
+import { redirect } from "next/navigation"
 
 const CardRoot = styled.div<{
   screenSize: "desktop" | "mobile"
@@ -159,9 +160,7 @@ const CoursewareButton = styled(
     const hasStarted = startDate && isInPast(startDate)
     const hasEnrolled =
       enrollmentStatus && enrollmentStatus !== EnrollmentStatus.NotEnrolled
-    const createEnrollment = useCreateEnrollment({
-      readable_id: coursewareId ?? "",
-    })
+    const createEnrollment = useCreateEnrollment()
     return (hasStarted && href) || !hasEnrolled ? (
       hasEnrolled && href ? (
         <ButtonLink
@@ -181,7 +180,16 @@ const CoursewareButton = styled(
           className={className}
           disabled={createEnrollment.isPending || !coursewareId}
           onClick={async () => {
-            await createEnrollment.mutateAsync()
+            await createEnrollment.mutateAsync(
+              { readable_id: coursewareId ?? "" },
+              {
+                onSuccess: () => {
+                  if (href) {
+                    redirect(href)
+                  }
+                },
+              },
+            )
           }}
           {...others}
         >

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
@@ -42,18 +42,18 @@ const EmailSettingsDialogInner: React.FC<DashboardDialogProps> = ({
       receive_emails: enrollment.receiveEmails ?? true,
     },
     onSubmit: async () => {
-      await updateEnrollment.mutateAsync()
+      await updateEnrollment.mutateAsync({
+        id: enrollment.id,
+        PatchedUpdateCourseRunEnrollmentRequest: {
+          receive_emails: formik.values.receive_emails,
+        },
+      })
       if (!updateEnrollment.isError) {
         modal.hide()
       }
     },
   })
-  const updateEnrollment = useUpdateEnrollment({
-    id: enrollment.id,
-    PatchedUpdateCourseRunEnrollmentRequest: {
-      receive_emails: formik.values.receive_emails,
-    },
-  })
+  const updateEnrollment = useUpdateEnrollment()
   return (
     <FormDialog
       title={"Email Settings"}
@@ -121,14 +121,14 @@ const UnenrollDialogInner: React.FC<DashboardDialogProps> = ({
   enrollment,
 }) => {
   const modal = NiceModal.useModal()
-  const destroyEnrollment = useDestroyEnrollment(enrollment.id)
+  const destroyEnrollment = useDestroyEnrollment()
   const formik = useFormik({
     enableReinitialize: true,
     validateOnChange: false,
     validateOnBlur: false,
     initialValues: {},
     onSubmit: async () => {
-      await destroyEnrollment.mutateAsync()
+      await destroyEnrollment.mutateAsync(enrollment.id)
       if (!destroyEnrollment.isError) {
         modal.hide()
       }


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/8353

### Description (What does it do?)
This PR adds functionality that redirects to a given course's courseware URL immediately after a successful enrollment is completed. As part of this, some changes were made to the enrollment mutations (create, update, delete) so that they don't require arguments on instantiation and instead receive those arguments when running `mutate` or `mutateAsync`. The keys for these are also invalidated after `onSettled` now as well, so after a request the queries are invalidated regardless. This way, if `onSuccess` is used, it doesn't override what's already there to refresh the queries.

### How can this be tested?
Follow the instructions in https://github.com/mitodl/mit-learn/pull/2319, but with the additional caveat that after a successful enrollment you should be redirected to the courseware URL for the course you are enrolling in.
