### PR TITLE
Add CDN instruction to serve stale Next.js pages if origin error

### DIFF
--- a/frontends/main/next.config.js
+++ b/frontends/main/next.config.js
@@ -46,7 +46,8 @@ const nextConfig = {
         headers: [
           {
             key: "Cache-Control",
-            value: "s-maxage=1800",
+            value:
+              "s-maxage=1800, stale-if-error=86400, stale-while-revalidate=86400",
           },
         ],
       },
@@ -62,7 +63,8 @@ const nextConfig = {
         headers: [
           {
             key: "Cache-Control",
-            value: "s-maxage=1800",
+            value:
+              "s-maxage=1800, stale-if-error=86400, stale-while-revalidate=86400",
           },
         ],
       },


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A


### Description (What does it do?)
<!--- Describe your changes in detail -->

The CDN cache pages are currently marked stale after 30 mins. In the event that Next.js is unreachable for 30 minutes, the site is down showing the Fastly / Varnish edge error page.

Adds a `stale-if-error` directive to the Cache-Control header on Next.js page responses, set to 1 day. This instructs Fastly to continue serving stale content for 1 day when the origin fetch fails.

Adds a `stale-while-revalidate` directive, also set to 1 day. Instructs Fastly to continue serving stale content while the new version is fetched. This covers any back off period (origin shielding) while Fastly refetches. 


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Optionally a long running test on RC, or common sense assessment and a check that the CDN is properly populated and serving cache hits when systems are happy.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

It's important that we're monitoring the service directly and notifying accordingly. This gives us potentially 2 days grace, depending on how Fastly stacks the directives, but loses efficacy if we're only monitoring at edge.
