### PR TITLE
add "just in time" dialog

### DIFF
--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -30,7 +30,7 @@
     "ol-test-utilities": "0.0.0"
   },
   "dependencies": {
-    "@mitodl/mitxonline-api-axios": "^2025.9.26",
+    "@mitodl/mitxonline-api-axios": "^2025.9.30",
     "@tanstack/react-query": "^5.66.0",
     "axios": "^1.12.2"
   }

--- a/frontends/api/src/mitxonline/clients.ts
+++ b/frontends/api/src/mitxonline/clients.ts
@@ -9,6 +9,7 @@ import {
   UsersApi,
   ProgramEnrollmentsApi,
   PagesApi,
+  CountriesApi,
 } from "@mitodl/mitxonline-api-axios/v2"
 import axios from "axios"
 
@@ -25,6 +26,7 @@ const BASE_PATH =
   process.env.NEXT_PUBLIC_MITX_ONLINE_BASE_URL?.replace(/\/+$/, "") ?? ""
 
 const usersApi = new UsersApi(undefined, BASE_PATH, axiosInstance)
+const countriesApi = new CountriesApi(undefined, BASE_PATH, axiosInstance)
 const b2bApi = new B2bApi(undefined, BASE_PATH, axiosInstance)
 const programsApi = new ProgramsApi(undefined, BASE_PATH, axiosInstance)
 const programCollectionsApi = new ProgramCollectionsApi(
@@ -63,6 +65,7 @@ const pagesApi = new PagesApi(undefined, BASE_PATH, axiosInstance)
 
 export {
   usersApi,
+  countriesApi,
   b2bApi,
   courseRunEnrollmentsApi,
   programEnrollmentsApi,

--- a/frontends/api/src/mitxonline/hooks/user/index.ts
+++ b/frontends/api/src/mitxonline/hooks/user/index.ts
@@ -1,12 +1,13 @@
-import { useQuery } from "@tanstack/react-query"
-import { usersApi } from "../../clients"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { countriesApi, usersApi } from "../../clients"
 import type { User } from "@mitodl/mitxonline-api-axios/v2"
+import { UsersApiUsersMePartialUpdateRequest } from "@mitodl/mitxonline-api-axios/v2"
 
-const useMitxOnlineCurrentUser = (opts: { enabled?: boolean } = {}) =>
+const useMitxOnlineUserMe = (opts: { enabled?: boolean } = {}) =>
   useQuery({
     queryKey: ["mitxonline", "currentUser"],
     queryFn: async (): Promise<User> => {
-      const response = await usersApi.usersCurrentUserRetrieve()
+      const response = await usersApi.usersMeRetrieve()
       return {
         ...response.data,
       }
@@ -14,5 +15,25 @@ const useMitxOnlineCurrentUser = (opts: { enabled?: boolean } = {}) =>
     ...opts,
   })
 
-export { useMitxOnlineCurrentUser }
+const useMitxOnlineCountries = () =>
+  useQuery({
+    queryKey: ["mitxonline", "countries"],
+    queryFn: async (): Promise<{ code: string; name: string }[]> => {
+      const response = await countriesApi.countriesList()
+      return response.data
+    },
+  })
+
+const useUpdateUserMutation = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (opts: UsersApiUsersMePartialUpdateRequest) =>
+      usersApi.usersMePartialUpdate(opts),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["mitxonline", "currentUser"] })
+    },
+  })
+}
+
+export { useMitxOnlineCountries, useMitxOnlineUserMe, useUpdateUserMutation }
 export type { User as MitxOnlineUser }

--- a/frontends/api/src/mitxonline/hooks/user/index.ts
+++ b/frontends/api/src/mitxonline/hooks/user/index.ts
@@ -1,28 +1,43 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  queryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 import { countriesApi, usersApi } from "../../clients"
 import type { User } from "@mitodl/mitxonline-api-axios/v2"
 import { UsersApiUsersMePartialUpdateRequest } from "@mitodl/mitxonline-api-axios/v2"
 
-const useMitxOnlineUserMe = (opts: { enabled?: boolean } = {}) =>
-  useQuery({
-    queryKey: ["mitxonline", "currentUser"],
-    queryFn: async (): Promise<User> => {
-      const response = await usersApi.usersMeRetrieve()
-      return {
-        ...response.data,
-      }
-    },
-    ...opts,
-  })
+const userKeys = {
+  root: ["mitxonline", "users"] as const,
+  me: () => [...userKeys.root, "me"] as const,
+  countries: () => ["mitxonline", "countries"] as const,
+}
 
-const useMitxOnlineCountries = () =>
-  useQuery({
-    queryKey: ["mitxonline", "countries"],
-    queryFn: async (): Promise<{ code: string; name: string }[]> => {
-      const response = await countriesApi.countriesList()
-      return response.data
-    },
-  })
+const queries = {
+  me: () =>
+    queryOptions({
+      queryKey: userKeys.me(),
+      queryFn: async () => {
+        const response = await usersApi.usersMeRetrieve()
+        return response.data
+      },
+    }),
+  countries: () =>
+    queryOptions({
+      queryKey: userKeys.countries(),
+      queryFn: async () => {
+        const response = await countriesApi.countriesList()
+        return response.data
+      },
+    }),
+}
+
+/**
+ * @deprecated Prefer direct use of queries.me()
+ */
+const useMitxOnlineUserMe = (opts: { enabled?: boolean } = {}) =>
+  useQuery({ ...queries.me(), ...opts })
 
 const useUpdateUserMutation = () => {
   const queryClient = useQueryClient()
@@ -30,10 +45,14 @@ const useUpdateUserMutation = () => {
     mutationFn: (opts: UsersApiUsersMePartialUpdateRequest) =>
       usersApi.usersMePartialUpdate(opts),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["mitxonline", "currentUser"] })
+      queryClient.invalidateQueries({ queryKey: userKeys.me() })
     },
   })
 }
 
-export { useMitxOnlineCountries, useMitxOnlineUserMe, useUpdateUserMutation }
+export {
+  queries as mitxUserQueries,
+  useMitxOnlineUserMe,
+  useUpdateUserMutation,
+}
 export type { User as MitxOnlineUser }

--- a/frontends/api/src/mitxonline/test-utils/factories/pages.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/pages.ts
@@ -244,6 +244,7 @@ const programPageItem: PartialFactory<ProgramPageItem> = (override) => {
           name: faker.person.fullName(),
           title_1: faker.person.jobTitle(),
           title_2: faker.person.jobTitle(),
+          title_3: "",
           organization: "Massachusetts Institute of Technology",
           signature_image: faker.image.urlLoremFlickr({
             width: 200,

--- a/frontends/api/src/mitxonline/test-utils/urls.ts
+++ b/frontends/api/src/mitxonline/test-utils/urls.ts
@@ -5,14 +5,12 @@ import type {
   ProgramCollectionsApiProgramCollectionsListRequest,
   ProgramsApiProgramsListV2Request,
 } from "@mitodl/mitxonline-api-axios/v2"
-import { RawAxiosRequestConfig } from "axios"
 import { queryify } from "ol-test-utilities"
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_MITX_ONLINE_BASE_URL
 
-const currentUser = {
-  get: (opts?: RawAxiosRequestConfig) =>
-    `${API_BASE_URL}/api/v0/users/current_user/${queryify(opts)}`,
+const userMe = {
+  get: () => `${API_BASE_URL}/api/v0/users/me`,
 }
 
 const enrollment = {
@@ -83,7 +81,7 @@ const certificates = {
 export {
   b2b,
   b2bAttach,
-  currentUser,
+  userMe,
   enrollment,
   programs,
   programCollections,

--- a/frontends/api/src/mitxonline/test-utils/urls.ts
+++ b/frontends/api/src/mitxonline/test-utils/urls.ts
@@ -13,6 +13,10 @@ const userMe = {
   get: () => `${API_BASE_URL}/api/v0/users/me`,
 }
 
+const countries = {
+  list: () => `${API_BASE_URL}/api/v0/countries/`,
+}
+
 const enrollment = {
   enrollmentsList: () => `${API_BASE_URL}/api/v1/enrollments/`,
   courseEnrollment: (id?: number) =>
@@ -82,6 +86,7 @@ export {
   b2b,
   b2bAttach,
   userMe,
+  countries,
   enrollment,
   programs,
   programCollections,

--- a/frontends/api/src/test-utils/mockAxios.ts
+++ b/frontends/api/src/test-utils/mockAxios.ts
@@ -14,9 +14,13 @@ type RequestMaker = (
   body?: unknown,
 ) => Promise<PartialAxiosResponse>
 
-const alwaysError: RequestMaker = (method, url, _body) => {
+const alwaysError: RequestMaker = (method, url, body) => {
   const msg = `No response specified for ${method} ${url}`
   console.error(msg)
+  if (body) {
+    console.error("and body:")
+    console.error(body)
+  }
   throw new Error(msg)
 }
 

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -62,6 +62,7 @@
     "next-router-mock": "^1.0.2",
     "ol-test-utilities": "0.0.0",
     "ts-jest": "^29.2.4",
+    "type-fest": "^5.0.1",
     "typescript": "^5"
   }
 }

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -14,7 +14,7 @@
     "@emotion/cache": "^11.13.1",
     "@emotion/styled": "^11.11.0",
     "@mitodl/course-search-utils": "3.3.2",
-    "@mitodl/mitxonline-api-axios": "^2025.9.26",
+    "@mitodl/mitxonline-api-axios": "^2025.9.30",
     "@mitodl/smoot-design": "^6.17.1",
     "@next/bundle-analyzer": "^14.2.15",
     "@react-pdf/renderer": "^4.3.0",

--- a/frontends/main/src/app-pages/B2BAttachPage/B2BAttachPage.test.tsx
+++ b/frontends/main/src/app-pages/B2BAttachPage/B2BAttachPage.test.tsx
@@ -30,7 +30,7 @@ describe("B2BAttachPage", () => {
       [Permission.Authenticated]: false,
     })
 
-    setMockResponse.get(mitxOnlineUrls.currentUser.get(), null)
+    setMockResponse.get(mitxOnlineUrls.userMe.get(), null)
     setMockResponse.post(b2bUrls.b2bAttach.b2bAttachView("test-code"), [])
 
     renderWithProviders(<B2BAttachPage code="test-code" />, {
@@ -58,7 +58,7 @@ describe("B2BAttachPage", () => {
     })
 
     setMockResponse.get(
-      mitxOnlineUrls.currentUser.get(),
+      mitxOnlineUrls.userMe.get(),
       mitxOnlineFactories.user.user(),
     )
 
@@ -88,7 +88,7 @@ describe("B2BAttachPage", () => {
       [Permission.Authenticated]: true,
     })
 
-    setMockResponse.get(mitxOnlineUrls.currentUser.get(), mitxOnlineUser)
+    setMockResponse.get(mitxOnlineUrls.userMe.get(), mitxOnlineUser)
 
     setMockResponse.post(b2bUrls.b2bAttach.b2bAttachView("test-code"), [])
 

--- a/frontends/main/src/app-pages/B2BAttachPage/B2BAttachPage.tsx
+++ b/frontends/main/src/app-pages/B2BAttachPage/B2BAttachPage.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { styled, Breadcrumbs, Container, Typography } from "ol-components"
 import * as urls from "@/common/urls"
 import { useB2BAttachMutation } from "api/mitxonline-hooks/organizations"
-import { useMitxOnlineCurrentUser } from "api/mitxonline-hooks/user"
+import { useMitxOnlineUserMe } from "api/mitxonline-hooks/user"
 import { userQueries } from "api/hooks/user"
 import { useQuery } from "@tanstack/react-query"
 import { useRouter } from "next-nprogress-bar"
@@ -31,7 +31,7 @@ const B2BAttachPage: React.FC<B2BAttachPageProps> = ({ code }) => {
     ...userQueries.me(),
     staleTime: 0,
   })
-  const { data: mitxOnlineUser } = useMitxOnlineCurrentUser()
+  const { data: mitxOnlineUser } = useMitxOnlineUserMe()
 
   React.useEffect(() => {
     attach?.()

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -487,6 +487,19 @@ describe.each([
         status: EnrollmentStatus.NotEnrolled,
       },
     })
+
+    // Mock user without country and year_of_birth to trigger JustInTimeDialog
+    const baseUser = mitxonline.factories.user.user()
+    const mitxUserWithoutRequiredFields = {
+      ...baseUser,
+      legal_address: { ...baseUser.legal_address, country: undefined },
+      user_profile: { ...baseUser.user_profile, year_of_birth: undefined },
+    }
+    setMockResponse.get(
+      mitxonline.urls.userMe.get(),
+      mitxUserWithoutRequiredFields,
+    )
+
     setMockResponse.post(
       mitxonline.urls.b2b.courseEnrollment(course.coursewareId ?? undefined),
       { result: "b2b-enroll-success", order: 1 },

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -8,12 +8,16 @@ import {
   expectWindowNavigation,
 } from "@/test-utils"
 import * as mitxonline from "api/mitxonline-test-utils"
+import {
+  urls as testUrls,
+  factories as testFactories,
+  mockAxiosInstance,
+} from "api/test-utils"
 import { DashboardCard, getDefaultContextMenuItems } from "./DashboardCard"
 import { dashboardCourse } from "./test-utils"
 import { faker } from "@faker-js/faker/locale/en"
 import moment from "moment"
 import { EnrollmentMode, EnrollmentStatus } from "./types"
-import { mockAxiosInstance } from "api/test-utils"
 
 const pastDashboardCourse: typeof dashboardCourse = (...overrides) => {
   return dashboardCourse(
@@ -48,6 +52,14 @@ const futureDashboardCourse: typeof dashboardCourse = (...overrides) => {
     ...overrides,
   )
 }
+
+beforeEach(() => {
+  // Mock user API call
+  const user = testFactories.user.user()
+  const mitxUser = mitxonline.factories.user.user()
+  setMockResponse.get(testUrls.userMe.get(), user)
+  setMockResponse.get(mitxonline.urls.userMe.get(), mitxUser)
+})
 
 describe.each([
   { display: "desktop", testId: "enrollment-card-desktop" },

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -188,9 +188,11 @@ const CoursewareButton = styled(
           className={className}
           disabled={createEnrollment.isPending || !coursewareId}
           onClick={async () => {
+            if (!href || !coursewareId) return
             if (showJustInTimeDialog) {
               NiceModal.show(JustInTimeDialog, {
-                href: href ?? undefined,
+                href: href,
+                readableId: coursewareId,
               })
               return
             } else {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -168,7 +168,7 @@ const CoursewareButton = styled(
     const createEnrollment = useCreateEnrollment()
     const userCountry = mitxOnlineUser.data?.legal_address?.country
     const userYearOfBirth = mitxOnlineUser.data?.user_profile?.year_of_birth
-    const showJustInTimeModal = !userCountry || !userYearOfBirth
+    const showJustInTimeDialog = !userCountry || !userYearOfBirth
     return (hasStarted && href) || !hasEnrolled ? (
       hasEnrolled && href ? (
         <ButtonLink
@@ -188,7 +188,7 @@ const CoursewareButton = styled(
           className={className}
           disabled={createEnrollment.isPending || !coursewareId}
           onClick={async () => {
-            if (showJustInTimeModal) {
+            if (showJustInTimeDialog) {
               NiceModal.show(JustInTimeDialog, {
                 href: href ?? undefined,
               })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -197,12 +197,10 @@ const CoursewareButton = styled(
               return
             } else {
               await createEnrollment.mutateAsync(
-                { readable_id: coursewareId ?? "" },
+                { readable_id: coursewareId },
                 {
                   onSuccess: () => {
-                    if (href) {
-                      window.location.href = href
-                    }
+                    window.location.href = href
                   },
                 },
               )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
@@ -7,12 +7,18 @@ import {
   within,
 } from "@/test-utils"
 import { EnrollmentDisplay } from "./EnrollmentDisplay"
+import { DashboardCard } from "./DashboardCard"
+import { dashboardCourse, setupEnrollments } from "./test-utils"
 import * as mitxonline from "api/mitxonline-test-utils"
+import {
+  urls as testUrls,
+  factories as testFactories,
+  mockAxiosInstance,
+} from "api/test-utils"
 import { useFeatureFlagEnabled } from "posthog-js/react"
-import { setupEnrollments } from "./test-utils"
 import { faker } from "@faker-js/faker/locale/en"
-import { mockAxiosInstance } from "api/test-utils"
 import invariant from "tiny-invariant"
+import { EnrollmentStatus } from "./types"
 
 jest.mock("posthog-js/react")
 const mockedUseFeatureFlagEnabled = jest
@@ -130,5 +136,141 @@ describe("DashboardDialogs", () => {
         url: mitxonline.urls.enrollment.courseEnrollment(enrollment.id),
       }),
     )
+  })
+
+  describe("JustInTimeDialog", () => {
+    const setupJustInTimeTest = () => {
+      // Setup MIT Learn user
+      const mitLearnUser = testFactories.user.user()
+      setMockResponse.get(testUrls.userMe.get(), mitLearnUser)
+
+      // Setup incomplete mitxonline user (missing country and year_of_birth)
+      const incompleteMitxUser = mitxonline.factories.user.user({
+        legal_address: null,
+        user_profile: null,
+      })
+      setMockResponse.get(mitxonline.urls.userMe.get(), incompleteMitxUser)
+
+      // Setup countries data
+      const countries = [
+        { code: "US", name: "United States" },
+        { code: "CA", name: "Canada" },
+        { code: "GB", name: "United Kingdom" },
+      ]
+      setMockResponse.get(mitxonline.urls.countries.list(), countries)
+
+      // Setup course for enrollment
+      const course = dashboardCourse({
+        enrollment: { status: EnrollmentStatus.NotEnrolled },
+        marketingUrl: "https://example.com/course",
+      })
+
+      // Setup enrollment API
+      setMockResponse.post(
+        mitxonline.urls.b2b.courseEnrollment(course.coursewareId || ""),
+        null,
+      )
+
+      return { mitLearnUser, incompleteMitxUser, countries, course }
+    }
+
+    test("Opens just-in-time dialog when enrolling with incomplete mitxonline user data", async () => {
+      const { course } = setupJustInTimeTest()
+
+      renderWithProviders(<DashboardCard dashboardResource={course} />)
+
+      const enrollButtons = await screen.findAllByTestId("courseware-button")
+      await user.click(enrollButtons[0]) // Use the first (desktop) button
+
+      const dialog = await screen.findByRole("dialog", {
+        name: "Just a Few More Details",
+      })
+      expect(dialog).toBeInTheDocument()
+
+      expect(
+        within(dialog).getByText(
+          "We need a bit more info before you can enroll.",
+        ),
+      ).toBeInTheDocument()
+      expect(within(dialog).getByLabelText("Country")).toBeInTheDocument()
+      expect(within(dialog).getByLabelText("Year of Birth")).toBeInTheDocument()
+    })
+
+    test("Validates required fields in just-in-time dialog", async () => {
+      const { course } = setupJustInTimeTest()
+
+      renderWithProviders(<DashboardCard dashboardResource={course} />)
+
+      const enrollButtons = await screen.findAllByTestId("courseware-button")
+      await user.click(enrollButtons[0]) // Use the first (desktop) button
+
+      const dialog = await screen.findByRole("dialog", {
+        name: "Just a Few More Details",
+      })
+
+      const submitButton = within(dialog).getByRole("button", {
+        name: "Submit",
+      })
+
+      // Try submitting with empty fields - should show validation errors
+      await user.click(submitButton)
+
+      // Should show validation errors
+      await screen.findByText("Country is required")
+      await screen.findByText("Year of birth is required")
+    })
+
+    test("Generates correct year of birth options (minimum age 13)", async () => {
+      const { course } = setupJustInTimeTest()
+
+      renderWithProviders(<DashboardCard dashboardResource={course} />)
+
+      const enrollButtons = await screen.findAllByTestId("courseware-button")
+      await user.click(enrollButtons[0]) // Use the first (desktop) button
+
+      const dialog = await screen.findByRole("dialog", {
+        name: "Just a Few More Details",
+      })
+
+      const yearSelect = within(dialog).getByLabelText("Year of Birth")
+      await user.click(yearSelect)
+
+      const currentYear = new Date().getFullYear()
+      const maxYear = currentYear - 13
+
+      // Should include the max allowed year
+      expect(screen.getByText(maxYear.toString())).toBeInTheDocument()
+
+      // Should NOT include years that would make someone under 13
+      expect(
+        screen.queryByText((currentYear - 12).toString()),
+      ).not.toBeInTheDocument()
+    })
+
+    test("Cancels just-in-time dialog without making API calls", async () => {
+      const { course } = setupJustInTimeTest()
+
+      renderWithProviders(<DashboardCard dashboardResource={course} />)
+
+      const enrollButtons = await screen.findAllByTestId("courseware-button")
+      await user.click(enrollButtons[0]) // Use the first (desktop) button
+
+      const dialog = await screen.findByRole("dialog", {
+        name: "Just a Few More Details",
+      })
+
+      const cancelButton = within(dialog).getByRole("button", {
+        name: "Cancel",
+      })
+      await user.click(cancelButton)
+
+      // No PATCH calls should have been made
+      expect(mockAxiosInstance.request).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "PATCH",
+          url: mitxonline.urls.userMe.get(),
+        }),
+      )
+    })
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
@@ -21,6 +21,8 @@ const mockedUseFeatureFlagEnabled = jest
 
 describe("DashboardDialogs", () => {
   const setupApis = (includeExpired: boolean = true) => {
+    const mitxOnlineUser = mitxonline.factories.user.user()
+    setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)
     const { enrollments, completed, expired, started, notStarted } =
       setupEnrollments(includeExpired)
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
@@ -6,6 +6,7 @@ import {
   DialogActions,
   Stack,
   LoadingSpinner,
+  SimpleSelectField,
 } from "ol-components"
 import { Button, Checkbox, Alert } from "@mitodl/smoot-design"
 
@@ -284,63 +285,55 @@ const JustInTimeDialogInner: React.FC<{ href: string }> = ({ href }) => {
           We need a bit more info before you can enroll.
         </Typography>
 
-        <div>
-          <label htmlFor="country">Country *</label>
-          <select
-            id="country"
-            name="country"
-            value={formik.values.country}
-            onChange={formik.handleChange}
-            style={{
-              width: "100%",
-              padding: "8px",
-              marginTop: "4px",
-              border: "1px solid #ccc",
-              borderRadius: "4px",
-            }}
-          >
-            <option value="">Select a country</option>
-            {countries?.map((country) => (
-              <option key={country.code} value={country.code}>
-                {country.name}
-              </option>
-            ))}
-          </select>
-          {formik.errors.country && (
-            <Typography variant="body2" color="error">
-              {formik.errors.country}
-            </Typography>
+        <SimpleSelectField
+          options={[
+            {
+              value: "",
+              label: "Please Select",
+            },
+          ].concat(
+            countries
+              ? countries.map((country) => ({
+                  value: country.code,
+                  label: country.name,
+                }))
+              : [],
           )}
-        </div>
+          name="country"
+          label="Country"
+          value={formik.values.country}
+          onChange={formik.handleChange}
+          fullWidth
+        />
+        {formik.errors.country && (
+          <Typography variant="body2" color="error">
+            {formik.errors.country}
+          </Typography>
+        )}
 
-        <div>
-          <label htmlFor="year_of_birth">Year of Birth *</label>
-          <select
-            id="year_of_birth"
-            name="year_of_birth"
-            value={formik.values.year_of_birth}
-            onChange={formik.handleChange}
-            style={{
-              width: "100%",
-              padding: "8px",
-              marginTop: "4px",
-              border: "1px solid #ccc",
-              borderRadius: "4px",
-            }}
-          >
-            <option value="">Select year</option>
-            {yearOptions.map((year) => (
-              <option key={year} value={year}>
-                {year}
-              </option>
-            ))}
-          </select>
-          {formik.errors.year_of_birth && (
-            <Typography variant="body2" color="error">
-              {formik.errors.year_of_birth}
-            </Typography>
+        <SimpleSelectField
+          options={[
+            {
+              value: "",
+              label: "Please Select",
+            },
+          ].concat(
+            yearOptions.map((year) => ({
+              value: year.toString(),
+              label: year.toString(),
+            })),
           )}
-        </div>
+          name="year_of_birth"
+          label="Year of Birth"
+          value={formik.values.year_of_birth}
+          onChange={formik.handleChange}
+          fullWidth
+        />
+        {formik.errors.year_of_birth && (
+          <Typography variant="body2" color="error">
+            {formik.errors.year_of_birth}
+          </Typography>
+        )}
       </Stack>
     </FormDialog>
   )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
@@ -9,6 +9,7 @@ import {
   SimpleSelectField,
 } from "ol-components"
 import { Button, Checkbox, Alert } from "@mitodl/smoot-design"
+import { useQuery } from "@tanstack/react-query"
 
 import NiceModal, { muiDialogV5 } from "@ebay/nice-modal-react"
 import { useFormik } from "formik"
@@ -18,9 +19,8 @@ import {
 } from "api/mitxonline-hooks/enrollment"
 import { DashboardCourseEnrollment } from "./types"
 import {
-  useMitxOnlineCountries,
+  mitxUserQueries,
   useUpdateUserMutation,
-  useMitxOnlineUserMe,
 } from "api/mitxonline-hooks/user"
 import * as Yup from "yup"
 
@@ -199,9 +199,9 @@ const jitSchema = Yup.object().shape({
 })
 
 const JustInTimeDialogInner: React.FC<{ href: string }> = ({ href }) => {
-  const { data: countries } = useMitxOnlineCountries()
+  const { data: countries } = useQuery(mitxUserQueries.countries())
   const updateUserMutation = useUpdateUserMutation()
-  const user = useMitxOnlineUserMe()
+  const user = useQuery(mitxUserQueries.me())
   const modal = NiceModal.useModal()
 
   // Generate year options (minimum age 13, so current year - 13 back to 1900)

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
@@ -7,6 +7,7 @@ import {
   Stack,
   LoadingSpinner,
   SimpleSelectField,
+  SimpleSelectOption,
 } from "ol-components"
 import { Button, Checkbox, Alert } from "@mitodl/smoot-design"
 import { useQuery } from "@tanstack/react-query"
@@ -207,9 +208,8 @@ const JustInTimeDialogInner: React.FC<{ href: string }> = ({ href }) => {
   // Generate year options (minimum age 13, so current year - 13 back to 1900)
   const currentYear = new Date().getFullYear()
   const maxYear = currentYear - 13
-  const yearOptions = Array.from(
-    { length: maxYear - 1900 + 1 },
-    (_, i) => maxYear - i,
+  const years = Array.from({ length: maxYear - 1900 + 1 }, (_, i) =>
+    (maxYear - i).toString(),
   )
 
   const yob = user?.data?.user_profile?.year_of_birth
@@ -242,10 +242,17 @@ const JustInTimeDialogInner: React.FC<{ href: string }> = ({ href }) => {
       }
     },
   })
-
-  const renderSelectValue = (value: string | string[]) => {
-    return value || <SelectPlaceholder>Please Select</SelectPlaceholder>
-  }
+  const countryOptions: SimpleSelectOption[] = [
+    { value: "", label: "Please Select", disabled: true },
+    ...(countries?.map(({ code, name }) => ({ value: code, label: name })) ??
+      []),
+  ]
+  const yobOptions: SimpleSelectOption[] = [
+    { value: "", label: "Please Select", disabled: true },
+    ...years.map((year): SimpleSelectOption => ({ value: year, label: year })),
+  ]
+  window.formik = formik
+  window.yobOptions = yobOptions
 
   return (
     <FormDialog
@@ -281,48 +288,34 @@ const JustInTimeDialogInner: React.FC<{ href: string }> = ({ href }) => {
         </Typography>
 
         <SimpleSelectField
-          options={[
-            {
-              value: "",
-              label: "Please Select",
-            },
-          ].concat(
-            countries
-              ? countries.map((country) => ({
-                  value: country.code,
-                  label: country.name,
-                }))
-              : [],
-          )}
+          options={countryOptions}
           name="country"
           label="Country"
-          value={formik.values.country}
+          value={countries ? formik.values.country : ""}
           onChange={formik.handleChange}
-          renderValue={renderSelectValue}
           fullWidth
           required
+          renderValue={
+            formik.values.country
+              ? undefined
+              : () => <SelectPlaceholder>Please Select</SelectPlaceholder>
+          }
           error={!!formik.errors.country}
           errorText={formik.errors.country}
         />
         <SimpleSelectField
-          options={[
-            {
-              value: "",
-              label: "Please Select",
-            },
-          ].concat(
-            yearOptions.map((year) => ({
-              value: year.toString(),
-              label: year.toString(),
-            })),
-          )}
+          options={yobOptions}
           name="year_of_birth"
           label="Year of Birth"
           value={formik.values.year_of_birth}
           onChange={formik.handleChange}
-          renderValue={renderSelectValue}
           fullWidth
           required
+          renderValue={
+            formik.values.year_of_birth
+              ? undefined
+              : () => <SelectPlaceholder>Please Select</SelectPlaceholder>
+          }
           error={!!formik.errors.year_of_birth}
           errorText={formik.errors.year_of_birth}
         />

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
@@ -257,18 +257,13 @@ const JustInTimeDialogInner: React.FC<{ href: string }> = ({ href }) => {
       {...muiDialogV5(modal)}
       actions={
         <DialogActions>
-          <Button
-            variant="secondary"
-            onClick={() => {
-              modal.hide()
-            }}
-          >
+          <Button variant="secondary" onClick={modal.hide}>
             Cancel
           </Button>
           <Button
             variant="primary"
             type="submit"
-            disabled={!formik.isValid || formik.isSubmitting}
+            disabled={formik.isSubmitting}
           >
             Submit
             {formik.isSubmitting && (
@@ -306,6 +301,7 @@ const JustInTimeDialogInner: React.FC<{ href: string }> = ({ href }) => {
           renderValue={renderSelectValue}
           fullWidth
           required
+          error={!!formik.errors.country}
           errorText={formik.errors.country}
         />
         <SimpleSelectField
@@ -327,6 +323,7 @@ const JustInTimeDialogInner: React.FC<{ href: string }> = ({ href }) => {
           renderValue={renderSelectValue}
           fullWidth
           required
+          error={!!formik.errors.year_of_birth}
           errorText={formik.errors.year_of_birth}
         />
       </Stack>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
@@ -31,6 +31,10 @@ const SpinnerContainer = styled.div({
   marginLeft: "8px",
 })
 
+const SelectPlaceholder = styled("span")(({ theme }) => ({
+  color: theme.custom.colors.silverGrayDark,
+}))
+
 type DashboardDialogProps = {
   title: string
   enrollment: DashboardCourseEnrollment
@@ -248,6 +252,10 @@ const JustInTimeDialogInner: React.FC<{ href: string }> = ({ href }) => {
     },
   })
 
+  const renderSelectValue = (value: string | string[]) => {
+    return value || <SelectPlaceholder>Please Select</SelectPlaceholder>
+  }
+
   return (
     <FormDialog
       title="Just a Few More Details"
@@ -303,6 +311,7 @@ const JustInTimeDialogInner: React.FC<{ href: string }> = ({ href }) => {
           label="Country"
           value={formik.values.country}
           onChange={formik.handleChange}
+          renderValue={renderSelectValue}
           fullWidth
         />
         {formik.errors.country && (
@@ -327,6 +336,7 @@ const JustInTimeDialogInner: React.FC<{ href: string }> = ({ href }) => {
           label="Year of Birth"
           value={formik.values.year_of_birth}
           onChange={formik.handleChange}
+          renderValue={renderSelectValue}
           fullWidth
         />
         {formik.errors.year_of_birth && (

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
@@ -244,7 +244,7 @@ const JustInTimeDialogInner: React.FC<{ href: string; readableId: string }> = ({
       await createEnrollment.mutateAsync({
         readable_id: readableId,
       })
-      window.location.href = href
+      window.location.assign(href)
       modal.hide()
     },
   })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
@@ -19,7 +19,6 @@ import {
 import { DashboardCourseEnrollment } from "./types"
 import {
   useMitxOnlineCountries,
-  useMitxOnlineUserMe,
   useUpdateUserMutation,
 } from "api/mitxonline-hooks/user"
 
@@ -193,7 +192,6 @@ const UnenrollDialogInner: React.FC<DashboardDialogProps> = ({
 }
 
 const JustInTimeDialogInner: React.FC<{ href: string }> = ({ href }) => {
-  const { data: mitxOnlineUser } = useMitxOnlineUserMe()
   const { data: countries } = useMitxOnlineCountries()
   const updateUserMutation = useUpdateUserMutation()
   const modal = NiceModal.useModal()
@@ -232,14 +230,6 @@ const JustInTimeDialogInner: React.FC<{ href: string }> = ({ href }) => {
           },
           legal_address: {
             country: values.country,
-            first_name:
-              mitxOnlineUser?.legal_address?.first_name ||
-              mitxOnlineUser?.name?.split(" ")[0] ||
-              "",
-            last_name:
-              mitxOnlineUser?.legal_address?.last_name ||
-              mitxOnlineUser?.name?.split(" ")[1] ||
-              "",
           },
         },
       })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
@@ -18,6 +18,8 @@ const mockedUseFeatureFlagEnabled = jest
 
 describe("EnrollmentDisplay", () => {
   const setupApis = (includeExpired: boolean = true) => {
+    const mitxOnlineUser = mitxonline.factories.user.user()
+    setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)
     const { enrollments, completed, expired, started, notStarted } =
       setupEnrollments(includeExpired)
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/test-utils.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/test-utils.ts
@@ -122,7 +122,7 @@ const setupProgramsAndCourses = () => {
   const orgX = factories.organizations.organization({ name: "Org X" })
   const mitxOnlineUser = factories.user.user({ b2b_organizations: [orgX] })
   setMockResponse.get(u.urls.userMe.get(), user)
-  setMockResponse.get(urls.currentUser.get(), mitxOnlineUser)
+  setMockResponse.get(urls.userMe.get(), mitxOnlineUser)
   setMockResponse.get(urls.organization.organizationList(""), orgX)
   setMockResponse.get(urls.organization.organizationList(orgX.slug), orgX)
 
@@ -244,7 +244,7 @@ function setupOrgDashboardMocks(
 ) {
   // Basic user and org setup
   setMockResponse.get(u.urls.userMe.get(), user)
-  setMockResponse.get(mitxonline.urls.currentUser.get(), mitxOnlineUser)
+  setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)
   setMockResponse.get(
     mitxonline.urls.organization.organizationList(org.slug),
     org,

--- a/frontends/main/src/app-pages/DashboardPage/DashboardLayout.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/DashboardLayout.test.tsx
@@ -46,7 +46,7 @@ describe("DashboardLayout", () => {
     })
 
     setMockResponse.get(urls.userMe.get(), user)
-    setMockResponse.get(mitxOnlineUrls.currentUser.get(), user)
+    setMockResponse.get(mitxOnlineUrls.userMe.get(), user)
 
     renderWithProviders(
       <DashboardLayout>

--- a/frontends/main/src/app-pages/DashboardPage/DashboardLayout.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/DashboardLayout.tsx
@@ -33,10 +33,7 @@ import {
   SETTINGS,
 } from "@/common/urls"
 import dynamic from "next/dynamic"
-import {
-  useMitxOnlineCurrentUser,
-  MitxOnlineUser,
-} from "api/mitxonline-hooks/user"
+import { useMitxOnlineUserMe, MitxOnlineUser } from "api/mitxonline-hooks/user"
 import { useUserMe } from "api/hooks/user"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { FeatureFlags } from "@/common/feature_flags"
@@ -293,7 +290,7 @@ const DashboardPage: React.FC<{
   const { isLoading: isLoadingUser, data: user } = useUserMe()
   const orgsEnabled = useFeatureFlagEnabled(FeatureFlags.OrganizationDashboard)
   const { isLoading: isLoadingMitxOnlineUser, data: mitxOnlineUser } =
-    useMitxOnlineCurrentUser({ enabled: !!orgsEnabled })
+    useMitxOnlineUserMe({ enabled: !!orgsEnabled })
 
   const tabData = useMemo(
     () =>

--- a/frontends/main/src/app-pages/DashboardPage/HomeContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/HomeContent.test.tsx
@@ -75,6 +75,7 @@ describe("HomeContent", () => {
       },
     })
     invariant(user.profile)
+    const mitxOnlineUser = mitxonline.factories.user.user()
 
     invariant(user.profile)
     const courses = factories.learningResources.courses
@@ -93,6 +94,7 @@ describe("HomeContent", () => {
     }
 
     setMockResponse.get(urls.userMe.get(), user)
+    setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)
     setMockResponse.get(urls.profileMe.get(), user.profile)
 
     // Set Top Picks Response

--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
@@ -27,7 +27,7 @@ import {
   OrganizationPage,
   UserProgramEnrollmentDetail,
 } from "@mitodl/mitxonline-api-axios/v2"
-import { useMitxOnlineCurrentUser } from "api/mitxonline-hooks/user"
+import { useMitxOnlineUserMe } from "api/mitxonline-hooks/user"
 import { ButtonLink } from "@mitodl/smoot-design"
 import { RiAwardFill } from "@remixicon/react"
 
@@ -433,7 +433,7 @@ const OrganizationContent: React.FC<OrganizationContentProps> = ({
   orgSlug,
 }) => {
   const { isLoading: isLoadingMitxOnlineUser, data: mitxOnlineUser } =
-    useMitxOnlineCurrentUser()
+    useMitxOnlineUserMe()
   const b2bOrganization = mitxOnlineUser?.b2b_organizations.find(
     (org) => org.slug.replace("org-", "") === orgSlug,
   )

--- a/frontends/ol-components/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/frontends/ol-components/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -17,6 +17,7 @@ type LoadingSpinnerProps = {
   loading: boolean
   size?: number | string
   "aria-label"?: string
+  color?: "primary" | "inherit"
 }
 
 const noDelay = { transitionDelay: "0ms" }
@@ -25,11 +26,12 @@ const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
   loading,
   size,
   "aria-label": label = "Loading",
+  color,
 }) => {
   return (
     <Container>
       <Fade in={loading} style={!loading ? noDelay : undefined} unmountOnExit>
-        <CircularProgress aria-label={label} size={size} />
+        <CircularProgress color={color} aria-label={label} size={size} />
       </Fade>
     </Container>
   )

--- a/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.tsx
+++ b/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.tsx
@@ -51,6 +51,7 @@ type SimpleSelectFieldProps = Pick<
   | "fullWidth"
   | "label"
   | "helpText"
+  | "error"
   | "errorText"
   | "required"
   | "size"

--- a/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.tsx
+++ b/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.tsx
@@ -58,6 +58,7 @@ type SimpleSelectFieldProps = Pick<
   | "onChange"
   | "name"
   | "className"
+  | "renderValue"
 > & {
   /**
    * The options for the dropdown

--- a/yarn.lock
+++ b/yarn.lock
@@ -13878,6 +13878,7 @@ __metadata:
     slick-carousel: "npm:^1.8.1"
     tiny-invariant: "npm:^1.3.3"
     ts-jest: "npm:^29.2.4"
+    type-fest: "npm:^5.0.1"
     typescript: "npm:^5"
     yup: "npm:^1.4.0"
   languageName: unknown
@@ -18858,6 +18859,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tagged-tag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "tagged-tag@npm:1.0.0"
+  checksum: 10/e37653df3e495daa7ea7790cb161b810b00075bba2e4d6c93fb06a709e747e3ae9da11a120d0489833203926511b39e038a2affbd9d279cfb7a2f3fcccd30b5d
+  languageName: node
+  linkType: hard
+
 "tapable@npm:^2.0.0, tapable@npm:^2.1.1, tapable@npm:^2.2.0, tapable@npm:^2.2.1":
   version: 2.2.1
   resolution: "tapable@npm:2.2.1"
@@ -19384,6 +19392,15 @@ __metadata:
   version: 4.26.1
   resolution: "type-fest@npm:4.26.1"
   checksum: 10/b82676194f80af228cb852e320d2ea8381c89d667d2e4d9f2bdfc8f254bccc039c7741a90c53617a4de0c9fdca8265ed18eb0888cd628f391c5c381c33a9f94b
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "type-fest@npm:5.0.1"
+  dependencies:
+    tagged-tag: "npm:^1.0.0"
+  checksum: 10/5ec4def4ce82e6a33cf2e1a50f7ef512226fbe85314e402155aaedd70d4aa7ccea4224a72234d5351b1b4a730b36243d5b011c147e91795d2eee0dba291c6e51
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,13 +2978,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/mitxonline-api-axios@npm:^2025.9.26":
-  version: 2025.9.26
-  resolution: "@mitodl/mitxonline-api-axios@npm:2025.9.26"
+"@mitodl/mitxonline-api-axios@npm:^2025.9.30":
+  version: 2025.9.30
+  resolution: "@mitodl/mitxonline-api-axios@npm:2025.9.30"
   dependencies:
     "@types/node": "npm:^20.11.19"
     axios: "npm:^1.6.5"
-  checksum: 10/99b57605623b8a68d53b4273c7bfec3fca45adfb664329f4b34f4ce67bce7bf216d0875c8bdf7f284d27ee55625bc6a29ed3bc09294994b83413098394b0e15e
+  checksum: 10/6ad742353a4913721d4695e22addf99495884cb0c8e85211066fd88f3f6e6bdc858ca891f4f6bd93b6621dfc86847edbf9e85c0291f88d5bcf3a2169c1b3deb5
   languageName: node
   linkType: hard
 
@@ -7166,7 +7166,7 @@ __metadata:
   resolution: "api@workspace:frontends/api"
   dependencies:
     "@faker-js/faker": "npm:^9.9.0"
-    "@mitodl/mitxonline-api-axios": "npm:^2025.9.26"
+    "@mitodl/mitxonline-api-axios": "npm:^2025.9.30"
     "@tanstack/react-query": "npm:^5.66.0"
     "@testing-library/react": "npm:^16.3.0"
     axios: "npm:^1.12.2"
@@ -13834,7 +13834,7 @@ __metadata:
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^9.9.0"
     "@mitodl/course-search-utils": "npm:3.3.2"
-    "@mitodl/mitxonline-api-axios": "npm:^2025.9.26"
+    "@mitodl/mitxonline-api-axios": "npm:^2025.9.30"
     "@mitodl/smoot-design": "npm:^6.17.1"
     "@next/bundle-analyzer": "npm:^14.2.15"
     "@react-pdf/renderer": "npm:^4.3.0"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/8647

### Description (What does it do?)
This PR adds a new dialog to `DashboardDialogs` called `JustInTimeDialog`. This dialog is displayed by `DashboardCard` when clicking the CTA if the user's MITx Online account is missing either their country of origin or their year of birth. If either of these pieces of information are missing, the dialog is displayed and the information is collected. It is then submitted as a `PATCH` request to MITx Online to update the user there, and once the request succeeds the user is then redirected to the courseware URL. On subsequent clicks of CTA's, the information will not be missing so they will simply be redirected to the courseware URL without the dialog showing.

### Screenshots (if appropriate):
<img width="2560" height="1271" alt="image" src="https://github.com/user-attachments/assets/35deceea-d345-4803-bd3d-721975a64b98" />
<img width="375" height="667" alt="image" src="https://github.com/user-attachments/assets/c8c78cff-5ced-4e74-865f-2df45f664d9e" />

### How can this be tested?

**Assuming you have MITxOnline <> Learn integrated locally AND a b2b org set up, with at least one user in it:** If not, see "Detailed Instructions" below.
1. Using an admin account on your local MITxOnline, find your Org user on the page http://mitxonline.odl.local:8013/admin/users/user/ and ensure it has no birth year or country set.
    - country is in an expandable section labeled "Legal address"
    - birth year is in an expandable section labeled "user profile"
2. Using your Org User, view your org dashboard, and try enrolling in a course. You should get the "JIT Dialog" where you can enter country/birth year.
3. After submitting the form, you should (1) be enrolled in the course, and (2) redirected to the course. _Redirect won't work if you don't have openedx set up;. that's ok._
4. Retry with one of but not both of birth year or country set; the form should be partially populated.



<details>
<summary> <strong>Detailed Setup Instructions</strong></summary>

In order to test this, you need a basic installation of `mitxonline` up and running with example data in it. You may be able to skip one or more steps if you have already done them:
- Ensure you have local `hosts` redirects for the following domains, replacing the example IP with your __local__ IP address (Google how to get this if unsure, mine is 192.168.1.50)
`
192.168.1.50 open.odl.local
192.168.1.50 api.open.odl.local
192.168.1.50 kc.ol.local
192.168.1.50 mitxonline.odl.local
```
- Clone `mitxonline`: https://github.com/mitodl/mitxonline
- Create a `.env` file with the following values:
```
CELERY_TASK_ALWAYS_EAGER=True
DJANGO_LOG_LEVEL=INFO
LOG_LEVEL=INFO
SENTRY_LOG_LEVEL=ERROR
MAILGUN_KEY=fake
MAILGUN_URL=
MAILGUN_RECIPIENT_OVERRIDE=
MAILGUN_SENDER_DOMAIN=.odl.local
SECRET_KEY=
STATUS_TOKEN=
UWSGI_THREADS=5
SENTRY_DSN=
MITX_ONLINE_BASE_URL=http://open.odl.local:8065/mitxonline
MITX_ONLINE_ADMIN_CLIENT_ID=refine-local-client-id
MITX_ONLINE_ADMIN_BASE_URL=http://mitxonline.odl.local:8016
POSTHOG_PROJECT_API_KEY=
POSTHOG_API_HOST=https://app.posthog.com/
HUBSPOT_HOME_PAGE_FORM_GUID=
HUBSPOT_PORTAL_ID=
APISIX_PORT=9080

# APISIX/Keycloak settings
APISIX_LOGOUT_URL=http://api.open.odl.local:8065/logout/
APISIX_SESSION_SECRET_KEY=supertopsecret1234
KC_SPI_THEME_WELCOME_THEME=scim
KC_SPI_REALM_RESTAPI_EXTENSION_SCIM_LICENSE_KEY=
KEYCLOAK_BASE_URL=http://kc.ol.local:8066
KEYCLOAK_CLIENT_ID=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
KEYCLOAK_CLIENT_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
KEYCLOAK_DISCOVERY_URL=http://kc.ol.local:8066/realms/ol-local/.well-known/openid-configuration
KEYCLOAK_REALM_NAME=ol-local
KEYCLOAK_SCOPES="openid profile ol-profile"
KEYCLOAK_SVC_KEYSTORE_PASSWORD=supertopsecret1234
KEYCLOAK_SVC_HOSTNAME=kc.ol.local
KEYCLOAK_SVC_ADMIN=admin
KEYCLOAK_SVC_ADMIN_PASSWORD=admin
AUTHORIZATION_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/auth
ACCESS_TOKEN_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/token
OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_KEY=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
SOCIAL_AUTH_OL_OIDC_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
USERINFO_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/userinfo
MITOL_APIGATEWAY_DISABLE_MIDDLEWARE=False

FEATURE_IGNORE_EDX_FAILURES=True
OPENEDX_API_CLIENT_ID=fake
OPENEDX_API_CLIENT_SECRET=fake
OPENEDX_SERVICE_WORKER_API_TOKEN=fake

CSRF_COOKIE_DOMAIN=.odl.local
CORS_ALLOWED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
CSRF_TRUSTED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
```
- Spin up `mitxonline` with `docker compose up --build -d`
- Promote the admin user with `docker compose exec web ./manage.py promote_user promote --superuser --email admin@odl.local`
- Populate test course data with `docker compose exec web ./manage.py populate_course_data`
- Generate docs with `pants docs ::`
- In `dist/sphinx/index.html`, read the section on generating a B2B organization / contract and create one, adding some of the test courses to it
- In Django admin, create a `Program` and add the courses to the program that are included in your B2B org, making sure to mark the program as "live"
- Make sure your user is associated with the B2B org you created
- Make sure you have a personal Posthog project configured and have the API key at the ready
- Before we spin up `mit-learn`, we need to set some env variables:
```
.env
...
MITX_ONLINE_UPSTREAM=mitxonline.odl.local:8013
MITX_ONLINE_DOMAIN=mitxonline.odl.local
MITX_ONLINE_BASE_URL=http://mitxonline.odl.local:8065
POSTHOG_ENABLED=True
CSRF_COOKIE_DOMAIN=.odl.local

shared.local.env
POSTHOG_PROJECT_API_KEY=YOUR_API_KEY_HERE
POSTHOG_PROJECT_ID=YOUR_PROJECT_ID_HERE
POSTHOG_TIMEOUT_MS=1500
```
- In your Posthog project, enable the `enrollment-dashboard` and `mitlearn-organization-dashboard` feature flags for all users
- Spin up `MIT Learn`
- Open an Incognito tab
- Browse to the site and click Log In
- Instead of logging in, create an account (this can be done by using a gmail address and then adding a `+` sign after your username, then adding any string)
- In Django admin in your normal browser window, logged in as an admin, set your test user you just created to be part of your B2B org
- Refresh the dashboard in the Incognito window and click on the org tab
- Click Start Module on any course
- You should be prompted with the just in time dialog
- Fill out a country and year of birth and submit it
- Verify that you are redirected to the courseware URL (this will not actually load if you have not properly configured the OpenEdx <-> MITx Online connection
- Browse back to the dashboard and attempt to click Start Module on any of the other courses
- Instead of showing the popup, you should be redirected to the courseware because this information is now set


</details>
