### PR TITLE
Disable postinstall scripts [security fix]

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,8 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+enableScripts: false
+
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.9.2.cjs


### PR DESCRIPTION
### What are the relevant tickets?
None, but in response to https://www.cisa.gov/news-events/alerts/2025/09/23/widespread-supply-chain-compromise-impacting-npm-ecosystem

### Description (What does it do?)
Disables postinstall scripts.

From [yarn docs](https://yarnpkg.com/advanced/lifecycle-scripts#postinstall):
> **warning**
> Postinstall scripts should be avoided at all cost, as they make installs slower and riskier. Many users will refuse to install dependencies that have postinstall scripts. Additionally, since the output isn't shown out of the box, using them to print a message to the user will not work as you expect.


### How can this be tested?
If you want to test that this actually does disable postinstall scripts, try running `yarn add @mitodl/smoot-design@0.0.0-7efb42b` on both `main` and this branch. That's a pre-release version of smoot design to which I [added a trivial postinstall script](https://github.com/mitodl/smoot-design/compare/main...cc/dummy-postinstall).  Then `ls node_modules/@mitodl/smoot-design`. On `main`, you'll see `smoot_postinstall_record.txt` in the directory. On this branch, you won't.

If you want to check that the app still works, I'd do `rm -rf node_modules` and restart everything, and check the frontend.