### PR TITLE
fix non-lexicographical ordering in org dashboard programs / program collections

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.test.tsx
@@ -66,6 +66,31 @@ describe("OrganizationContent", () => {
     })
   })
 
+  it("displays courses in the correct order based on program.courseIds, regardless of API response order", async () => {
+    const { orgX, programA, coursesA } = setupProgramsAndCourses()
+
+    // Mock API to return courses in reverse order from program.courseIds
+    const reversedCoursesA = [...coursesA].reverse()
+    setMockResponse.get(
+      expect.stringContaining(
+        `/api/v2/courses/?id=${programA.courses.join("%2C")}`,
+      ),
+      { results: reversedCoursesA },
+    )
+
+    renderWithProviders(<OrganizationContent orgSlug={orgX.slug} />)
+
+    const programElement = await screen.findByTestId("org-program-root")
+    const cards = await within(programElement).findAllByTestId(
+      "enrollment-card-desktop",
+    )
+
+    // Verify courses appear in program.courseIds order, not API response order
+    coursesA.forEach((course, i) => {
+      expect(cards[i]).toHaveTextContent(course.title)
+    })
+  })
+
   test("Shows correct enrollment status", async () => {
     const { orgX, programA, coursesA } = setupProgramsAndCourses()
     const enrollments = [
@@ -132,19 +157,16 @@ describe("OrganizationContent", () => {
       { results: [programB] },
     )
 
-    // Mock the courses API calls for programs in the collection
-    // Use dynamic matching since course IDs are randomly generated
+    // Mock the bulk course API call with first course from each program
+    const firstCourseA = coursesA.find((c) => c.id === programA.courses[0])
+    const firstCourseB = coursesB.find((c) => c.id === programB.courses[0])
+    const firstCourseIds = [programB.courses[0], programA.courses[0]] // B first, then A to match collection order
+
     setMockResponse.get(
       expect.stringContaining(
-        `/api/v2/courses/?id=${programA.courses.join("%2C")}`,
+        `/api/v2/courses/?id=${firstCourseIds.join("%2C")}`,
       ),
-      { results: coursesA },
-    )
-    setMockResponse.get(
-      expect.stringContaining(
-        `/api/v2/courses/?id=${programB.courses.join("%2C")}`,
-      ),
-      { results: coursesB },
+      { results: [firstCourseB, firstCourseA] }, // Response order should match request order
     )
 
     renderWithProviders(<OrganizationContent orgSlug={orgX.slug} />)
@@ -168,8 +190,47 @@ describe("OrganizationContent", () => {
 
     // Verify the order matches the programCollection.programs array [programB.id, programA.id]
     const programCards = collection.getAllByTestId("enrollment-card-desktop")
-    expect(programCards[0]).toHaveTextContent(coursesB[0].title)
-    expect(programCards[1]).toHaveTextContent(coursesA[0].title)
+    expect(programCards[0]).toHaveTextContent(firstCourseB!.title)
+    expect(programCards[1]).toHaveTextContent(firstCourseA!.title)
+  })
+
+  test("Program collection displays the first course from each program", async () => {
+    const { orgX, programA, programCollection, coursesA } =
+      setupProgramsAndCourses()
+
+    programCollection.programs = [programA.id]
+    setMockResponse.get(urls.programCollections.programCollectionsList(), {
+      results: [programCollection],
+    })
+
+    setMockResponse.get(
+      expect.stringContaining(`/api/v2/programs/?id=${programA.id}`),
+      { results: [programA] },
+    )
+
+    // Mock bulk API call for the first course
+    const firstCourseId = programA.courses[0]
+    const firstCourse = coursesA.find((c) => c.id === firstCourseId)
+    setMockResponse.get(
+      expect.stringContaining(`/api/v2/courses/?id=${firstCourseId}`),
+      { results: [firstCourse] },
+    )
+
+    renderWithProviders(<OrganizationContent orgSlug={orgX.slug} />)
+
+    const collection = await screen.findByTestId("org-program-collection-root")
+
+    // Wait for program cards to be rendered
+    const programCards = await waitFor(() => {
+      const programCards = within(collection).getAllByTestId(
+        "enrollment-card-desktop",
+      )
+      expect(programCards.length).toBeGreaterThan(0)
+      return programCards
+    })
+
+    // Should display the first course by program.courseIds order
+    expect(programCards[0]).toHaveTextContent(firstCourse!.title)
   })
 
   test("Does not render a program separately if it is part of a collection", async () => {
@@ -265,34 +326,32 @@ describe("OrganizationContent", () => {
     const { orgX, programA, programB, programCollection, coursesB } =
       setupProgramsAndCourses()
 
+    // Modify programA to have no courses to test "at least one program has courses"
+    const programANoCourses = { ...programA, courses: [] }
+
     // Set up the collection to include both programs
-    programCollection.programs = [programA.id, programB.id]
+    programCollection.programs = [programANoCourses.id, programB.id]
     setMockResponse.get(urls.programCollections.programCollectionsList(), {
       results: [programCollection],
     })
 
     // Mock individual program API calls for the collection
     setMockResponse.get(
-      expect.stringContaining(`/api/v2/programs/?id=${programA.id}`),
-      { results: [programA] },
+      expect.stringContaining(`/api/v2/programs/?id=${programANoCourses.id}`),
+      { results: [programANoCourses] },
     )
     setMockResponse.get(
       expect.stringContaining(`/api/v2/programs/?id=${programB.id}`),
       { results: [programB] },
     )
 
-    // Mock programA to have no courses, programB to have courses
+    // Mock bulk course API call - only programB has courses, so only its first course should be included
+    const firstCourseBId = programB.courses[0]
+    const firstCourseB = coursesB.find((c) => c.id === firstCourseBId)
+
     setMockResponse.get(
-      expect.stringContaining(
-        `/api/v2/courses/?id=${programA.courses.join("%2C")}`,
-      ),
-      { results: [] },
-    )
-    setMockResponse.get(
-      expect.stringContaining(
-        `/api/v2/courses/?id=${programB.courses.join("%2C")}`,
-      ),
-      { results: coursesB },
+      expect.stringContaining(`/api/v2/courses/?id=${firstCourseBId}`),
+      { results: [firstCourseB] },
     )
 
     renderWithProviders(<OrganizationContent orgSlug={orgX.slug} />)
@@ -307,11 +366,11 @@ describe("OrganizationContent", () => {
     // Should see the collection header
     expect(collection.getByText(programCollection.title)).toBeInTheDocument()
 
-    // Should see programB's courses
+    // Should see programB's course
     await waitFor(() => {
-      expect(collection.getAllByText(coursesB[0].title).length).toBeGreaterThan(
-        0,
-      )
+      expect(
+        collection.getAllByText(firstCourseB!.title).length,
+      ).toBeGreaterThan(0)
     })
   })
 

--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
@@ -131,9 +131,9 @@ const ProgramDescription = styled(Typography)({
 // Custom hook to handle multiple program queries and check if any have courses
 const useProgramCollectionCourses = (programIds: number[], orgId: number) => {
   const programQueries = useQueries({
-    queries: programIds.map((programId) => ({
-      ...programsQueries.programsList({ id: programId, org_id: orgId }),
-    })),
+    queries: programIds.map((programId) =>
+      programsQueries.programsList({ id: programId, org_id: orgId }),
+    ),
   })
 
   const isLoading = programQueries.some((query) => query.isLoading)

--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
@@ -175,6 +175,25 @@ const OrgProgramCollectionDisplay: React.FC<{
   const sanitizedDescription = DOMPurify.sanitize(collection.description ?? "")
   const { isLoading, programsWithCourses, hasAnyCourses } =
     useProgramCollectionCourses(collection.programIds, orgId)
+  const firstCourseIds = programsWithCourses
+    .map((p) => p?.program.courseIds[0])
+    .filter((id): id is number => id !== undefined)
+  const courses = useQuery({
+    ...coursesQueries.coursesList({
+      id: firstCourseIds,
+      org_id: orgId,
+    }),
+    enabled: firstCourseIds.length > 0,
+  })
+  const rawCourses =
+    courses.data?.results.sort((a, b) => {
+      return firstCourseIds.indexOf(a.id) - firstCourseIds.indexOf(b.id)
+    }) ?? []
+  const transformedCourses = transform.organizationCoursesWithContracts({
+    courses: rawCourses,
+    contracts: contracts ?? [],
+    enrollments: enrollments ?? [],
+  })
 
   const header = (
     <ProgramHeader>
@@ -214,17 +233,26 @@ const OrgProgramCollectionDisplay: React.FC<{
     <ProgramRoot data-testid="org-program-collection-root">
       {header}
       <PlainList>
-        {programsWithCourses.map((item) =>
-          item ? (
-            <ProgramCollectionItem
-              key={item.programId}
-              program={item.program}
-              contracts={contracts}
-              enrollments={enrollments}
-              orgId={orgId}
+        {courses.isLoading &&
+          programsWithCourses.map((item) => (
+            <Skeleton
+              key={item?.programId}
+              width="100%"
+              height="65px"
+              style={{ marginBottom: "16px" }}
             />
-          ) : null,
-        )}
+          ))}
+        {transformedCourses.map((course) => (
+          <DashboardCardStyled
+            Component="li"
+            key={course.key}
+            dashboardResource={course}
+            courseNoun="Module"
+            offerUpgrade={false}
+            titleHref={course.run?.coursewareUrl}
+            buttonHref={course.run?.coursewareUrl}
+          />
+        ))}
       </PlainList>
     </ProgramRoot>
   )
@@ -260,8 +288,12 @@ const OrgProgramDisplay: React.FC<{
     <Skeleton width="100%" height="65px" style={{ marginBottom: "16px" }} />
   )
   if (programLoading || courses.isLoading) return skeleton
+  const rawCourses =
+    courses.data?.results.sort((a, b) => {
+      return program.courseIds.indexOf(a.id) - program.courseIds.indexOf(b.id)
+    }) ?? []
   const transformedCourses = transform.organizationCoursesWithContracts({
-    courses: courses.data?.results ?? [],
+    courses: rawCourses,
     contracts: contracts ?? [],
     enrollments: courseRunEnrollments ?? [],
   })
@@ -304,59 +336,6 @@ const OrgProgramDisplay: React.FC<{
         ))}
       </PlainList>
     </ProgramRoot>
-  )
-}
-
-const ProgramCollectionItem: React.FC<{
-  program: DashboardProgram
-  contracts?: ContractPage[]
-  enrollments?: CourseRunEnrollment[]
-  orgId: number
-}> = ({ program, contracts, enrollments, orgId }) => {
-  return (
-    <ProgramCard
-      program={program}
-      contracts={contracts}
-      enrollments={enrollments}
-      orgId={orgId}
-    />
-  )
-}
-
-const ProgramCard: React.FC<{
-  program: DashboardProgram
-  contracts?: ContractPage[]
-  enrollments?: CourseRunEnrollment[]
-  orgId: number
-}> = ({ program, contracts, enrollments, orgId }) => {
-  const courses = useQuery(
-    coursesQueries.coursesList({
-      id: program.courseIds,
-      org_id: orgId,
-    }),
-  )
-  const skeleton = (
-    <Skeleton width="100%" height="65px" style={{ marginBottom: "16px" }} />
-  )
-  if (courses.isLoading) return skeleton
-  const transformedCourses = transform.organizationCoursesWithContracts({
-    courses: courses.data?.results ?? [],
-    contracts: contracts ?? [],
-    enrollments: enrollments ?? [],
-  })
-  if (courses.isLoading || !transformedCourses.length) return skeleton
-  // For now we assume the first course is the main one for the program.
-  const course = transformedCourses[0]
-  return (
-    <DashboardCard
-      Component="li"
-      key={program.key}
-      dashboardResource={course}
-      courseNoun={"Module"}
-      offerUpgrade={false}
-      titleHref={course.run.coursewareUrl ?? ""}
-      buttonHref={course.run.coursewareUrl ?? ""}
-    />
   )
 }
 

--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
@@ -133,10 +133,6 @@ const useProgramCollectionCourses = (programIds: number[], orgId: number) => {
   const programQueries = useQueries({
     queries: programIds.map((programId) => ({
       ...programsQueries.programsList({ id: programId, org_id: orgId }),
-      queryKey: [
-        ...programsQueries.programsList({ id: programId, org_id: orgId })
-          .queryKey,
-      ],
     })),
   })
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/8626

### Description (What does it do?)
This PR fixes a bug with the ordering of courses within programs and program collections. The courses API endpoint in mitxonline does not respect the order that you pass ID's in when making a query for the detail of multiple courses. The courses end up being ordered alphabetically in a non-lexicographical manner. This PR does re-ordering on the frontend of the results so that the order matches the order of the ID's in the `courses` array on the program API response. The querying of the courses in a program collection has also been optimized to only use one query for all the first courses in each program in the collection, rather than making one query per collection.

### How can this be tested?
In order to test this, you need a basic installation of `mitxonline` up and running with example data in it. You may be able to skip one or more steps if you have already done them:
- Ensure you have local `hosts` redirects for the following domains, replacing the example IP with your __local__ IP address (Google how to get this if unsure, mine is 192.168.1.50)
```
192.168.1.50 open.odl.local
192.168.1.50 api.open.odl.local
192.168.1.50 kc.ol.local
192.168.1.50 mitxonline.odl.local
```
- Clone `mitxonline`: https://github.com/mitodl/mitxonline
- Create a `.env` file with the following values:
```
CELERY_TASK_ALWAYS_EAGER=True
DJANGO_LOG_LEVEL=INFO
LOG_LEVEL=INFO
SENTRY_LOG_LEVEL=ERROR
MAILGUN_KEY=fake
MAILGUN_URL=
MAILGUN_RECIPIENT_OVERRIDE=
MAILGUN_SENDER_DOMAIN=.odl.local
SECRET_KEY=
STATUS_TOKEN=
UWSGI_THREADS=5
SENTRY_DSN=
MITX_ONLINE_BASE_URL=http://open.odl.local:8065/mitxonline
MITX_ONLINE_ADMIN_CLIENT_ID=refine-local-client-id
MITX_ONLINE_ADMIN_BASE_URL=http://mitxonline.odl.local:8016
POSTHOG_PROJECT_API_KEY=
POSTHOG_API_HOST=https://app.posthog.com/
HUBSPOT_HOME_PAGE_FORM_GUID=
HUBSPOT_PORTAL_ID=
APISIX_PORT=9080

# APISIX/Keycloak settings
APISIX_LOGOUT_URL=http://api.open.odl.local:8065/logout/
APISIX_SESSION_SECRET_KEY=supertopsecret1234
KC_SPI_THEME_WELCOME_THEME=scim
KC_SPI_REALM_RESTAPI_EXTENSION_SCIM_LICENSE_KEY=
KEYCLOAK_BASE_URL=http://kc.ol.local:8066
KEYCLOAK_CLIENT_ID=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
KEYCLOAK_CLIENT_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
KEYCLOAK_DISCOVERY_URL=http://kc.ol.local:8066/realms/ol-local/.well-known/openid-configuration
KEYCLOAK_REALM_NAME=ol-local
KEYCLOAK_SCOPES="openid profile ol-profile"
KEYCLOAK_SVC_KEYSTORE_PASSWORD=supertopsecret1234
KEYCLOAK_SVC_HOSTNAME=kc.ol.local
KEYCLOAK_SVC_ADMIN=admin
KEYCLOAK_SVC_ADMIN_PASSWORD=admin
AUTHORIZATION_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/auth
ACCESS_TOKEN_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/token
OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_KEY=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
SOCIAL_AUTH_OL_OIDC_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
USERINFO_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/userinfo
MITOL_APIGATEWAY_DISABLE_MIDDLEWARE=False

FEATURE_IGNORE_EDX_FAILURES=True
OPENEDX_API_CLIENT_ID=fake
OPENEDX_API_CLIENT_SECRET=fake
OPENEDX_SERVICE_WORKER_API_TOKEN=fake

CSRF_COOKIE_DOMAIN=.odl.local
CORS_ALLOWED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
CSRF_TRUSTED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
```
- Spin up `mitxonline` with `docker compose up --build -d`
- Promote the admin user with `docker compose exec web ./manage.py promote_user promote --superuser --email admin@odl.local`
- Populate test course data with `docker compose exec web ./manage.py populate_course_data`
- Generate docs with `pants docs ::`
- In `dist/sphinx/index.html`, read the section on generating a B2B organization / contract and create one, adding all 10 of the test courses
- In Django admin, create a `Program` and add all of the courses to the program that are included in your B2B org, making sure to mark the program as "live"
- Create a few more programs with 1 or 2 courses from the test courses
- Navigate to Wagtail at http://mitxonline.odl.local:8065/cms
- Browse to Home Page -> Program Collections
- Create a new program collection
- Add the extra programs you created above
- Make sure you have a personal Posthog project configured and have the API key at the ready
- Before we spin up `mit-learn`, we need to set some env variables:
```
.env
...
MITX_ONLINE_UPSTREAM=mitxonline.odl.local:8013
MITX_ONLINE_DOMAIN=mitxonline.odl.local
MITX_ONLINE_BASE_URL=http://mitxonline.odl.local:8065
POSTHOG_ENABLED=True
CSRF_COOKIE_DOMAIN=.odl.local

shared.local.env
POSTHOG_PROJECT_API_KEY=YOUR_API_KEY_HERE
POSTHOG_PROJECT_ID=YOUR_PROJECT_ID_HERE
POSTHOG_TIMEOUT_MS=1500
```
- In your Posthog project, enable the `enrollment-dashboard` and `mitlearn-organization-dashboard` feature flags for all users
- Spin up `MIT Learn`
- Go to the org dashboard for the org you created
- Ensure that Case 10 is displayed at the bottom of the list on the first program you created, and not at the top
- Ensure that the first course for each program is displayed in the correct order in the program collection