### PR TITLE
adding fix for flaky test

### DIFF
--- a/learning_resources/tasks_test.py
+++ b/learning_resources/tasks_test.py
@@ -16,6 +16,7 @@ from learning_resources.constants import LearningResourceType, PlatformType
 from learning_resources.etl.constants import MARKETING_PAGE_FILE_TYPE, ETLSource
 from learning_resources.factories import (
     LearningResourceFactory,
+    LearningResourcePlatformFactory,
 )
 from learning_resources.models import LearningResource
 from learning_resources.tasks import (
@@ -686,8 +687,19 @@ def test_remove_duplicate_resources(mocker, mocked_celery):
     """
     duplicate_id = "duplicate_id"
 
-    LearningResourceFactory.create_batch(3, readable_id=duplicate_id, published=False)
-    LearningResourceFactory.create(readable_id=duplicate_id)
+    for platform_type in [PlatformType.edx, PlatformType.xpro, PlatformType.youtube]:
+        LearningResourceFactory.create(
+            readable_id=duplicate_id,
+            published=False,
+            platform=LearningResourcePlatformFactory.create(code=platform_type.name),
+        )
+
+    LearningResourceFactory.create(
+        readable_id=duplicate_id,
+        platform=LearningResourcePlatformFactory.create(
+            code=platform_type.mitxonline.name
+        ),
+    )
     assert LearningResource.objects.filter(readable_id=duplicate_id).count() == 4
     with pytest.raises(mocked_celery.replace_exception_class):
         remove_duplicate_resources()


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/8387
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR fixes a flaky test which fails when learning resources have the same platform and readable id which violates a db constraint

### How can this be tested?
1. checkout main
2. in the web container install pytest-repeat `pip install pytest-repeat`
3. run the flaky test enough times to see it fail ` pytest learning_resources/tasks_test.py::test_remove_duplicate_resources --count 100 -x`
4. checkout this branch
5. re-run the test and see it pass 100% of the time
