### PR TITLE
remove priority ordering from org dashboard programs

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.test.tsx
@@ -113,8 +113,8 @@ describe("OrganizationContent", () => {
     const { orgX, programA, programB, programCollection, coursesA, coursesB } =
       setupProgramsAndCourses()
 
-    // Set up the collection to include both programs
-    programCollection.programs = [programA.id, programB.id]
+    // Set up the collection to include both programs in a specific order
+    programCollection.programs = [programB.id, programA.id] // Note: B first, then A
     setMockResponse.get(urls.programCollections.programCollectionsList(), {
       results: [programCollection],
     })
@@ -157,17 +157,16 @@ describe("OrganizationContent", () => {
     const collection = within(collectionItems[0])
     expect(collection.getByText(programCollection.title)).toBeInTheDocument()
 
-    // Wait for the course data to load and check that courses are displayed
+    // Wait for program cards to be rendered
     await waitFor(() => {
-      expect(collection.getAllByText(coursesA[0].title).length).toBeGreaterThan(
-        0,
-      )
+      const programCards = collection.getAllByTestId("enrollment-card-desktop")
+      expect(programCards.length).toBe(2)
     })
-    await waitFor(() => {
-      expect(collection.getAllByText(coursesB[0].title).length).toBeGreaterThan(
-        0,
-      )
-    })
+
+    // Verify the order matches the programCollection.programs array [programB.id, programA.id]
+    const programCards = collection.getAllByTestId("enrollment-card-desktop")
+    expect(programCards[0]).toHaveTextContent(coursesB[0].title)
+    expect(programCards[1]).toHaveTextContent(coursesA[0].title)
   })
 
   test("Does not render a program separately if it is part of a collection", async () => {

--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
@@ -291,19 +291,17 @@ const OrgProgramDisplay: React.FC<{
         )}
       </ProgramHeader>
       <PlainList>
-        {transform
-          .sortDashboardCourses(program, transformedCourses)
-          .map((course) => (
-            <DashboardCardStyled
-              Component="li"
-              key={course.key}
-              dashboardResource={course}
-              courseNoun="Module"
-              offerUpgrade={false}
-              titleHref={course.run?.coursewareUrl}
-              buttonHref={course.run?.coursewareUrl}
-            />
-          ))}
+        {transformedCourses.map((course) => (
+          <DashboardCardStyled
+            Component="li"
+            key={course.key}
+            dashboardResource={course}
+            courseNoun="Module"
+            offerUpgrade={false}
+            titleHref={course.run?.coursewareUrl}
+            buttonHref={course.run?.coursewareUrl}
+          />
+        ))}
       </PlainList>
     </ProgramRoot>
   )


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/8526

### Description (What does it do?)
This PR removes the usage of `sortDashboardCourses` from programs displayed in `OrganizationContent.tsx`. Programs have a pre-defined order when they are returned from the API, and this function is designed to push what a learner is currently working on to the top of the list when viewing the "My Learning" section of the dashboard home page.

### How can this be tested?
In order to test this, you need a basic installation of `mitxonline` up and running with example data in it. You may be able to skip one or more steps if you have already done them:
- Ensure you have local `hosts` redirects for the following domains, replacing the example IP with your __local__ IP address (Google how to get this if unsure, mine is 192.168.1.50)
```
192.168.1.50 open.odl.local
192.168.1.50 api.open.odl.local
192.168.1.50 kc.ol.local
192.168.1.50 mitxonline.odl.local
```
- Clone `mitxonline`: https://github.com/mitodl/mitxonline
- Create a `.env` file with the following values:
```
CELERY_TASK_ALWAYS_EAGER=True
DJANGO_LOG_LEVEL=INFO
LOG_LEVEL=INFO
SENTRY_LOG_LEVEL=ERROR
MAILGUN_KEY=fake
MAILGUN_URL=
MAILGUN_RECIPIENT_OVERRIDE=
MAILGUN_SENDER_DOMAIN=.odl.local
SECRET_KEY=
STATUS_TOKEN=
UWSGI_THREADS=5
SENTRY_DSN=
MITX_ONLINE_BASE_URL=http://open.odl.local:8065/mitxonline
MITX_ONLINE_ADMIN_CLIENT_ID=refine-local-client-id
MITX_ONLINE_ADMIN_BASE_URL=http://mitxonline.odl.local:8016
POSTHOG_PROJECT_API_KEY=
POSTHOG_API_HOST=https://app.posthog.com/
HUBSPOT_HOME_PAGE_FORM_GUID=
HUBSPOT_PORTAL_ID=
APISIX_PORT=9080

# APISIX/Keycloak settings
APISIX_LOGOUT_URL=http://api.open.odl.local:8065/logout/
APISIX_SESSION_SECRET_KEY=supertopsecret1234
KC_SPI_THEME_WELCOME_THEME=scim
KC_SPI_REALM_RESTAPI_EXTENSION_SCIM_LICENSE_KEY=
KEYCLOAK_BASE_URL=http://kc.ol.local:8066
KEYCLOAK_CLIENT_ID=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
KEYCLOAK_CLIENT_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
KEYCLOAK_DISCOVERY_URL=http://kc.ol.local:8066/realms/ol-local/.well-known/openid-configuration
KEYCLOAK_REALM_NAME=ol-local
KEYCLOAK_SCOPES="openid profile ol-profile"
KEYCLOAK_SVC_KEYSTORE_PASSWORD=supertopsecret1234
KEYCLOAK_SVC_HOSTNAME=kc.ol.local
KEYCLOAK_SVC_ADMIN=admin
KEYCLOAK_SVC_ADMIN_PASSWORD=admin
AUTHORIZATION_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/auth
ACCESS_TOKEN_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/token
OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_KEY=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
SOCIAL_AUTH_OL_OIDC_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
USERINFO_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/userinfo
MITOL_APIGATEWAY_DISABLE_MIDDLEWARE=False

FEATURE_IGNORE_EDX_FAILURES=True
OPENEDX_API_CLIENT_ID=fake
OPENEDX_API_CLIENT_SECRET=fake
OPENEDX_SERVICE_WORKER_API_TOKEN=fake

CSRF_COOKIE_DOMAIN=.odl.local
CORS_ALLOWED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
CSRF_TRUSTED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
```
- Spin up `mitxonline` with `docker compose up --build -d`
- Promote the admin user with `docker compose exec web ./manage.py promote_user promote --superuser --email admin@odl.local`
- Populate test course data with `docker compose exec web ./manage.py populate_course_data`
- Generate docs with `pants docs ::`
- In `dist/sphinx/index.html`, read the section on generating a B2B organization / contract and create two, adding some of the test courses to both, and some to only org a / only org b
- In Django admin, create a `Program` and add some courses to the program that are included in your B2B org, making sure to mark the program as "live"
- Create a few more programs with different courses in them that are not part of your B2B org
- Navigate to Wagtail at http://mitxonline.odl.local:8065/cms
- Browse to Home Page -> Program Collections
- Create a new program collection
- Add both programs to your collection, the one that's part of your org and the one that isn't
- Make sure you have a personal Posthog project configured and have the API key at the ready
- Before we spin up `mit-learn`, we need to set some env variables:
```
.env
...
MITX_ONLINE_UPSTREAM=mitxonline.odl.local:8013
MITX_ONLINE_DOMAIN=mitxonline.odl.local
MITX_ONLINE_BASE_URL=http://mitxonline.odl.local:8065
POSTHOG_ENABLED=True
CSRF_COOKIE_DOMAIN=.odl.local

shared.local.env
POSTHOG_PROJECT_API_KEY=YOUR_API_KEY_HERE
POSTHOG_PROJECT_ID=YOUR_PROJECT_ID_HERE
POSTHOG_TIMEOUT_MS=1500
```
- In your Posthog project, enable the `enrollment-dashboard` and `mitlearn-organization-dashboard` feature flags for all users
- Spin up `MIT Learn`
- Go to the org dashboard for the org you created
- Enroll in the course at the bottom of the list
- After you are navigated to the courseware url, press the back button to navigate back to the org dashboard
- Verify that the ordering of the program is maintained