### PR TITLE
canvas: ingest files referenced in content

### DIFF
--- a/learning_resources/etl/canvas.py
+++ b/learning_resources/etl/canvas.py
@@ -42,6 +42,15 @@ from main.utils import now_in_utc
 
 log = logging.getLogger(__name__)
 
+# list of file regexes we should ignore
+IGNORE_FILES = [
+    r"course_settings/course_settings.xml",
+    r"course_settings/context.xml",
+    r"course_settings/files_meta.xml",
+    r"course_settings/module_meta.xml",
+    r"imsmanifest.xml",
+    r"*/assignment_settings.xml",
+]
 
 NAMESPACES = {
     "cccv1p0": "http://canvas.instructure.com/xsd/cccv1p0",

--- a/learning_resources/etl/canvas.py
+++ b/learning_resources/etl/canvas.py
@@ -5,12 +5,14 @@ import sys
 import zipfile
 from collections import defaultdict
 from collections.abc import Generator
-from datetime import datetime
+from datetime import UTC, datetime
 from io import BytesIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from urllib.parse import unquote_plus
+from urllib.parse import unquote, unquote_plus
+from zoneinfo import ZoneInfo
 
+import dateutil
 import pypdfium2 as pdfium
 from bs4 import BeautifulSoup
 from defusedxml import ElementTree
@@ -44,12 +46,12 @@ log = logging.getLogger(__name__)
 
 # list of file regexes we should ignore
 IGNORE_FILES = [
-    r"course_settings/course_settings.xml",
-    r"course_settings/context.xml",
-    r"course_settings/files_meta.xml",
-    r"course_settings/module_meta.xml",
-    r"imsmanifest.xml",
-    r"*/assignment_settings.xml",
+    "course_settings.xml",
+    "context.xml",
+    "files_meta.xml",
+    "module_meta.xml",
+    "imsmanifest.xml",
+    "assignment_settings.xml",
 ]
 
 NAMESPACES = {
@@ -198,20 +200,21 @@ def transform_canvas_content_files(
     basedir = course_zipfile.name.split(".")[0]
     zipfile_path = course_zipfile.absolute()
     # grab published module and file items
-    published_items = (
-        [
-            Path(item["path"]).resolve()
-            for item in parse_module_meta(zipfile_path)["active"]
-        ]
-        + [
-            Path(item["path"]).resolve()
-            for item in parse_files_meta(zipfile_path)["active"]
-        ]
-        + [
-            Path(item["path"]).resolve()
-            for item in parse_web_content(zipfile_path)["active"]
-        ]
-    )
+    published_items = [
+        Path(item["path"]).resolve()
+        for item in parse_module_meta(zipfile_path)["active"]
+    ] + [
+        Path(item["path"]).resolve()
+        for item in parse_files_meta(zipfile_path)["active"]
+    ]
+    for item in parse_web_content(zipfile_path)["active"]:
+        published_items.append(Path(item["path"]).resolve())
+        published_items.extend(
+            [
+                Path(embedded_file).resolve()
+                for embedded_file in item.get("embedded_files", [])
+            ]
+        )
 
     def _generate_content():
         """Inner generator for yielding content data"""
@@ -326,7 +329,12 @@ def is_date_locked(lock_at: str, unlock_at: str) -> bool:
     now = now_in_utc()
     if unlock_at and unlock_at.lower() != "nil":
         try:
-            unlock_dt = datetime.fromisoformat(unlock_at.replace("Z", "+00:00"))
+            unlock_dt = (
+                dateutil.parser.parse(unlock_at)
+                .replace(tzinfo=ZoneInfo("US/Eastern"))
+                .astimezone(UTC)
+            )
+
             if now < unlock_dt:
                 return True
         except Exception:
@@ -334,7 +342,11 @@ def is_date_locked(lock_at: str, unlock_at: str) -> bool:
 
     if lock_at and lock_at.lower() != "nil":
         try:
-            lock_dt = datetime.fromisoformat(lock_at.replace("Z", "+00:00"))
+            lock_dt = (
+                dateutil.parser.parse(lock_at)
+                .replace(tzinfo=ZoneInfo("US/Eastern"))
+                .astimezone(UTC)
+            )
             if now > lock_dt:
                 return True
         except Exception:
@@ -479,6 +491,28 @@ def _workflow_state_from_html(html: str) -> str:
     return meta.get("content") if meta else None
 
 
+def _embedded_files_from_html(html: str) -> list[str]:
+    """
+    Extract Canvas file links from HTML, replacing $IMS-CC-FILEBASE$ with web_resources
+    and returning URL-decoded paths without query params.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    links = []
+
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        if href.startswith("$IMS-CC-FILEBASE$"):
+            # Remove query parameters if present
+            clean_href = href.split("?")[0]
+            # Replace $IMS-CC-FILEBASE$ with "web_resources"
+            clean_href = clean_href.replace("$IMS-CC-FILEBASE$", "web_resources")
+            # URL decode
+            decoded = unquote(clean_href)
+            links.append(decoded)
+
+    return links
+
+
 def _workflow_state_from_xml(xml_string: str) -> bool:
     """
     Determine the workflow_state (published/unpublished) from assignment_settings.xml
@@ -550,6 +584,7 @@ def parse_web_content(course_archive_path: str) -> dict:
             if item_link and item_link.endswith(".html"):
                 file_path = resource_map_item["href"]
                 html_content = course_archive.read(file_path)
+                embedded_files = _embedded_files_from_html(html_content)
                 if assignment_settings:
                     xml_content = course_archive.read(assignment_settings)
                     workflow_state = _workflow_state_from_xml(xml_content)
@@ -571,6 +606,7 @@ def parse_web_content(course_archive_path: str) -> dict:
                         {
                             "title": title,
                             "path": file_path,
+                            "embedded_files": embedded_files,
                         }
                     )
                 else:
@@ -578,6 +614,7 @@ def parse_web_content(course_archive_path: str) -> dict:
                         {
                             "title": title,
                             "path": file_path,
+                            "embedded_files": embedded_files,
                         }
                     )
     return publish_status

--- a/learning_resources/etl/canvas_test.py
+++ b/learning_resources/etl/canvas_test.py
@@ -906,3 +906,78 @@ def test_parse_files_meta_excludes_tutorbot_folder(tmp_path, settings):
     assert result["active"][0]["path"].name == "file2.html"
     assert len(result["unpublished"]) == 1
     assert result["unpublished"][0]["path"].name == "tutorfile.html"
+
+
+def test_embedded_files_from_html(tmp_path, mocker):
+    """
+    Test that _embedded_files_from_html processes files embedded in HTML content
+    even if they are not in modules_meta.xml or files_meta.xml.
+    """
+    html_content = """
+    <html>
+    <head><meta name="workflow_state" content="active"/></head>
+        <body>
+            <a href="$IMS-CC-FILEBASE$/file1.pdf">Embedded File 1</a>
+        </body>
+    </html>
+    """
+    module_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <modules xmlns="http://canvas.instructure.com/xsd/cccv1p0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    >
+      <module>
+
+        <title>Module 1</title>
+        <items>
+          <item identifier="RES3">
+            <workflow_state>active</workflow_state>
+            <title>Item 1</title>
+            <hidden>false</hidden>
+             <locked>false</locked>
+            <identifierref>RES3</identifierref>
+            <content_type>resource</content_type>
+          </item>
+        </items>
+      </module>
+    </modules>
+    """
+    manifest_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <manifest xmlns="http://www.imsglobal.org/xsd/imsccv1p1/imscp_v1p1">
+      <resources>
+        <resource identifier="RES1" type="webcontent"  href="web_resources/file1.pdf">
+          <file href="web_resources/file1.pdf"/>
+        </resource>
+        <resource identifier="RES2" type="webcontent" href="web_resources/file2.html">
+          <file href="web_resources/file2.html"/>
+        </resource>
+        <resource identifier="RES3" type="webcontent" href="web_resources/html_page.html">
+          <file href="web_resources/html_page.html"/>
+        </resource>
+      </resources>
+    </manifest>
+    """
+    zip_path = make_canvas_zip_with_module_meta(tmp_path, module_xml, manifest_xml)
+    with zipfile.ZipFile(zip_path, "a") as zf:
+        zf.writestr("web_resources/file1.pdf", "content of file1")
+        zf.writestr("web_resources/file2.html", "content of file2")
+        zf.writestr("web_resources/html_page.html", html_content)
+
+    result = parse_web_content(zip_path)
+
+    assert "web_resources/file1.pdf" in result["active"][0]["embedded_files"]
+
+    mocker.patch(
+        "learning_resources.etl.utils.extract_text_metadata",
+        return_value={"content": "test"},
+    )
+    mocker.patch("learning_resources.etl.canvas.bulk_resources_unpublished_actions")
+
+    # Create a fake zipfile with the published file
+    run = LearningResourceRunFactory.create()
+    files = list(
+        transform_canvas_content_files(
+            Path(zip_path), run, url_config={}, overwrite=True
+        )
+    )
+
+    assert any(file["source_path"] == "web_resources/html_page.html" for file in files)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/8489
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This Pr resolves an issue where we have certain files that appear "unpublished" based on what we see in the archive configuration but are actually visible and accessible to users since they are included on certain html pages


### How can this be tested?
1. checkout main
2. process a canvas course via `python manage.py backpopulate_canvas_courses --canvas-ids 34716`
3. Once that completes, look up a file in that course that we know is "unpublished" in files browser but it is included on an html page - `ContentFile.objects.filter(source_path__icontains="HW1.pdf"` should come up empty
4. checkout this branch
5. restart celery
6. repeat the above and see there is now a file when running `ContentFile.objects.filter(source_path__icontains="HW1.pdf")`
