### PR TITLE
Make fields for LearningResource readonly so we can access admin pages that currently 502

### DIFF
--- a/learning_resources/admin.py
+++ b/learning_resources/admin.py
@@ -81,6 +81,10 @@ class LearningResourceRunAdmin(admin.ModelAdmin):
     )
     autocomplete_fields = ("instructors", "learning_resource")
 
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.for_serialization()
+
 
 class LearningResourceRunInline(TabularInline):
     """Inline list items for course/program runs"""
@@ -149,6 +153,7 @@ class LearningPathInline(TabularInline):
     model = models.LearningPath
     extra = 0
     show_change_link = True
+    readonly_fields = ("author",)
 
 
 class VideoInline(TabularInline):
@@ -216,6 +221,10 @@ class LearningResourceAdmin(admin.ModelAdmin):
     ]
     autocomplete_fields = ("topics",)
 
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.for_serialization()
+
 
 class UserListAdmin(admin.ModelAdmin):
     """UserList Admin"""
@@ -223,6 +232,7 @@ class UserListAdmin(admin.ModelAdmin):
     model = models.UserList
     search_fields = ("title", "author__username", "author__email")
     list_display = ("title", "author", "created_on", "updated_on")
+    readonly_fields = ("author",)
 
 
 class VideoChannelAdmin(admin.ModelAdmin):


### PR DESCRIPTION
### What are the relevant tickets?
github.com/mitodl/hq/issues/8247

### Description (What does it do?)
In production, attempting to access certain LearningResources results in an OOMKill of the pod executing the queries followed by a user facing 502. There's more context on our investigation in [this thread](https://mitodl.slack.com/archives/C03K5HYGPT9/p1756241789980579). 

This change makes the author field readonly, preventing rendering from querying all users on certain admin pages.

### How can this be tested?
The simplest way to see the changes are to compare between RC and your local environment given that the admin pages on production OOM. For example, if you look at the Author field on the User List admin pages, you can see that on RC we render a dropdown for all users, while with this PR it's a simple readonly field:
Local
<img width="1642" height="904" alt="Screenshot 2025-09-08 at 11 44 37 AM" src="https://github.com/user-attachments/assets/7d028190-d294-466a-b2ce-2a9eea289068" />

learn.rc.mit
<img width="1664" height="934" alt="Screenshot 2025-09-08 at 11 44 49 AM" src="https://github.com/user-attachments/assets/053fdd51-374b-4c26-a8a5-01d99487bcc6" />


### Additional Context
It is possible this doesn't end up fixing the issue - while we observed a query for users is where it died, it's only a proximate cause. To be absolutely sure, we'd need to see the actual distribution of memory usage, but that's much less straightforward to do.
