### PR TITLE
ingest canvas html content

### DIFF
--- a/learning_resources/etl/canvas.py
+++ b/learning_resources/etl/canvas.py
@@ -314,7 +314,6 @@ def is_file_published(file_meta: dict) -> bool:
         bool: True if file is published/visible, False otherwise.
     """
     now = now_in_utc()
-
     hidden = str(file_meta.get("hidden", "false")).lower() == "true"
     locked = str(file_meta.get("locked", "false")).lower() == "true"
     unlock_at = file_meta.get("unlock_at")
@@ -380,7 +379,10 @@ def parse_files_meta(course_archive_path: str) -> dict:
                 file_path = Path(file)
                 file_data["path"] = file_path
                 file_data["title"] = file_data.get("display_name")
-                if file_data["published"]:
+                # explicitly exclude files in web_resources/ai/tutor
+                if file_data["published"] and not file.startswith(
+                    settings.CANVAS_TUTORBOT_FOLDER
+                ):
                     publish_status["active"].append(file_data)
                 else:
                     publish_status["unpublished"].append(file_data)

--- a/learning_resources/etl/canvas.py
+++ b/learning_resources/etl/canvas.py
@@ -430,7 +430,7 @@ def parse_module_meta(course_archive_path: str) -> dict:
     return publish_status
 
 
-def _compact_element(element):
+def _compact_element(element: ElementTree.Element) -> dict | str | None:
     """Recursively compact an element into a nested dictionary"""
     if len(element) == 0:  # No children, return text
         return element.text.strip() if element.text else None
@@ -442,7 +442,7 @@ def _compact_element(element):
     }
 
 
-def _workflow_state_from_html(html):
+def _workflow_state_from_html(html: str) -> str:
     """
     Extract the workflow_state meta tag from html
     """
@@ -465,7 +465,7 @@ def _workflow_state_from_xml(xml):
         log.exception("Error parsing XML: %s", sys.stderr)
 
 
-def _title_from_html(html):
+def _title_from_html(html: str) -> str:
     """
     Extract the title element from HTML content
     """
@@ -642,6 +642,9 @@ def pdf_to_base64_images(pdf_path, fmt="JPEG", max_size=2000, quality=85):
 
 
 def _pdf_to_markdown(pdf_path):
+    """
+    Convert a PDF file to markdown using an llm
+    """
     markdown = ""
     for im in pdf_to_base64_images(pdf_path):
         response = completion(

--- a/learning_resources/etl/canvas.py
+++ b/learning_resources/etl/canvas.py
@@ -459,7 +459,10 @@ def parse_web_content(course_archive_path: str) -> dict:
     publish_status = {"active": [], "unpublished": []}
 
     with zipfile.ZipFile(course_archive_path, "r") as course_archive:
-        manifest_xml = course_archive.read("imsmanifest.xml")
+        manifest_path = "imsmanifest.xml"
+        if manifest_path not in course_archive.namelist():
+            return publish_status
+        manifest_xml = course_archive.read(manifest_path)
         resource_map = extract_resources_by_identifier(manifest_xml)
         for item in resource_map:
             item_link = resource_map[item].get("href")

--- a/learning_resources/etl/canvas.py
+++ b/learning_resources/etl/canvas.py
@@ -430,7 +430,7 @@ def parse_module_meta(course_archive_path: str) -> dict:
     return publish_status
 
 
-def _compact_element(element: ElementTree.Element) -> dict | str | None:
+def _compact_element(element) -> dict | str | None:
     """Recursively compact an element into a nested dictionary"""
     if len(element) == 0:  # No children, return text
         return element.text.strip() if element.text else None

--- a/learning_resources/etl/canvas_test.py
+++ b/learning_resources/etl/canvas_test.py
@@ -6,12 +6,15 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from defusedxml import ElementTree
 
 from learning_resources.constants import LearningResourceType, PlatformType
 from learning_resources.etl.canvas import (
+    _compact_element,
     is_file_published,
     parse_canvas_settings,
     parse_module_meta,
+    parse_web_content,
     run_for_canvas_archive,
     transform_canvas_content_files,
     transform_canvas_problem_files,
@@ -591,7 +594,7 @@ def test_is_file_published(file_meta, expected):
 
 def test_published_module_and_files_meta_content_ingestion(mocker, tmp_path):
     """
-    Test published files from files_meta and module_meta are retained,
+    Test published files from files_meta and module_meta are retained
     """
 
     module_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
@@ -692,3 +695,165 @@ def test_published_module_and_files_meta_content_ingestion(mocker, tmp_path):
     assert "/file1.html" in result_paths
     assert "/file3.html" in result_paths
     assert bulk_unpub.mock_calls[0].args[0] == [stale_contentfile.id]
+
+
+@pytest.mark.parametrize(
+    ("element", "expected"),
+    [
+        # Test case: Element with no children, only text
+        (
+            ElementTree.fromstring("""<tag>Sample Text</tag>"""),
+            "Sample Text",
+        ),
+        # Test case: Element with children, nested structure
+        (
+            ElementTree.fromstring(
+                """<parent>
+                <child1>Child 1 Text</child1>
+                <child2>
+                    <subchild>Subchild Text</subchild>
+                </child2>
+            </parent>
+        """
+            ),
+            {
+                "child1": "Child 1 Text",
+                "child2": {"subchild": "Subchild Text"},
+            },
+        ),
+        # Test case: Element with mixed text and children
+        (
+            ElementTree.fromstring(
+                """<mixed>Parent Text<child>Child Text</child></mixed>"""
+            ),
+            {
+                "child": "Child Text",
+            },
+        ),
+    ],
+)
+def test_compact_element(element, expected):
+    """
+    Test _compact_element function with nested tags.
+    """
+    result = _compact_element(element)
+    assert result == expected
+
+
+def test_parse_web_content_returns_active_and_unpublished(tmp_path):
+    """
+    Test that parse_web_content returns active and unpublished items
+    """
+    manifest_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <manifest xmlns="http://www.imsglobal.org/xsd/imsccv1p1/imscp_v1p1">
+      <resources>
+        <resource identifier="RES1" type="webcontent" href="file1.html">
+          <file href="file1.html"/>
+        </resource>
+        <resource identifier="RES2" type="webcontent" href="file2.html">
+          <file href="file2.html"/>
+        </resource>
+      </resources>
+    </manifest>
+    """
+    html_content_active = b"""<html>
+    <head><title>Active Content</title><meta name="workflow_state" content="active"></head>
+    <body>Content</body>
+    </html>
+    """
+    html_content_unpublished = b"""<html>
+    <head><title>Unpublished Content</title><meta name="workflow_state" content="unpublished"></head>
+    <body>Content</body>
+    </html>
+    """
+    zip_path = tmp_path / "canvas_course.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("imsmanifest.xml", manifest_xml)
+        zf.writestr("file1.html", html_content_active)
+        zf.writestr("file2.html", html_content_unpublished)
+
+    result = parse_web_content(zip_path)
+    assert "active" in result
+    assert "unpublished" in result
+
+    assert any(
+        item["title"] == "Active Content" and item["path"] == "file1.html"
+        for item in result["active"]
+    )
+    assert any(
+        item["title"] == "Unpublished Content" and item["path"] == "file2.html"
+        for item in result["unpublished"]
+    )
+
+
+def test_parse_web_content_handles_missing_workflow_state(tmp_path):
+    """
+    Test that parse_web_content handles missing workflow_state gracefully
+    """
+    manifest_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <manifest xmlns="http://www.imsglobal.org/xsd/imsccv1p1/imscp_v1p1">
+      <resources>
+        <resource identifier="RES1" type="webcontent" href="file1.html">
+          <file href="file1.html"/>
+        </resource>
+      </resources>
+    </manifest>
+    """
+    html_content = b"""<html>
+    <head><title>No Workflow State</title></head>
+    <body>Content</body>
+    </html>
+    """
+    zip_path = tmp_path / "canvas_course.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("imsmanifest.xml", manifest_xml)
+        zf.writestr("file1.html", html_content)
+
+    result = parse_web_content(zip_path)
+    assert "active" in result
+    assert "unpublished" in result
+    assert len(result["active"]) == 0
+    assert len(result["unpublished"]) == 1
+    assert result["unpublished"][0]["title"] == "No Workflow State"
+    assert result["unpublished"][0]["path"] == "file1.html"
+
+
+def test_parse_web_content_excludes_instructor_only_content(tmp_path):
+    """
+    Test that parse_web_content excludes content intended for Instructors only
+    """
+    manifest_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <manifest xmlns="http://www.imsglobal.org/xsd/imsccv1p1/imscp_v1p1">
+      <resources>
+        <resource identifier="RES1" type="webcontent" href="file1.html">
+          <file href="file1.html"/>
+          <metadata>
+            <lom>
+              <educational>
+                <intendedEndUserRole>
+                  <value>Instructor</value>
+                </intendedEndUserRole>
+              </educational>
+            </lom>
+          </metadata>
+        </resource>
+      </resources>
+    </manifest>
+    """
+    html_content = b"""<html>
+    <head><title>Instructor Only Content</title><meta name="workflow_state" content="active"></head>
+    <body>Content</body>
+    </html>
+    """
+    zip_path = tmp_path / "canvas_course.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("imsmanifest.xml", manifest_xml)
+        zf.writestr("file1.html", html_content)
+
+    result = parse_web_content(zip_path)
+    assert "active" in result
+    assert "unpublished" in result
+    assert len(result["active"]) == 0
+    assert len(result["unpublished"]) == 1
+    assert result["unpublished"][0]["title"] == "Instructor Only Content"
+    assert result["unpublished"][0]["path"] == "file1.html"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/8436
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR makes it so:
- we include published html/wiki content and assignment pages as part of ingesting a canvas course.
- explicitly filter out contents of the tutorbot folder even if it is somehow included in the files_meta.xml (out of abundance of caution)


### How can this be tested?
1. checkout main
2. restart celery
3. ingest a canvas course: `python manage.py backpopulate_canvas_courses --canvas-ids 34062 --overwrite`
4. view the list of files that were ingested: ` LearningResource.objects.filter(readable_id__istartswith="34062").first().runs.first().content_files.all().values_list("source_path", flat=True)`
5. note that it is empty for this particular course.
6. do the same for another with published files:
 `python manage.py backpopulate_canvas_courses --canvas-ids 34062 --overwrite`
```python
LearningResource.objects.filter(readable_id__istartswith="14566").first().runs.first().content_files.all().values_list("source_path", flat=True)
```
7. note the files and filetypes
8. checkout this branch
9. restart celery
10. re-run the backpopulate commmands for each
11. note that published html content exists for both courses

### Additional Context
- This PR also includes an extra check to filter out web_resources/ai/tutor just in case it were to inadvertently  end up in files manifest.
- The files that have assignment_settings.xml also have an extra check to see if it is only visible to instructors