### PR TITLE
canvas citation fixes for files with spaces

### DIFF
--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -343,7 +343,7 @@ def documents_from_olx(
                         "mime_type": mimetype,
                         "archive_checksum": archive_checksum,
                         "file_extension": extension_lower,
-                        "source_path": f"{path}/{filename.replace(' ', '_')}",
+                        "source_path": f"{path}/{filename}",
                     },
                 )
 
@@ -358,6 +358,7 @@ def get_edx_module_id(path: str, run: LearningResourceRun) -> str:
     Returns:
         str: The XBlock ID
     """
+    path = path.replace(" ", "_")
     folder = path.split("/")[-2]
 
     if folder == "static":


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes  https://github.com/mitodl/hq/issues/8381
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR resolves an issue where canvas files that have spaces in them are not properly mapped to urls for citations. The original implementation relied on the "source_path" property of the contentfile which in the substitutes spaces for underscores.

### How can this be tested?
1. on main, run ```python manage.py backpopulate_canvas_courses --canvas-ids 34631 --overwrite```
2. check to see what files have urls associated. 
```python
from learning_resources.models import *
ContentFile.objects.filter(run__learning_resource__readable_id__contains="15.060_FA25", url__isnull=False).values_list("run__learning_resource__readable_id", "key", "url")
```
3. you should only see one
4. now checkout this branch. make sure you restart the celery container
5. re-run ```python manage.py backpopulate_canvas_courses --canvas-ids 34631 --overwrite```
6. check which files have urls associated with them and you should a lot more.
```python
In [2]: ContentFile.objects.filter(run__learning_resource__readable_id__contains="15.060_FA25", url__isnull=False).values_list("run__learning_resource__readable_id", "key", "url")
Out[2]: <ContentFileQuerySet [('34631-15.060_FA25', 'block-v1:34631-15.060_FA25+canvas+type@Deliverable 5+block@Milagro_Case', 'https://canvas.mit.edu/courses/34631/files/5513003/'), ('34631-15.060_FA25', 'block-v1:34631-15.060_FA25+canvas+type@Lecture 1+block@15.060-Class_1-Lecture_Slides-Understanding_Data_charapod25', 'https://canvas.mit.edu/courses/34631/files/5573252/'), ('34631-15.060_FA25', 'block-v1:34631-15.060_FA25+canvas+type@web_resources+block@15.060_DMD_Fall_2025_Syllabus_V5', 'https://canvas.mit.edu/courses/34631/files/5577132/'), ('34631-15.060_FA25', 'block-v1:34631-15.060_FA25+canvas+type@web_resources+block@Python_Cheatsheet', 'https://canvas.mit.edu/courses/34631/files/5577964/'), ('34631-15.060_FA25', 'block-v1:34631-15.060_FA25+canvas+type@Deliverable 1+block@15.060_Deliverable_1', 'https://canvas.mit.edu/courses/34631/files/5577291/'), ('34631-15.060_FA25', 'block-v1:34631-15.060_FA25+canvas+type@Lecture 1+block@Optima_Airlines_Case', 'https://canvas.mit.edu/courses/34631/files/5512989/')]>
```

### Additional Context
The initial implementation hinged off of "source_path" which is intentionally left alone since other things depend on it. we instead add new fields to preserve the original path and filename which could also be used down the road
