### PR TITLE
fix course run certificate link in org dashboard

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -11,7 +11,7 @@ import {
   theme,
 } from "ol-components"
 import { useQuery } from "@tanstack/react-query"
-import { mitxonlineEnrollmentsToDashboardCourses } from "./transform"
+import { userEnrollmentsToDashboardCourses } from "./transform"
 import { DashboardCard } from "./DashboardCard"
 import { DashboardCourse, EnrollmentStatus } from "./types"
 import { MaybeHasStatusAndDetail } from "@/app/getQueryClient"
@@ -176,7 +176,7 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
 const EnrollmentDisplay = () => {
   const { data: enrolledCourses, isLoading } = useQuery({
     ...enrollmentQueries.courseRunEnrollmentsList(),
-    select: mitxonlineEnrollmentsToDashboardCourses,
+    select: userEnrollmentsToDashboardCourses,
     throwOnError: (error) => {
       const err = error as MaybeHasStatusAndDetail
       const status = err?.response?.status

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/transform.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/transform.test.tsx
@@ -16,7 +16,306 @@ import {
 } from "./test-utils"
 import { faker } from "@faker-js/faker/locale/en"
 
-describe("Certificate handling", () => {
+describe("Transforming mitxonline enrollment data to DashboardResource", () => {
+  test.each([
+    {
+      grades: [mitx.enrollment.grade({ passed: true })],
+      enrollmentStatus: EnrollmentStatus.Completed,
+    },
+    {
+      grades: [mitx.enrollment.grade({ passed: false })],
+      enrollmentStatus: EnrollmentStatus.Enrolled,
+    },
+    { grades: [], enrollmentStatus: EnrollmentStatus.Enrolled },
+  ])(
+    "Property renames and EnrollmentStatus",
+    ({ grades, enrollmentStatus }) => {
+      const apiData = mitx.enrollment.courseEnrollment({
+        grades,
+      })
+      const transformed = userEnrollmentsToDashboardCourses([apiData])
+      expect(transformed).toHaveLength(1)
+      expect(transformed[0]).toEqual({
+        key: `mitxonline-course-${apiData.run.course.id}-${apiData.run.id}`,
+        coursewareId: apiData.run.courseware_id ?? null,
+        type: DashboardResourceType.Course,
+        title: apiData.run.title,
+        marketingUrl: apiData.run.course.page?.page_url,
+        run: {
+          startDate: apiData.run.start_date,
+          endDate: apiData.run.end_date,
+          coursewareUrl: apiData.run.courseware_url,
+          certificateUpgradeDeadline: apiData.run.upgrade_deadline,
+          certificateUpgradePrice: apiData.run.products[0]?.price,
+          canUpgrade: expect.any(Boolean), // check this in a moment
+          certificate: {
+            uuid: apiData.certificate?.uuid ?? "",
+            link: apiData.certificate?.link ?? "",
+          },
+        },
+        enrollment: {
+          id: apiData.id,
+          status: enrollmentStatus,
+          mode: apiData.enrollment_mode,
+          receiveEmails: apiData.edx_emails_subscription,
+        },
+      } satisfies DashboardResource)
+    },
+  )
+
+  test("CertificateUpgradePrice is first price in prices array", () => {
+    // Unclear why the mitxonline API has this as an array.
+    const apiData = mitx.enrollment.courseEnrollment({
+      // @ts-expect-error not fully implementing product objects
+      run: { products: [{ price: "10" }, { price: "20" }] },
+    })
+    const transformed = userEnrollmentsToDashboardCourses([apiData])
+    expect(transformed).toHaveLength(1)
+    expect(transformed[0].run.certificateUpgradePrice).toEqual("10")
+  })
+
+  test("sortDashboardCourses sorts courses by enrollment status and program order", () => {
+    const { programA, coursesA } = setupProgramsAndCourses()
+
+    const enrollments = [
+      mitx.enrollment.courseEnrollment({
+        run: {
+          id: coursesA[0].courseruns[0].id,
+          course: { id: coursesA[0].id },
+        },
+        grades: [mitx.enrollment.grade({ passed: true })],
+        enrollment_mode: "audit",
+      }),
+      mitx.enrollment.courseEnrollment({
+        run: {
+          id: coursesA[1].courseruns[0].id,
+          course: { id: coursesA[1].id },
+        },
+        grades: [],
+        enrollment_mode: "verified",
+      }),
+    ]
+
+    const transformedCourses = organizationCoursesWithContracts({
+      courses: coursesA,
+      enrollments,
+    })
+    const sortedCourses = sortDashboardCourses(
+      mitxonlineProgram(programA),
+      transformedCourses,
+    )
+
+    const enrolledCourse = sortedCourses.find(
+      (course) => course.enrollment?.status === EnrollmentStatus.Enrolled,
+    )
+    const completedCourse = sortedCourses.find(
+      (course) => course.enrollment?.status === EnrollmentStatus.Completed,
+    )
+    const notEnrolledCourses = sortedCourses.filter(
+      (course) =>
+        !course.enrollment ||
+        course.enrollment.status === EnrollmentStatus.NotEnrolled,
+    )
+
+    // Verify we found all expected courses
+    expect(enrolledCourse).toBeDefined()
+    expect(completedCourse).toBeDefined()
+    expect(notEnrolledCourses).toHaveLength(2)
+
+    // Verify sorting: enrolled first, then completed, then not enrolled
+    expect(sortedCourses[0]).toEqual(enrolledCourse) // Enrolled course should be first
+    expect(sortedCourses[1]).toEqual(completedCourse) // Completed course should be second
+    expect(sortedCourses[2]).toEqual(notEnrolledCourses[0]) // First not enrolled course
+    expect(sortedCourses[3]).toEqual(notEnrolledCourses[1]) // Second not enrolled course
+  })
+
+  test("selects course runs associated with organization's contract", () => {
+    const orgId = faker.number.int()
+    const contracts = createTestContracts(orgId, 2)
+    const contractIds = contracts.map((c) => c.id)
+    const courses = createCoursesWithContractRuns(contracts)
+
+    const transformedCourses = organizationCoursesWithContracts({
+      courses,
+      contracts,
+      enrollments: [],
+    })
+
+    // Should have transformed all courses
+    expect(transformedCourses).toHaveLength(3)
+
+    transformedCourses.forEach((transformedCourse, index) => {
+      const originalCourse = courses[index]
+
+      // Should use the course run with matching contract
+      const expectedRun = originalCourse.courseruns.find(
+        (run) => run.b2b_contract && contractIds.includes(run.b2b_contract),
+      )
+
+      expect(transformedCourse.run.startDate).toBe(expectedRun?.start_date)
+      expect(transformedCourse.run.endDate).toBe(expectedRun?.end_date)
+      expect(transformedCourse.coursewareId).toBe(
+        expectedRun?.courseware_id ?? null,
+      )
+    })
+  })
+
+  test("falls back to unenrolled course when no contract-matching runs exist", () => {
+    const orgId = faker.number.int()
+    const contracts = createTestContracts(orgId, 1)
+
+    // Create courses where runs don't match the contract
+    const courses = factories.courses
+      .courses({ count: 2 })
+      .results.map((course) => ({
+        ...course,
+        courseruns: course.courseruns.map((run) => ({
+          ...run,
+          b2b_contract: faker.number.int(), // Different contract ID
+        })),
+      }))
+
+    const transformedCourses = organizationCoursesWithContracts({
+      courses,
+      contracts,
+      enrollments: [],
+    })
+
+    transformedCourses.forEach((transformedCourse) => {
+      // Should not have enrollment since no matching contract runs
+      expect(transformedCourse.enrollment).toBeUndefined()
+
+      // Should still have course data but with contract-scoped run or null
+      expect(transformedCourse.title).toBeDefined()
+      expect(transformedCourse.type).toBe("course")
+    })
+  })
+
+  test("includes enrollments only for contract-scoped runs", () => {
+    const orgId = faker.number.int()
+    const contracts = createTestContracts(orgId, 1)
+    const contractIds = contracts.map((c) => c.id)
+    const courses = createCoursesWithContractRuns(contracts)
+    const enrollments = createEnrollmentsForContractRuns(courses, contractIds)
+
+    const transformedCourses = organizationCoursesWithContracts({
+      courses,
+      contracts,
+      enrollments,
+    })
+
+    // Should have enrollments for courses with contract-matching runs
+    const enrolledCourses = transformedCourses.filter(
+      (course) => course.enrollment,
+    )
+    expect(enrolledCourses.length).toBeGreaterThan(0)
+
+    enrolledCourses.forEach((course) => {
+      expect(course.enrollment).toBeDefined()
+      expect(course.enrollment?.status).toMatch(/enrolled|completed/)
+    })
+  })
+
+  test("filters out enrollments for non-contract runs", () => {
+    const orgId = faker.number.int()
+    const contracts = createTestContracts(orgId, 1)
+    const contractIds = contracts.map((c) => c.id)
+    const courses = createCoursesWithContractRuns(contracts)
+
+    // Create enrollments for both contract and non-contract runs
+    const contractEnrollments = createEnrollmentsForContractRuns(
+      courses,
+      contractIds,
+    )
+    const nonContractEnrollments = courses.flatMap((course) =>
+      course.courseruns
+        .filter(
+          (run) => !run.b2b_contract || !contractIds.includes(run.b2b_contract),
+        )
+        .map((run) =>
+          factories.enrollment.courseEnrollment({
+            run: {
+              id: run.id,
+              course: { id: course.id, title: course.title },
+              title: run.title,
+            },
+          }),
+        ),
+    )
+
+    const allEnrollments = [...contractEnrollments, ...nonContractEnrollments]
+
+    const transformedCourses = organizationCoursesWithContracts({
+      courses,
+      contracts,
+      enrollments: allEnrollments,
+    })
+
+    // Should only include enrollments for contract runs
+    const enrolledCourses = transformedCourses.filter(
+      (course) => course.enrollment,
+    )
+
+    enrolledCourses.forEach((course) => {
+      // Verify the enrollment corresponds to a contract run
+      const originalCourse = courses.find(
+        (c) => c.id.toString() === course.key.split("-")[2],
+      )
+      const contractRun = originalCourse?.courseruns.find(
+        (run) => run.b2b_contract && contractIds.includes(run.b2b_contract),
+      )
+      expect(contractRun).toBeDefined()
+    })
+  })
+
+  test("selects run associated with contract for unenrolled courses", () => {
+    const orgId = faker.number.int()
+    const contracts = createTestContracts(orgId, 1)
+    const contractIds = contracts.map((c) => c.id)
+    const courses = createCoursesWithContractRuns(contracts)
+
+    courses.forEach((course) => {
+      const transformedCourse = createOrgUnenrolledCourse(course, contracts)
+
+      // Should select the run with matching contract
+      const expectedRun = course.courseruns.find(
+        (run) => run.b2b_contract && contractIds.includes(run.b2b_contract),
+      )
+
+      expect(transformedCourse.run.startDate).toBe(expectedRun?.start_date)
+      expect(transformedCourse.coursewareId).toBe(
+        expectedRun?.courseware_id ?? null,
+      )
+    })
+  })
+
+  test("handles courses with no contract-matching runs gracefully", () => {
+    const orgId = faker.number.int()
+    const contracts = createTestContracts(orgId, 1)
+
+    const course = factories.courses.course({
+      courseruns: [
+        {
+          ...factories.courses.course().courseruns[0],
+          b2b_contract: faker.number.int(), // Different contract
+        },
+      ],
+    })
+
+    const transformedCourse = createOrgUnenrolledCourse(course, contracts)
+
+    // Should still return a valid course object
+    expect(transformedCourse.title).toBe(course.title)
+    expect(transformedCourse.type).toBe("course")
+
+    // Run data should be null/empty since no matching contract run found
+    expect(transformedCourse.run.startDate).toBeUndefined()
+    expect(transformedCourse.run.endDate).toBeUndefined()
+    expect(transformedCourse.run.coursewareUrl).toBeUndefined()
+    expect(transformedCourse.coursewareId).toBeNull()
+    expect(transformedCourse.run.canUpgrade).toBe(false) // !!undefined is false
+  })
+
   describe("userEnrollmentsToDashboardCourses", () => {
     test("includes certificate with transformed link", () => {
       const enrollmentWithCert = mitx.enrollment.courseEnrollment({
@@ -218,308 +517,6 @@ describe("Certificate handling", () => {
         uuid: "",
         link: "",
       })
-    })
-  })
-
-  describe("Transforming mitxonline enrollment data to DashboardResource - Original Tests", () => {
-    test.each([
-      {
-        grades: [mitx.enrollment.grade({ passed: true })],
-        enrollmentStatus: EnrollmentStatus.Completed,
-      },
-      {
-        grades: [mitx.enrollment.grade({ passed: false })],
-        enrollmentStatus: EnrollmentStatus.Enrolled,
-      },
-      { grades: [], enrollmentStatus: EnrollmentStatus.Enrolled },
-    ])(
-      "Property renames and EnrollmentStatus",
-      ({ grades, enrollmentStatus }) => {
-        const apiData = mitx.enrollment.courseEnrollment({
-          grades,
-        })
-        const transformed = userEnrollmentsToDashboardCourses([apiData])
-        expect(transformed).toHaveLength(1)
-        expect(transformed[0]).toEqual({
-          key: `mitxonline-course-${apiData.run.course.id}-${apiData.run.id}`,
-          coursewareId: apiData.run.courseware_id ?? null,
-          type: DashboardResourceType.Course,
-          title: apiData.run.title,
-          marketingUrl: apiData.run.course.page?.page_url,
-          run: {
-            startDate: apiData.run.start_date,
-            endDate: apiData.run.end_date,
-            coursewareUrl: apiData.run.courseware_url,
-            certificateUpgradeDeadline: apiData.run.upgrade_deadline,
-            certificateUpgradePrice: apiData.run.products[0]?.price,
-            canUpgrade: expect.any(Boolean), // check this in a moment
-            certificate: {
-              uuid: apiData.certificate?.uuid ?? "",
-              link: apiData.certificate?.link ?? "",
-            },
-          },
-          enrollment: {
-            id: apiData.id,
-            status: enrollmentStatus,
-            mode: apiData.enrollment_mode,
-            receiveEmails: apiData.edx_emails_subscription,
-          },
-        } satisfies DashboardResource)
-      },
-    )
-
-    test("CertificateUpgradePrice is first price in prices array", () => {
-      // Unclear why the mitxonline API has this as an array.
-      const apiData = mitx.enrollment.courseEnrollment({
-        // @ts-expect-error not fully implementing product objects
-        run: { products: [{ price: "10" }, { price: "20" }] },
-      })
-      const transformed = userEnrollmentsToDashboardCourses([apiData])
-      expect(transformed).toHaveLength(1)
-      expect(transformed[0].run.certificateUpgradePrice).toEqual("10")
-    })
-
-    test("sortDashboardCourses sorts courses by enrollment status and program order", () => {
-      const { programA, coursesA } = setupProgramsAndCourses()
-
-      const enrollments = [
-        mitx.enrollment.courseEnrollment({
-          run: {
-            id: coursesA[0].courseruns[0].id,
-            course: { id: coursesA[0].id },
-          },
-          grades: [mitx.enrollment.grade({ passed: true })],
-          enrollment_mode: "audit",
-        }),
-        mitx.enrollment.courseEnrollment({
-          run: {
-            id: coursesA[1].courseruns[0].id,
-            course: { id: coursesA[1].id },
-          },
-          grades: [],
-          enrollment_mode: "verified",
-        }),
-      ]
-
-      const transformedCourses = organizationCoursesWithContracts({
-        courses: coursesA,
-        enrollments,
-      })
-      const sortedCourses = sortDashboardCourses(
-        mitxonlineProgram(programA),
-        transformedCourses,
-      )
-
-      const enrolledCourse = sortedCourses.find(
-        (course) => course.enrollment?.status === EnrollmentStatus.Enrolled,
-      )
-      const completedCourse = sortedCourses.find(
-        (course) => course.enrollment?.status === EnrollmentStatus.Completed,
-      )
-      const notEnrolledCourses = sortedCourses.filter(
-        (course) =>
-          !course.enrollment ||
-          course.enrollment.status === EnrollmentStatus.NotEnrolled,
-      )
-
-      // Verify we found all expected courses
-      expect(enrolledCourse).toBeDefined()
-      expect(completedCourse).toBeDefined()
-      expect(notEnrolledCourses).toHaveLength(2)
-
-      // Verify sorting: enrolled first, then completed, then not enrolled
-      expect(sortedCourses[0]).toEqual(enrolledCourse) // Enrolled course should be first
-      expect(sortedCourses[1]).toEqual(completedCourse) // Completed course should be second
-      expect(sortedCourses[2]).toEqual(notEnrolledCourses[0]) // First not enrolled course
-      expect(sortedCourses[3]).toEqual(notEnrolledCourses[1]) // Second not enrolled course
-    })
-
-    test("selects course runs associated with organization's contract", () => {
-      const orgId = faker.number.int()
-      const contracts = createTestContracts(orgId, 2)
-      const contractIds = contracts.map((c) => c.id)
-      const courses = createCoursesWithContractRuns(contracts)
-
-      const transformedCourses = organizationCoursesWithContracts({
-        courses,
-        contracts,
-        enrollments: [],
-      })
-
-      // Should have transformed all courses
-      expect(transformedCourses).toHaveLength(3)
-
-      transformedCourses.forEach((transformedCourse, index) => {
-        const originalCourse = courses[index]
-
-        // Should use the course run with matching contract
-        const expectedRun = originalCourse.courseruns.find(
-          (run) => run.b2b_contract && contractIds.includes(run.b2b_contract),
-        )
-
-        expect(transformedCourse.run.startDate).toBe(expectedRun?.start_date)
-        expect(transformedCourse.run.endDate).toBe(expectedRun?.end_date)
-        expect(transformedCourse.coursewareId).toBe(
-          expectedRun?.courseware_id ?? null,
-        )
-      })
-    })
-
-    test("falls back to unenrolled course when no contract-matching runs exist", () => {
-      const orgId = faker.number.int()
-      const contracts = createTestContracts(orgId, 1)
-
-      // Create courses where runs don't match the contract
-      const courses = factories.courses
-        .courses({ count: 2 })
-        .results.map((course) => ({
-          ...course,
-          courseruns: course.courseruns.map((run) => ({
-            ...run,
-            b2b_contract: faker.number.int(), // Different contract ID
-          })),
-        }))
-
-      const transformedCourses = organizationCoursesWithContracts({
-        courses,
-        contracts,
-        enrollments: [],
-      })
-
-      transformedCourses.forEach((transformedCourse) => {
-        // Should not have enrollment since no matching contract runs
-        expect(transformedCourse.enrollment).toBeUndefined()
-
-        // Should still have course data but with contract-scoped run or null
-        expect(transformedCourse.title).toBeDefined()
-        expect(transformedCourse.type).toBe("course")
-      })
-    })
-
-    test("includes enrollments only for contract-scoped runs", () => {
-      const orgId = faker.number.int()
-      const contracts = createTestContracts(orgId, 1)
-      const contractIds = contracts.map((c) => c.id)
-      const courses = createCoursesWithContractRuns(contracts)
-      const enrollments = createEnrollmentsForContractRuns(courses, contractIds)
-
-      const transformedCourses = organizationCoursesWithContracts({
-        courses,
-        contracts,
-        enrollments,
-      })
-
-      // Should have enrollments for courses with contract-matching runs
-      const enrolledCourses = transformedCourses.filter(
-        (course) => course.enrollment,
-      )
-      expect(enrolledCourses.length).toBeGreaterThan(0)
-
-      enrolledCourses.forEach((course) => {
-        expect(course.enrollment).toBeDefined()
-        expect(course.enrollment?.status).toMatch(/enrolled|completed/)
-      })
-    })
-
-    test("filters out enrollments for non-contract runs", () => {
-      const orgId = faker.number.int()
-      const contracts = createTestContracts(orgId, 1)
-      const contractIds = contracts.map((c) => c.id)
-      const courses = createCoursesWithContractRuns(contracts)
-
-      // Create enrollments for both contract and non-contract runs
-      const contractEnrollments = createEnrollmentsForContractRuns(
-        courses,
-        contractIds,
-      )
-      const nonContractEnrollments = courses.flatMap((course) =>
-        course.courseruns
-          .filter(
-            (run) =>
-              !run.b2b_contract || !contractIds.includes(run.b2b_contract),
-          )
-          .map((run) =>
-            factories.enrollment.courseEnrollment({
-              run: {
-                id: run.id,
-                course: { id: course.id, title: course.title },
-                title: run.title,
-              },
-            }),
-          ),
-      )
-
-      const allEnrollments = [...contractEnrollments, ...nonContractEnrollments]
-
-      const transformedCourses = organizationCoursesWithContracts({
-        courses,
-        contracts,
-        enrollments: allEnrollments,
-      })
-
-      // Should only include enrollments for contract runs
-      const enrolledCourses = transformedCourses.filter(
-        (course) => course.enrollment,
-      )
-
-      enrolledCourses.forEach((course) => {
-        // Verify the enrollment corresponds to a contract run
-        const originalCourse = courses.find(
-          (c) => c.id.toString() === course.key.split("-")[2],
-        )
-        const contractRun = originalCourse?.courseruns.find(
-          (run) => run.b2b_contract && contractIds.includes(run.b2b_contract),
-        )
-        expect(contractRun).toBeDefined()
-      })
-    })
-
-    test("selects run associated with contract for unenrolled courses", () => {
-      const orgId = faker.number.int()
-      const contracts = createTestContracts(orgId, 1)
-      const contractIds = contracts.map((c) => c.id)
-      const courses = createCoursesWithContractRuns(contracts)
-
-      courses.forEach((course) => {
-        const transformedCourse = createOrgUnenrolledCourse(course, contracts)
-
-        // Should select the run with matching contract
-        const expectedRun = course.courseruns.find(
-          (run) => run.b2b_contract && contractIds.includes(run.b2b_contract),
-        )
-
-        expect(transformedCourse.run.startDate).toBe(expectedRun?.start_date)
-        expect(transformedCourse.coursewareId).toBe(
-          expectedRun?.courseware_id ?? null,
-        )
-      })
-    })
-
-    test("handles courses with no contract-matching runs gracefully", () => {
-      const orgId = faker.number.int()
-      const contracts = createTestContracts(orgId, 1)
-
-      const course = factories.courses.course({
-        courseruns: [
-          {
-            ...factories.courses.course().courseruns[0],
-            b2b_contract: faker.number.int(), // Different contract
-          },
-        ],
-      })
-
-      const transformedCourse = createOrgUnenrolledCourse(course, contracts)
-
-      // Should still return a valid course object
-      expect(transformedCourse.title).toBe(course.title)
-      expect(transformedCourse.type).toBe("course")
-
-      // Run data should be null/empty since no matching contract run found
-      expect(transformedCourse.run.startDate).toBeUndefined()
-      expect(transformedCourse.run.endDate).toBeUndefined()
-      expect(transformedCourse.run.coursewareUrl).toBeUndefined()
-      expect(transformedCourse.coursewareId).toBeNull()
-      expect(transformedCourse.run.canUpgrade).toBe(false) // !!undefined is false
     })
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/transform.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/transform.test.tsx
@@ -17,499 +17,35 @@ import {
 import { faker } from "@faker-js/faker/locale/en"
 
 describe("Certificate handling", () => {
-  test("userEnrollmentsToDashboardCourses includes certificate with transformed link", () => {
-    const enrollmentWithCert = mitx.enrollment.courseEnrollment({
-      certificate: {
-        uuid: "test-uuid-123",
-        link: "/certificate/abc123/",
-      },
-    })
-
-    const transformed = userEnrollmentsToDashboardCourses([enrollmentWithCert])
-
-    expect(transformed[0].run.certificate).toEqual({
-      uuid: "test-uuid-123",
-      link: "/certificate/course/abc123/",
-    })
-    expect(transformed[0].enrollment?.certificate).toBeUndefined() // Certificate should only be in run
-  })
-
-  test("userEnrollmentsToDashboardCourses handles missing certificate gracefully", () => {
-    const enrollmentWithoutCert = mitx.enrollment.courseEnrollment({
-      certificate: null,
-    })
-
-    const transformed = userEnrollmentsToDashboardCourses([
-      enrollmentWithoutCert,
-    ])
-
-    expect(transformed[0].run.certificate).toEqual({
-      uuid: "",
-      link: "",
-    })
-  })
-
-  test("organizationCoursesWithContracts includes certificate in enrollment", () => {
-    const orgId = faker.number.int()
-    const contracts = createTestContracts(orgId, 1)
-    const contractIds = contracts.map((c) => c.id)
-    const courses = createCoursesWithContractRuns(contracts)
-
-    // Create enrollments manually with certificate data
-    const enrollments = courses.flatMap((course) =>
-      course.courseruns
-        .filter(
-          (run) => run.b2b_contract && contractIds.includes(run.b2b_contract),
-        )
-        .map((run) =>
-          factories.enrollment.courseEnrollment({
-            run: {
-              id: run.id,
-              course: {
-                id: course.id,
-                title: course.title,
-              },
-              title: run.title,
-            },
-            certificate: {
-              uuid: "org-cert-uuid",
-              link: "/certificate/org123/",
-            },
-          }),
-        ),
-    )
-
-    const transformedCourses = organizationCoursesWithContracts({
-      courses,
-      contracts,
-      enrollments,
-    })
-
-    const courseWithEnrollment = transformedCourses.find(
-      (course) => course.enrollment,
-    )
-    expect(courseWithEnrollment?.enrollment?.certificate).toEqual({
-      uuid: "org-cert-uuid",
-      link: "/certificate/course/org123/",
-    })
-    expect(courseWithEnrollment?.run.certificate).toEqual({
-      uuid: "org-cert-uuid",
-      link: "/certificate/course/org123/",
-    })
-  })
-
-  test("organizationCoursesWithContracts handles enrollment without certificate", () => {
-    const orgId = faker.number.int()
-    const contracts = createTestContracts(orgId, 1)
-    const contractIds = contracts.map((c) => c.id)
-    const courses = createCoursesWithContractRuns(contracts)
-
-    // Create enrollments manually without certificate data
-    const enrollments = courses.flatMap((course) =>
-      course.courseruns
-        .filter(
-          (run) => run.b2b_contract && contractIds.includes(run.b2b_contract),
-        )
-        .map((run) =>
-          factories.enrollment.courseEnrollment({
-            run: {
-              id: run.id,
-              course: {
-                id: course.id,
-                title: course.title,
-              },
-              title: run.title,
-            },
-            certificate: null,
-          }),
-        ),
-    )
-
-    const transformedCourses = organizationCoursesWithContracts({
-      courses,
-      contracts,
-      enrollments,
-    })
-
-    const courseWithEnrollment = transformedCourses.find(
-      (course) => course.enrollment,
-    )
-    expect(courseWithEnrollment?.enrollment?.certificate).toEqual({
-      uuid: "",
-      link: "",
-    })
-    expect(courseWithEnrollment?.run.certificate).toEqual({
-      uuid: "",
-      link: "",
-    })
-  })
-
-  test("certificate link transformation handles various URL formats", () => {
-    const testCases = [
-      {
-        input: "/certificate/abc123/",
-        expected: "/certificate/course/abc123/",
-        description: "standard format",
-      },
-      {
-        input: "/certificate/xyz789/",
-        expected: "/certificate/course/xyz789/",
-        description: "different certificate ID",
-      },
-      {
-        input: "/some/other/path",
-        expected: "/some/other/path",
-        description: "non-matching format should remain unchanged",
-      },
-      {
-        input: "",
-        expected: "",
-        description: "empty string",
-      },
-    ]
-
-    testCases.forEach(({ input, expected }) => {
-      const enrollment = mitx.enrollment.courseEnrollment({
-        certificate: {
-          uuid: "test-uuid",
-          link: input,
-        },
-      })
-
-      const transformed = userEnrollmentsToDashboardCourses([enrollment])
-      expect(transformed[0].run.certificate?.link).toBe(expected)
-    })
-  })
-})
-
-describe("Transforming mitxonline enrollment data to DashboardResource - Original Tests", () => {
-  test.each([
-    {
-      grades: [mitx.enrollment.grade({ passed: true })],
-      enrollmentStatus: EnrollmentStatus.Completed,
-    },
-    {
-      grades: [mitx.enrollment.grade({ passed: false })],
-      enrollmentStatus: EnrollmentStatus.Enrolled,
-    },
-    { grades: [], enrollmentStatus: EnrollmentStatus.Enrolled },
-  ])(
-    "Property renames and EnrollmentStatus",
-    ({ grades, enrollmentStatus }) => {
-      const apiData = mitx.enrollment.courseEnrollment({
-        grades,
-      })
-      const transformed = userEnrollmentsToDashboardCourses([apiData])
-      expect(transformed).toHaveLength(1)
-      expect(transformed[0]).toEqual({
-        key: `mitxonline-course-${apiData.run.course.id}-${apiData.run.id}`,
-        coursewareId: apiData.run.courseware_id ?? null,
-        type: DashboardResourceType.Course,
-        title: apiData.run.title,
-        marketingUrl: apiData.run.course.page?.page_url,
-        run: {
-          startDate: apiData.run.start_date,
-          endDate: apiData.run.end_date,
-          coursewareUrl: apiData.run.courseware_url,
-          certificateUpgradeDeadline: apiData.run.upgrade_deadline,
-          certificateUpgradePrice: apiData.run.products[0]?.price,
-          canUpgrade: expect.any(Boolean), // check this in a moment
-          certificate: {
-            uuid: apiData.certificate?.uuid ?? "",
-            link: apiData.certificate?.link ?? "",
-          },
-        },
-        enrollment: {
-          id: apiData.id,
-          status: enrollmentStatus,
-          mode: apiData.enrollment_mode,
-          receiveEmails: apiData.edx_emails_subscription,
-        },
-      } satisfies DashboardResource)
-    },
-  )
-
-  test("CertificateUpgradePrice is first price in prices array", () => {
-    // Unclear why the mitxonline API has this as an array.
-    const apiData = mitx.enrollment.courseEnrollment({
-      // @ts-expect-error not fully implementing product objects
-      run: { products: [{ price: "10" }, { price: "20" }] },
-    })
-    const transformed = userEnrollmentsToDashboardCourses([apiData])
-    expect(transformed).toHaveLength(1)
-    expect(transformed[0].run.certificateUpgradePrice).toEqual("10")
-  })
-
-  test("sortDashboardCourses sorts courses by enrollment status and program order", () => {
-    const { programA, coursesA } = setupProgramsAndCourses()
-
-    const enrollments = [
-      mitx.enrollment.courseEnrollment({
-        run: {
-          id: coursesA[0].courseruns[0].id,
-          course: { id: coursesA[0].id },
-        },
-        grades: [mitx.enrollment.grade({ passed: true })],
-        enrollment_mode: "audit",
-      }),
-      mitx.enrollment.courseEnrollment({
-        run: {
-          id: coursesA[1].courseruns[0].id,
-          course: { id: coursesA[1].id },
-        },
-        grades: [],
-        enrollment_mode: "verified",
-      }),
-    ]
-
-    const transformedCourses = organizationCoursesWithContracts({
-      courses: coursesA,
-      enrollments,
-    })
-    const sortedCourses = sortDashboardCourses(
-      mitxonlineProgram(programA),
-      transformedCourses,
-    )
-
-    const enrolledCourse = sortedCourses.find(
-      (course) => course.enrollment?.status === EnrollmentStatus.Enrolled,
-    )
-    const completedCourse = sortedCourses.find(
-      (course) => course.enrollment?.status === EnrollmentStatus.Completed,
-    )
-    const notEnrolledCourses = sortedCourses.filter(
-      (course) =>
-        !course.enrollment ||
-        course.enrollment.status === EnrollmentStatus.NotEnrolled,
-    )
-
-    // Verify we found all expected courses
-    expect(enrolledCourse).toBeDefined()
-    expect(completedCourse).toBeDefined()
-    expect(notEnrolledCourses).toHaveLength(2)
-
-    // Verify sorting: enrolled first, then completed, then not enrolled
-    expect(sortedCourses[0]).toEqual(enrolledCourse) // Enrolled course should be first
-    expect(sortedCourses[1]).toEqual(completedCourse) // Completed course should be second
-    expect(sortedCourses[2]).toEqual(notEnrolledCourses[0]) // First not enrolled course
-    expect(sortedCourses[3]).toEqual(notEnrolledCourses[1]) // Second not enrolled course
-  })
-
-  test("selects course runs associated with organization's contract", () => {
-    const orgId = faker.number.int()
-    const contracts = createTestContracts(orgId, 2)
-    const contractIds = contracts.map((c) => c.id)
-    const courses = createCoursesWithContractRuns(contracts)
-
-    const transformedCourses = organizationCoursesWithContracts({
-      courses,
-      contracts,
-      enrollments: [],
-    })
-
-    // Should have transformed all courses
-    expect(transformedCourses).toHaveLength(3)
-
-    transformedCourses.forEach((transformedCourse, index) => {
-      const originalCourse = courses[index]
-
-      // Should use the course run with matching contract
-      const expectedRun = originalCourse.courseruns.find(
-        (run) => run.b2b_contract && contractIds.includes(run.b2b_contract),
-      )
-
-      expect(transformedCourse.run.startDate).toBe(expectedRun?.start_date)
-      expect(transformedCourse.run.endDate).toBe(expectedRun?.end_date)
-      expect(transformedCourse.coursewareId).toBe(
-        expectedRun?.courseware_id ?? null,
-      )
-    })
-  })
-
-  test("falls back to unenrolled course when no contract-matching runs exist", () => {
-    const orgId = faker.number.int()
-    const contracts = createTestContracts(orgId, 1)
-
-    // Create courses where runs don't match the contract
-    const courses = factories.courses
-      .courses({ count: 2 })
-      .results.map((course) => ({
-        ...course,
-        courseruns: course.courseruns.map((run) => ({
-          ...run,
-          b2b_contract: faker.number.int(), // Different contract ID
-        })),
-      }))
-
-    const transformedCourses = organizationCoursesWithContracts({
-      courses,
-      contracts,
-      enrollments: [],
-    })
-
-    transformedCourses.forEach((transformedCourse) => {
-      // Should not have enrollment since no matching contract runs
-      expect(transformedCourse.enrollment).toBeUndefined()
-
-      // Should still have course data but with contract-scoped run or null
-      expect(transformedCourse.title).toBeDefined()
-      expect(transformedCourse.type).toBe("course")
-    })
-  })
-
-  test("includes enrollments only for contract-scoped runs", () => {
-    const orgId = faker.number.int()
-    const contracts = createTestContracts(orgId, 1)
-    const contractIds = contracts.map((c) => c.id)
-    const courses = createCoursesWithContractRuns(contracts)
-    const enrollments = createEnrollmentsForContractRuns(courses, contractIds)
-
-    const transformedCourses = organizationCoursesWithContracts({
-      courses,
-      contracts,
-      enrollments,
-    })
-
-    // Should have enrollments for courses with contract-matching runs
-    const enrolledCourses = transformedCourses.filter(
-      (course) => course.enrollment,
-    )
-    expect(enrolledCourses.length).toBeGreaterThan(0)
-
-    enrolledCourses.forEach((course) => {
-      expect(course.enrollment).toBeDefined()
-      expect(course.enrollment?.status).toMatch(/enrolled|completed/)
-    })
-  })
-
-  test("filters out enrollments for non-contract runs", () => {
-    const orgId = faker.number.int()
-    const contracts = createTestContracts(orgId, 1)
-    const contractIds = contracts.map((c) => c.id)
-    const courses = createCoursesWithContractRuns(contracts)
-
-    // Create enrollments for both contract and non-contract runs
-    const contractEnrollments = createEnrollmentsForContractRuns(
-      courses,
-      contractIds,
-    )
-    const nonContractEnrollments = courses.flatMap((course) =>
-      course.courseruns
-        .filter(
-          (run) => !run.b2b_contract || !contractIds.includes(run.b2b_contract),
-        )
-        .map((run) =>
-          factories.enrollment.courseEnrollment({
-            run: {
-              id: run.id,
-              course: { id: course.id, title: course.title },
-              title: run.title,
-            },
-          }),
-        ),
-    )
-
-    const allEnrollments = [...contractEnrollments, ...nonContractEnrollments]
-
-    const transformedCourses = organizationCoursesWithContracts({
-      courses,
-      contracts,
-      enrollments: allEnrollments,
-    })
-
-    // Should only include enrollments for contract runs
-    const enrolledCourses = transformedCourses.filter(
-      (course) => course.enrollment,
-    )
-
-    enrolledCourses.forEach((course) => {
-      // Verify the enrollment corresponds to a contract run
-      const originalCourse = courses.find(
-        (c) => c.id.toString() === course.key.split("-")[2],
-      )
-      const contractRun = originalCourse?.courseruns.find(
-        (run) => run.b2b_contract && contractIds.includes(run.b2b_contract),
-      )
-      expect(contractRun).toBeDefined()
-    })
-  })
-
-  test("selects run associated with contract for unenrolled courses", () => {
-    const orgId = faker.number.int()
-    const contracts = createTestContracts(orgId, 1)
-    const contractIds = contracts.map((c) => c.id)
-    const courses = createCoursesWithContractRuns(contracts)
-
-    courses.forEach((course) => {
-      const transformedCourse = createOrgUnenrolledCourse(course, contracts)
-
-      // Should select the run with matching contract
-      const expectedRun = course.courseruns.find(
-        (run) => run.b2b_contract && contractIds.includes(run.b2b_contract),
-      )
-
-      expect(transformedCourse.run.startDate).toBe(expectedRun?.start_date)
-      expect(transformedCourse.coursewareId).toBe(
-        expectedRun?.courseware_id ?? null,
-      )
-    })
-  })
-
-  test("handles courses with no contract-matching runs gracefully", () => {
-    const orgId = faker.number.int()
-    const contracts = createTestContracts(orgId, 1)
-
-    const course = factories.courses.course({
-      courseruns: [
-        {
-          ...factories.courses.course().courseruns[0],
-          b2b_contract: faker.number.int(), // Different contract
-        },
-      ],
-    })
-
-    const transformedCourse = createOrgUnenrolledCourse(course, contracts)
-
-    // Should still return a valid course object
-    expect(transformedCourse.title).toBe(course.title)
-    expect(transformedCourse.type).toBe("course")
-
-    // Run data should be null/empty since no matching contract run found
-    expect(transformedCourse.run.startDate).toBeUndefined()
-    expect(transformedCourse.run.endDate).toBeUndefined()
-    expect(transformedCourse.run.coursewareUrl).toBeUndefined()
-    expect(transformedCourse.coursewareId).toBeNull()
-    expect(transformedCourse.run.canUpgrade).toBe(false) // !!undefined is false
-  })
-})
-
-describe("Certificate handling in transformations", () => {
   describe("userEnrollmentsToDashboardCourses", () => {
-    test("includes certificate data from enrollment in course run", () => {
-      const apiData = mitx.enrollment.courseEnrollment({
+    test("includes certificate with transformed link", () => {
+      const enrollmentWithCert = mitx.enrollment.courseEnrollment({
         certificate: {
           uuid: "test-uuid-123",
           link: "/certificate/abc123/",
         },
       })
 
-      const transformed = userEnrollmentsToDashboardCourses([apiData])
+      const transformed = userEnrollmentsToDashboardCourses([
+        enrollmentWithCert,
+      ])
 
-      expect(transformed).toHaveLength(1)
       expect(transformed[0].run.certificate).toEqual({
         uuid: "test-uuid-123",
         link: "/certificate/course/abc123/",
       })
+      expect(transformed[0].enrollment?.certificate).toBeUndefined() // Certificate should only be in run
     })
 
     test("handles missing certificate gracefully", () => {
-      const apiData = mitx.enrollment.courseEnrollment({
+      const enrollmentWithoutCert = mitx.enrollment.courseEnrollment({
         certificate: null,
       })
 
-      const transformed = userEnrollmentsToDashboardCourses([apiData])
+      const transformed = userEnrollmentsToDashboardCourses([
+        enrollmentWithoutCert,
+      ])
 
-      expect(transformed).toHaveLength(1)
       expect(transformed[0].run.certificate).toEqual({
         uuid: "",
         link: "",
@@ -549,25 +85,75 @@ describe("Certificate handling in transformations", () => {
         expect(transformed[0].run.certificate?.link).toBe(expected)
       })
     })
+
+    test("certificate link transformation handles various URL formats", () => {
+      const testCases = [
+        {
+          input: "/certificate/abc123/",
+          expected: "/certificate/course/abc123/",
+          description: "standard format",
+        },
+        {
+          input: "/certificate/xyz789/",
+          expected: "/certificate/course/xyz789/",
+          description: "different certificate ID",
+        },
+        {
+          input: "/some/other/path",
+          expected: "/some/other/path",
+          description: "non-matching format should remain unchanged",
+        },
+        {
+          input: "",
+          expected: "",
+          description: "empty string",
+        },
+      ]
+
+      testCases.forEach(({ input, expected }) => {
+        const enrollment = mitx.enrollment.courseEnrollment({
+          certificate: {
+            uuid: "test-uuid",
+            link: input,
+          },
+        })
+
+        const transformed = userEnrollmentsToDashboardCourses([enrollment])
+        expect(transformed[0].run.certificate?.link).toBe(expected)
+      })
+    })
   })
 
   describe("organizationCoursesWithContracts", () => {
     test("includes certificate data from org enrollment", () => {
       const orgId = faker.number.int()
       const contracts = createTestContracts(orgId, 1)
+      const contractIds = contracts.map((c) => c.id)
       const courses = createCoursesWithContractRuns(contracts)
-      const enrollments = [
-        mitx.enrollment.courseEnrollment({
-          run: {
-            id: courses[0].courseruns[0].id,
-            course: { id: courses[0].id },
-          },
-          certificate: {
-            uuid: "org-cert-uuid-123",
-            link: "/certificate/org123/",
-          },
-        }),
-      ]
+
+      // Create enrollments manually with certificate data
+      const enrollments = courses.flatMap((course) =>
+        course.courseruns
+          .filter(
+            (run) => run.b2b_contract && contractIds.includes(run.b2b_contract),
+          )
+          .map((run) =>
+            factories.enrollment.courseEnrollment({
+              run: {
+                id: run.id,
+                course: {
+                  id: course.id,
+                  title: course.title,
+                },
+                title: run.title,
+              },
+              certificate: {
+                uuid: "org-cert-uuid",
+                link: "/certificate/org123/",
+              },
+            }),
+          ),
+      )
 
       const transformedCourses = organizationCoursesWithContracts({
         courses,
@@ -575,35 +161,45 @@ describe("Certificate handling in transformations", () => {
         enrollments,
       })
 
-      const enrolledCourse = transformedCourses.find(
+      const courseWithEnrollment = transformedCourses.find(
         (course) => course.enrollment,
       )
-      expect(enrolledCourse).toBeDefined()
-
-      // Certificate should be in both enrollment and run
-      expect(enrolledCourse?.enrollment?.certificate).toEqual({
-        uuid: "org-cert-uuid-123",
+      expect(courseWithEnrollment?.enrollment?.certificate).toEqual({
+        uuid: "org-cert-uuid",
         link: "/certificate/course/org123/",
       })
-      expect(enrolledCourse?.run.certificate).toEqual({
-        uuid: "org-cert-uuid-123",
+      expect(courseWithEnrollment?.run.certificate).toEqual({
+        uuid: "org-cert-uuid",
         link: "/certificate/course/org123/",
       })
     })
 
-    test("handles organization courses without certificates", () => {
+    test("organizationCoursesWithContracts handles enrollment without certificate", () => {
       const orgId = faker.number.int()
       const contracts = createTestContracts(orgId, 1)
+      const contractIds = contracts.map((c) => c.id)
       const courses = createCoursesWithContractRuns(contracts)
-      const enrollments = [
-        mitx.enrollment.courseEnrollment({
-          run: {
-            id: courses[0].courseruns[0].id,
-            course: { id: courses[0].id },
-          },
-          certificate: null,
-        }),
-      ]
+
+      // Create enrollments manually without certificate data
+      const enrollments = courses.flatMap((course) =>
+        course.courseruns
+          .filter(
+            (run) => run.b2b_contract && contractIds.includes(run.b2b_contract),
+          )
+          .map((run) =>
+            factories.enrollment.courseEnrollment({
+              run: {
+                id: run.id,
+                course: {
+                  id: course.id,
+                  title: course.title,
+                },
+                title: run.title,
+              },
+              certificate: null,
+            }),
+          ),
+      )
 
       const transformedCourses = organizationCoursesWithContracts({
         courses,
@@ -611,50 +207,319 @@ describe("Certificate handling in transformations", () => {
         enrollments,
       })
 
-      const enrolledCourse = transformedCourses.find(
+      const courseWithEnrollment = transformedCourses.find(
         (course) => course.enrollment,
       )
-      expect(enrolledCourse).toBeDefined()
-
-      // Certificate should have empty values
-      expect(enrolledCourse?.enrollment?.certificate).toEqual({
+      expect(courseWithEnrollment?.enrollment?.certificate).toEqual({
         uuid: "",
         link: "",
       })
-      expect(enrolledCourse?.run.certificate).toEqual({
+      expect(courseWithEnrollment?.run.certificate).toEqual({
         uuid: "",
         link: "",
-      })
-    })
-
-    test("unenrolled courses do not have certificate data", () => {
-      const orgId = faker.number.int()
-      const contracts = createTestContracts(orgId, 1)
-      const courses = createCoursesWithContractRuns(contracts)
-
-      const transformedCourses = organizationCoursesWithContracts({
-        courses,
-        contracts,
-        enrollments: [], // No enrollments
-      })
-
-      transformedCourses.forEach((course) => {
-        expect(course.enrollment).toBeUndefined()
-        expect(course.run.certificate).toBeUndefined()
       })
     })
   })
 
-  describe("createOrgUnenrolledCourse", () => {
-    test("does not include certificate data for unenrolled courses", () => {
+  describe("Transforming mitxonline enrollment data to DashboardResource - Original Tests", () => {
+    test.each([
+      {
+        grades: [mitx.enrollment.grade({ passed: true })],
+        enrollmentStatus: EnrollmentStatus.Completed,
+      },
+      {
+        grades: [mitx.enrollment.grade({ passed: false })],
+        enrollmentStatus: EnrollmentStatus.Enrolled,
+      },
+      { grades: [], enrollmentStatus: EnrollmentStatus.Enrolled },
+    ])(
+      "Property renames and EnrollmentStatus",
+      ({ grades, enrollmentStatus }) => {
+        const apiData = mitx.enrollment.courseEnrollment({
+          grades,
+        })
+        const transformed = userEnrollmentsToDashboardCourses([apiData])
+        expect(transformed).toHaveLength(1)
+        expect(transformed[0]).toEqual({
+          key: `mitxonline-course-${apiData.run.course.id}-${apiData.run.id}`,
+          coursewareId: apiData.run.courseware_id ?? null,
+          type: DashboardResourceType.Course,
+          title: apiData.run.title,
+          marketingUrl: apiData.run.course.page?.page_url,
+          run: {
+            startDate: apiData.run.start_date,
+            endDate: apiData.run.end_date,
+            coursewareUrl: apiData.run.courseware_url,
+            certificateUpgradeDeadline: apiData.run.upgrade_deadline,
+            certificateUpgradePrice: apiData.run.products[0]?.price,
+            canUpgrade: expect.any(Boolean), // check this in a moment
+            certificate: {
+              uuid: apiData.certificate?.uuid ?? "",
+              link: apiData.certificate?.link ?? "",
+            },
+          },
+          enrollment: {
+            id: apiData.id,
+            status: enrollmentStatus,
+            mode: apiData.enrollment_mode,
+            receiveEmails: apiData.edx_emails_subscription,
+          },
+        } satisfies DashboardResource)
+      },
+    )
+
+    test("CertificateUpgradePrice is first price in prices array", () => {
+      // Unclear why the mitxonline API has this as an array.
+      const apiData = mitx.enrollment.courseEnrollment({
+        // @ts-expect-error not fully implementing product objects
+        run: { products: [{ price: "10" }, { price: "20" }] },
+      })
+      const transformed = userEnrollmentsToDashboardCourses([apiData])
+      expect(transformed).toHaveLength(1)
+      expect(transformed[0].run.certificateUpgradePrice).toEqual("10")
+    })
+
+    test("sortDashboardCourses sorts courses by enrollment status and program order", () => {
+      const { programA, coursesA } = setupProgramsAndCourses()
+
+      const enrollments = [
+        mitx.enrollment.courseEnrollment({
+          run: {
+            id: coursesA[0].courseruns[0].id,
+            course: { id: coursesA[0].id },
+          },
+          grades: [mitx.enrollment.grade({ passed: true })],
+          enrollment_mode: "audit",
+        }),
+        mitx.enrollment.courseEnrollment({
+          run: {
+            id: coursesA[1].courseruns[0].id,
+            course: { id: coursesA[1].id },
+          },
+          grades: [],
+          enrollment_mode: "verified",
+        }),
+      ]
+
+      const transformedCourses = organizationCoursesWithContracts({
+        courses: coursesA,
+        enrollments,
+      })
+      const sortedCourses = sortDashboardCourses(
+        mitxonlineProgram(programA),
+        transformedCourses,
+      )
+
+      const enrolledCourse = sortedCourses.find(
+        (course) => course.enrollment?.status === EnrollmentStatus.Enrolled,
+      )
+      const completedCourse = sortedCourses.find(
+        (course) => course.enrollment?.status === EnrollmentStatus.Completed,
+      )
+      const notEnrolledCourses = sortedCourses.filter(
+        (course) =>
+          !course.enrollment ||
+          course.enrollment.status === EnrollmentStatus.NotEnrolled,
+      )
+
+      // Verify we found all expected courses
+      expect(enrolledCourse).toBeDefined()
+      expect(completedCourse).toBeDefined()
+      expect(notEnrolledCourses).toHaveLength(2)
+
+      // Verify sorting: enrolled first, then completed, then not enrolled
+      expect(sortedCourses[0]).toEqual(enrolledCourse) // Enrolled course should be first
+      expect(sortedCourses[1]).toEqual(completedCourse) // Completed course should be second
+      expect(sortedCourses[2]).toEqual(notEnrolledCourses[0]) // First not enrolled course
+      expect(sortedCourses[3]).toEqual(notEnrolledCourses[1]) // Second not enrolled course
+    })
+
+    test("selects course runs associated with organization's contract", () => {
+      const orgId = faker.number.int()
+      const contracts = createTestContracts(orgId, 2)
+      const contractIds = contracts.map((c) => c.id)
+      const courses = createCoursesWithContractRuns(contracts)
+
+      const transformedCourses = organizationCoursesWithContracts({
+        courses,
+        contracts,
+        enrollments: [],
+      })
+
+      // Should have transformed all courses
+      expect(transformedCourses).toHaveLength(3)
+
+      transformedCourses.forEach((transformedCourse, index) => {
+        const originalCourse = courses[index]
+
+        // Should use the course run with matching contract
+        const expectedRun = originalCourse.courseruns.find(
+          (run) => run.b2b_contract && contractIds.includes(run.b2b_contract),
+        )
+
+        expect(transformedCourse.run.startDate).toBe(expectedRun?.start_date)
+        expect(transformedCourse.run.endDate).toBe(expectedRun?.end_date)
+        expect(transformedCourse.coursewareId).toBe(
+          expectedRun?.courseware_id ?? null,
+        )
+      })
+    })
+
+    test("falls back to unenrolled course when no contract-matching runs exist", () => {
       const orgId = faker.number.int()
       const contracts = createTestContracts(orgId, 1)
-      const course = createCoursesWithContractRuns(contracts)[0]
+
+      // Create courses where runs don't match the contract
+      const courses = factories.courses
+        .courses({ count: 2 })
+        .results.map((course) => ({
+          ...course,
+          courseruns: course.courseruns.map((run) => ({
+            ...run,
+            b2b_contract: faker.number.int(), // Different contract ID
+          })),
+        }))
+
+      const transformedCourses = organizationCoursesWithContracts({
+        courses,
+        contracts,
+        enrollments: [],
+      })
+
+      transformedCourses.forEach((transformedCourse) => {
+        // Should not have enrollment since no matching contract runs
+        expect(transformedCourse.enrollment).toBeUndefined()
+
+        // Should still have course data but with contract-scoped run or null
+        expect(transformedCourse.title).toBeDefined()
+        expect(transformedCourse.type).toBe("course")
+      })
+    })
+
+    test("includes enrollments only for contract-scoped runs", () => {
+      const orgId = faker.number.int()
+      const contracts = createTestContracts(orgId, 1)
+      const contractIds = contracts.map((c) => c.id)
+      const courses = createCoursesWithContractRuns(contracts)
+      const enrollments = createEnrollmentsForContractRuns(courses, contractIds)
+
+      const transformedCourses = organizationCoursesWithContracts({
+        courses,
+        contracts,
+        enrollments,
+      })
+
+      // Should have enrollments for courses with contract-matching runs
+      const enrolledCourses = transformedCourses.filter(
+        (course) => course.enrollment,
+      )
+      expect(enrolledCourses.length).toBeGreaterThan(0)
+
+      enrolledCourses.forEach((course) => {
+        expect(course.enrollment).toBeDefined()
+        expect(course.enrollment?.status).toMatch(/enrolled|completed/)
+      })
+    })
+
+    test("filters out enrollments for non-contract runs", () => {
+      const orgId = faker.number.int()
+      const contracts = createTestContracts(orgId, 1)
+      const contractIds = contracts.map((c) => c.id)
+      const courses = createCoursesWithContractRuns(contracts)
+
+      // Create enrollments for both contract and non-contract runs
+      const contractEnrollments = createEnrollmentsForContractRuns(
+        courses,
+        contractIds,
+      )
+      const nonContractEnrollments = courses.flatMap((course) =>
+        course.courseruns
+          .filter(
+            (run) =>
+              !run.b2b_contract || !contractIds.includes(run.b2b_contract),
+          )
+          .map((run) =>
+            factories.enrollment.courseEnrollment({
+              run: {
+                id: run.id,
+                course: { id: course.id, title: course.title },
+                title: run.title,
+              },
+            }),
+          ),
+      )
+
+      const allEnrollments = [...contractEnrollments, ...nonContractEnrollments]
+
+      const transformedCourses = organizationCoursesWithContracts({
+        courses,
+        contracts,
+        enrollments: allEnrollments,
+      })
+
+      // Should only include enrollments for contract runs
+      const enrolledCourses = transformedCourses.filter(
+        (course) => course.enrollment,
+      )
+
+      enrolledCourses.forEach((course) => {
+        // Verify the enrollment corresponds to a contract run
+        const originalCourse = courses.find(
+          (c) => c.id.toString() === course.key.split("-")[2],
+        )
+        const contractRun = originalCourse?.courseruns.find(
+          (run) => run.b2b_contract && contractIds.includes(run.b2b_contract),
+        )
+        expect(contractRun).toBeDefined()
+      })
+    })
+
+    test("selects run associated with contract for unenrolled courses", () => {
+      const orgId = faker.number.int()
+      const contracts = createTestContracts(orgId, 1)
+      const contractIds = contracts.map((c) => c.id)
+      const courses = createCoursesWithContractRuns(contracts)
+
+      courses.forEach((course) => {
+        const transformedCourse = createOrgUnenrolledCourse(course, contracts)
+
+        // Should select the run with matching contract
+        const expectedRun = course.courseruns.find(
+          (run) => run.b2b_contract && contractIds.includes(run.b2b_contract),
+        )
+
+        expect(transformedCourse.run.startDate).toBe(expectedRun?.start_date)
+        expect(transformedCourse.coursewareId).toBe(
+          expectedRun?.courseware_id ?? null,
+        )
+      })
+    })
+
+    test("handles courses with no contract-matching runs gracefully", () => {
+      const orgId = faker.number.int()
+      const contracts = createTestContracts(orgId, 1)
+
+      const course = factories.courses.course({
+        courseruns: [
+          {
+            ...factories.courses.course().courseruns[0],
+            b2b_contract: faker.number.int(), // Different contract
+          },
+        ],
+      })
 
       const transformedCourse = createOrgUnenrolledCourse(course, contracts)
 
-      expect(transformedCourse.enrollment).toBeUndefined()
-      expect(transformedCourse.run.certificate).toBeUndefined()
+      // Should still return a valid course object
+      expect(transformedCourse.title).toBe(course.title)
+      expect(transformedCourse.type).toBe("course")
+
+      // Run data should be null/empty since no matching contract run found
+      expect(transformedCourse.run.startDate).toBeUndefined()
+      expect(transformedCourse.run.endDate).toBeUndefined()
+      expect(transformedCourse.run.coursewareUrl).toBeUndefined()
+      expect(transformedCourse.coursewareId).toBeNull()
+      expect(transformedCourse.run.canUpgrade).toBe(false) // !!undefined is false
     })
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/transform.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/transform.ts
@@ -25,6 +25,9 @@ import { groupBy } from "lodash"
 const sources = {
   mitxonline: "mitxonline",
 }
+
+const CERTIFICATE_LINK_PATTERN = /\/certificate\/([^/]+)\/$/
+
 type KeyOpts = {
   source: string
   resourceType: DashboardResourceType
@@ -99,7 +102,7 @@ const userEnrollmentsToDashboardCourses = (
           uuid: enrollment.certificate?.uuid ?? "",
           link:
             enrollment.certificate?.link?.replace(
-              /\/certificate\/([^/]+)\/$/,
+              CERTIFICATE_LINK_PATTERN,
               "/certificate/course/$1/",
             ) ?? "",
         },
@@ -149,7 +152,7 @@ const enrollmentToOrgDashboardEnrollment = (
       uuid: raw.certificate?.uuid ?? "",
       link:
         raw.certificate?.link?.replace(
-          /\/certificate\/([^/]+)\/$/,
+          CERTIFICATE_LINK_PATTERN,
           "/certificate/course/$1/",
         ) ?? "",
     },

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/types.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/types.ts
@@ -58,6 +58,10 @@ type DashboardCourseEnrollment = {
   status: EnrollmentStatus
   mode: EnrollmentMode
   receiveEmails?: boolean
+  certificate?: {
+    uuid: string
+    link: string
+  }
 }
 
 type DashboardProgram = {

--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.test.tsx
@@ -5,7 +5,7 @@ import { setMockResponse } from "api/test-utils"
 import { urls, factories } from "api/mitxonline-test-utils"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import {
-  mitxonlineOrgCourses,
+  organizationCoursesWithContracts,
   mitxonlineProgram,
   sortDashboardCourses,
 } from "./CoursewareDisplay/transform"
@@ -90,7 +90,10 @@ describe("OrganizationContent", () => {
     expect(cards.length).toBeGreaterThan(0)
     const sortedCourses = sortDashboardCourses(
       mitxonlineProgram(programA),
-      mitxonlineOrgCourses({ courses: coursesA, enrollments: enrollments }),
+      organizationCoursesWithContracts({
+        courses: coursesA,
+        enrollments: enrollments,
+      }),
     )
 
     cards.forEach((card, i) => {

--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
@@ -260,7 +260,7 @@ const OrgProgramDisplay: React.FC<{
     <Skeleton width="100%" height="65px" style={{ marginBottom: "16px" }} />
   )
   if (programLoading || courses.isLoading) return skeleton
-  const transformedCourses = transform.mitxonlineOrgCourses({
+  const transformedCourses = transform.organizationCoursesWithContracts({
     courses: courses.data?.results ?? [],
     contracts: contracts ?? [],
     enrollments: courseRunEnrollments ?? [],
@@ -339,7 +339,7 @@ const ProgramCard: React.FC<{
     <Skeleton width="100%" height="65px" style={{ marginBottom: "16px" }} />
   )
   if (courses.isLoading) return skeleton
-  const transformedCourses = transform.mitxonlineOrgCourses({
+  const transformedCourses = transform.organizationCoursesWithContracts({
     courses: courses.data?.results ?? [],
     contracts: contracts ?? [],
     enrollments: enrollments ?? [],


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/8552

### Description (What does it do?)
In https://github.com/mitodl/mit-learn/pull/2453, the MITx Online API `transform.ts` code that handles transforming raw API data into intermediate classes in the Learn frontend was updated. The org dashboard and the my learning section of the dashboard home page now use separate functions to obtain the courses they list. This was done so that the `b2b_contract` property attached to course runs can be properly evaluated to make sure you are getting the proper course runs in the organization dashboard. Certificate info was accidentally left out of the data being returned to the org dashboard. This PR adds that data back and does some refactoring. The functions in `transform.ts` have been renamed to more accurately reflect their function, and new tests have been added surrounding the transformation of certificate links from the API.

### How can this be tested?
In order to test this, you need a basic installation of `mitxonline` up and running with example data in it. You may be able to skip one or more steps if you have already done them:
- Ensure you have local `hosts` redirects for the following domains, replacing the example IP with your __local__ IP address (Google how to get this if unsure, mine is 192.168.1.50)
```
192.168.1.50 open.odl.local
192.168.1.50 api.open.odl.local
192.168.1.50 kc.ol.local
192.168.1.50 mitxonline.odl.local
```
- Clone `mitxonline`: https://github.com/mitodl/mitxonline
- Create a `.env` file with the following values:
```
CELERY_TASK_ALWAYS_EAGER=True
DJANGO_LOG_LEVEL=INFO
LOG_LEVEL=INFO
SENTRY_LOG_LEVEL=ERROR
MAILGUN_KEY=fake
MAILGUN_URL=
MAILGUN_RECIPIENT_OVERRIDE=
MAILGUN_SENDER_DOMAIN=.odl.local
SECRET_KEY=
STATUS_TOKEN=
UWSGI_THREADS=5
SENTRY_DSN=
MITX_ONLINE_BASE_URL=http://open.odl.local:8065/mitxonline
MITX_ONLINE_ADMIN_CLIENT_ID=refine-local-client-id
MITX_ONLINE_ADMIN_BASE_URL=http://mitxonline.odl.local:8016
POSTHOG_PROJECT_API_KEY=
POSTHOG_API_HOST=https://app.posthog.com/
HUBSPOT_HOME_PAGE_FORM_GUID=
HUBSPOT_PORTAL_ID=
APISIX_PORT=9080

# APISIX/Keycloak settings
APISIX_LOGOUT_URL=http://api.open.odl.local:8065/logout/
APISIX_SESSION_SECRET_KEY=supertopsecret1234
KC_SPI_THEME_WELCOME_THEME=scim
KC_SPI_REALM_RESTAPI_EXTENSION_SCIM_LICENSE_KEY=
KEYCLOAK_BASE_URL=http://kc.ol.local:8066
KEYCLOAK_CLIENT_ID=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
KEYCLOAK_CLIENT_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
KEYCLOAK_DISCOVERY_URL=http://kc.ol.local:8066/realms/ol-local/.well-known/openid-configuration
KEYCLOAK_REALM_NAME=ol-local
KEYCLOAK_SCOPES="openid profile ol-profile"
KEYCLOAK_SVC_KEYSTORE_PASSWORD=supertopsecret1234
KEYCLOAK_SVC_HOSTNAME=kc.ol.local
KEYCLOAK_SVC_ADMIN=admin
KEYCLOAK_SVC_ADMIN_PASSWORD=admin
AUTHORIZATION_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/auth
ACCESS_TOKEN_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/token
OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_KEY=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
SOCIAL_AUTH_OL_OIDC_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
USERINFO_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/userinfo
MITOL_APIGATEWAY_DISABLE_MIDDLEWARE=False

FEATURE_IGNORE_EDX_FAILURES=True
OPENEDX_API_CLIENT_ID=fake
OPENEDX_API_CLIENT_SECRET=fake
OPENEDX_SERVICE_WORKER_API_TOKEN=fake

CSRF_COOKIE_DOMAIN=.odl.local
CORS_ALLOWED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
CSRF_TRUSTED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
```
- Spin up `mitxonline` with `docker compose up --build -d`
- Promote the admin user with `docker compose exec web ./manage.py promote_user promote --superuser --email admin@odl.local`
- Populate test course data with `docker compose exec web ./manage.py populate_course_data`
- Generate docs with `pants docs ::`
- In `dist/sphinx/index.html`, read the section on generating a B2B organization / contract and create one, adding some of the test courses to it
- In Django admin, create a `Program` and add the courses to the program that are included in your B2B org, making sure to mark the program as "live"
- Navigate to Wagtail at http://mitxonline.odl.local:8065/cms
- If you don't have a Signatory, browse to Home Page -> Signatories and create one
- Browse to Home Page -> Courses
- If there is not a Course Page for one of the courses you enrolled in, create one
- Create a child Certificate Page for one of the course pages you are enrolled in
- Browse to Django admin and then to Course run certificates
- Make sure your user is associated with the B2B org you created
- Create a course run certificate for your user, pointing at the certificate page we just created and the course run matching the same course
- Create a course run grade for the course run you used
- Make sure you have a personal Posthog project configured and have the API key at the ready
- Before we spin up `mit-learn`, we need to set some env variables:
```
.env
...
MITX_ONLINE_UPSTREAM=mitxonline.odl.local:8013
MITX_ONLINE_DOMAIN=mitxonline.odl.local
MITX_ONLINE_BASE_URL=http://mitxonline.odl.local:8065
POSTHOG_ENABLED=True
CSRF_COOKIE_DOMAIN=.odl.local

shared.local.env
POSTHOG_PROJECT_API_KEY=YOUR_API_KEY_HERE
POSTHOG_PROJECT_ID=YOUR_PROJECT_ID_HERE
POSTHOG_TIMEOUT_MS=1500
```
- In your Posthog project, enable the `enrollment-dashboard` and `mitlearn-organization-dashboard` feature flags for all users
- Spin up `MIT Learn`
- Log in with the `admin@odl.local` test user
- Navigate to the Dashboard
- Click on your b2b org's tab
- Enroll in the course that you created the cert for, then navigate back to the org dashboard
- Ensure that there is a certificate link present on the course and that you can click it and it goes to the certificate page