### PR TITLE
Celery task tweaks

### DIFF
--- a/docker-compose.apps.yml
+++ b/docker-compose.apps.yml
@@ -59,7 +59,7 @@ services:
     command: >
       /bin/bash -c '
       sleep 3;
-      celery -A main.celery:app worker -E -Q default,edx_content -B --scheduler redbeat.RedBeatScheduler -l ${MITOL_LOG_LEVEL:-INFO}'
+      celery -A main.celery:app worker -E -Q default,edx_content,embeddings -B --scheduler redbeat.RedBeatScheduler -l ${MITOL_LOG_LEVEL:-INFO}'
     depends_on:
       db:
         condition: service_healthy

--- a/main/celery.py
+++ b/main/celery.py
@@ -17,6 +17,7 @@ app.conf.task_default_queue = "default"
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)  # pragma: no cover
 
 app.conf.task_routes = {
+    "vector_search.tasks.generate_embeddings": {"queue": "embeddings"},
     "learning_resources.tasks.get_content_tasks": {"queue": "edx_content"},
     "learning_resources.tasks.get_content_files": {"queue": "edx_content"},
     "learning_resources.tasks.import_all_xpro_files": {"queue": "edx_content"},

--- a/main/settings_celery.py
+++ b/main/settings_celery.py
@@ -60,9 +60,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "update-podcasts": {
         "task": "learning_resources.tasks.get_podcast_data",
-        "schedule": get_int(
-            "PODCAST_FETCH_SCHEDULE_SECONDS", 60 * 60 * 2
-        ),  # default is every 2 hours
+        "schedule": crontab(minute=0, hour="6,23"),  # 2am and 7pm EST
     },
     "update-professional-ed-resources-every-1-days": {
         "task": "learning_resources.tasks.get_mitpe_data",
@@ -80,9 +78,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "update-youtube-videos": {
         "task": "learning_resources.tasks.get_youtube_data",
-        "schedule": get_int(
-            "YOUTUBE_FETCH_SCHEDULE_SECONDS", 60 * 30
-        ),  # default is every 30 minutes
+        "schedule": crontab(minute=30, hour=8),  # 4:30am EST
     },
     "update-youtube-transcripts": {
         "task": "learning_resources.tasks.get_youtube_transcripts",

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -338,7 +338,9 @@ def embed_run_content_files(self, run_id):
         celery.group(
             [
                 generate_embeddings.si(ids, CONTENT_FILE_TYPE, overwrite=True)
-                for ids in chunks(content_file_ids)
+                for ids in chunks(
+                    content_file_ids, chunk_size=settings.QDRANT_CHUNK_SIZE
+                )
             ]
         )
     )
@@ -355,6 +357,6 @@ def remove_run_content_files(run_id):
     return celery.group(
         [
             remove_embeddings.si(ids, CONTENT_FILE_TYPE)
-            for ids in chunks(content_file_ids)
+            for ids in chunks(content_file_ids, chunk_size=settings.QDRANT_CHUNK_SIZE)
         ]
     )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/8689


### Description (What does it do?)
This PR makes several small tweaks to celery tasks:
- restores settings. QDRANT_CHUNK_SIZE in places where it was missing for batching embedding tasks
- routes the generate_embeddings task to its own separate queue (we will need some separate infra-side changes to make full use of this but this is the first step)
- adjust the schedule for the youtube and podcast celery tasks so they run less frequently and dont overlap:
    - get_podcast_data -  2am and 7pm EST
    - get_youtube_data - 4:30am EST

### How can this be tested?
1. checkout this branch
2. restart celery (so new queue is picked up)
3. in django shell validate that the new batch/chunk sizes are in effect:
```python
 from vector_search.tasks import remove_run_content_files
run = <some run id>
remove_run_content_files(run.id) # <-- you should see an array of 100 ids
```
4. run the generate embeddings task and while running inspect the celery tasks in a separate (bash)shell:
```sh
celery inspect active
```
should output something like:
```
{'id': '22c30d57-61fb-4286-9fd7-0c733ddb9129', 'name': 'vector_search.tasks.generate_embeddings', 'args': [[4734, 4735, 4736, 4737, 4738,  4816, 4817, 4818, 4819, 4820, 4821, 4822, 4823, 4824, 4825, 4826, 4827, 4828, 4829, 4830, 4831, 4832, 4833], 'content_file', False], 'kwargs': {}, 'type': 'vector_search.tasks.generate_embeddings', 'hostname': 'celery@50f59ee1e302', 'time_start': 1758817469.2850175, 'acknowledged': False, 'delivery_info': {'exchange': '', 'routing_key': 'embeddings', 'priority': 0, 'redelivered': False}, 'worker_pid': 19301}
```
where the "routing_key" should now be embeddings


### Additional Context
1. once deployed we should run into very long backed up celery queues less frequently (or hopefully never)
2. There will be follow up tasks to make use of the embedding celery queue -  the generate_embeddings tasks are high in number and short-lived tasks as opposed to the long running etl tasks and so should be in a separate queue.
3. Long term i think we may want to have separate queues for different "task priorities" - for example we would want subscription emails to go out at exactly the same of day and not be delayed due to other tasks 