### PR TITLE
Fix posthog import

### DIFF
--- a/learning_resources/etl/posthog_test.py
+++ b/learning_resources/etl/posthog_test.py
@@ -82,18 +82,11 @@ def test_posthog_transform_lrd_view_events(mocker, mock_posthog_event_bucket, se
     transformed_events = list(transformed_events)
     assert len(transformed_events) == 4
 
-    assert transformed_events[0].resourceType == "course"
-    assert transformed_events[0].platformCode == "see"
-    assert transformed_events[0].resourceId == 3235
-    assert transformed_events[0].readableId == "a05U1000004xD2BIAU"
+    assert transformed_events[0].resource_id == 3235
     assert transformed_events[0].event_date.to_pydatetime() == datetime(
         2025, 8, 28, 15, 20, 10, 403000, tzinfo=UTC
     )
-
-    assert transformed_events[1].resourceType == "course"
-    assert transformed_events[1].platformCode == "see"
-    assert transformed_events[1].resourceId == 3235
-    assert transformed_events[1].readableId == "a05U1000004xD2BIAU"
+    assert transformed_events[1].resource_id == 3235
     assert transformed_events[1].event_date.to_pydatetime() == datetime(
         2025, 8, 28, 15, 20, 13, 620000, tzinfo=UTC
     )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8319

### Description (What does it do?)
While testing https://github.com/mitodl/mit-learn/pull/2489 i  noticed
1) An error in this line https://github.com/mitodl/mit-learn/blob/main/learning_resources/etl/posthog.py#L96C13-L96C66 because `platform` is None for learning paths
2) Lots of noisy warnings because the export files contain posthog traces for llm calls

This pr fixes those issues 

### How can this be tested?
set 
POSTHOG_EVENT_S3_BUCKET=ol-data-lake-landing-zone-qa
POSTHOG_EVENT_S3_PREFIX=thirdparty/posthog/learn/events/
and AWS keys from rc

from the shell run
```
from learning_resources.tasks import get_learning_resource_views
get_learning_resource_views()
```
you should get some messages such as
`WARNING: skipping event for resource ID 17235 - resource not found`
since the resource ids in your local database don't match rc.

You should not see any messages saying
`WARNING: skipping event for resource ID None - resource not found`
and you should not see errors
