### PR TITLE
Refactor price assignment for mitxonline

### DIFF
--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -151,20 +151,25 @@ def extract_courses():
         log.warning("Missing required setting MITX_ONLINE_COURSES_API_URL")
 
     return []
+    
 
-
-def parse_program_prices(program_data: dict) -> list[dict]:
-    """Return a list of unique prices for a program"""
-    prices = [program_data.get("current_price") or 0.00]
-    price_string = parse_page_attribute(program_data, "price")
-    if price_string:
-        prices.extend(
-            [
-                float(price.replace(",", ""))
-                for price in re.findall(r"[\d\.,]+", price_string)
-            ]
+def parse_prices(parent_data: dict) -> list[dict]:
+    """
+    Return a list of unique prices for a course/program.
+    $0.00 (free) is always included for the non-certificate option.
+    Other prices come from the parent course/program's min_price & max_price fields.
+    """
+    free_price_str = "0.00"
+    return [
+        transform_price(price)
+        for price in sorted(
+            {
+                Decimal(free_price_str),
+                Decimal(parent_data.get("min_price") or free_price_str),
+                Decimal(parent_data.get("max_price") or free_price_str)
+            }
         )
-    return [transform_price(Decimal(price)) for price in sorted(set(prices))]
+    ]
 
 
 def parse_departments(departments_data: list[dict or str]) -> list[str]:
@@ -226,22 +231,7 @@ def _transform_run(course_run: dict, course: dict) -> dict:
         ),
         "description": clean_data(parse_page_attribute(course_run, "description")),
         "image": _transform_image(course_run),
-        "prices": [
-            transform_price(price)
-            for price in sorted(
-                {
-                    Decimal("0.00"),
-                    *[
-                        Decimal(price)
-                        for price in [
-                            product.get("price")
-                            for product in course_run.get("products", [])
-                        ]
-                        if price is not None
-                    ],
-                }
-            )
-        ],
+        "prices":parse_prices(course),
         "instructors": [
             {"full_name": instructor["name"]}
             for instructor in parse_page_attribute(course, "instructors", is_list=True)
@@ -418,7 +408,7 @@ def transform_programs(programs: list[dict]) -> list[dict]:
                     "description": clean_data(
                         parse_page_attribute(program, "description")
                     ),
-                    "prices": parse_program_prices(program),
+                    "prices": parse_prices(program),
                     "status": RunStatus.current.value
                     if parse_page_attribute(program, "page_url")
                     else RunStatus.archived.value,

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -151,7 +151,7 @@ def extract_courses():
         log.warning("Missing required setting MITX_ONLINE_COURSES_API_URL")
 
     return []
-    
+
 
 def parse_prices(parent_data: dict) -> list[dict]:
     """
@@ -166,7 +166,7 @@ def parse_prices(parent_data: dict) -> list[dict]:
             {
                 Decimal(free_price_str),
                 Decimal(parent_data.get("min_price") or free_price_str),
-                Decimal(parent_data.get("max_price") or free_price_str)
+                Decimal(parent_data.get("max_price") or free_price_str),
             }
         )
     ]
@@ -231,7 +231,7 @@ def _transform_run(course_run: dict, course: dict) -> dict:
         ),
         "description": clean_data(parse_page_attribute(course_run, "description")),
         "image": _transform_image(course_run),
-        "prices":parse_prices(course),
+        "prices": parse_prices(course),
         "instructors": [
             {"full_name": instructor["name"]}
             for instructor in parse_page_attribute(course, "instructors", is_list=True)

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -4,7 +4,6 @@ import json
 
 # pylint: disable=redefined-outer-name
 from datetime import datetime
-from decimal import Decimal
 from unittest.mock import ANY
 from urllib.parse import parse_qs, urljoin, urlparse
 

--- a/test_json/mitxonline_courses.json
+++ b/test_json/mitxonline_courses.json
@@ -150,7 +150,7 @@
         ]
       },
       "min_price": null,
-      "max_price": 456,      
+      "max_price": 456,
       "programs": null,
       "topics": [
         {
@@ -223,7 +223,7 @@
         ]
       },
       "min_price": 123,
-      "max_price": null,      
+      "max_price": null,
       "programs": null,
       "topics": [
         {

--- a/test_json/mitxonline_courses.json
+++ b/test_json/mitxonline_courses.json
@@ -44,6 +44,8 @@
           "name": "Mathematics"
         }
       ],
+      "min_price": 123,
+      "max_price": 456,
       "certificate_type": "Certificate of Completion",
       "required_prerequisites": true,
       "duration": "14 weeks",
@@ -147,6 +149,8 @@
           }
         ]
       },
+      "min_price": null,
+      "max_price": 456,      
       "programs": null,
       "topics": [
         {
@@ -218,6 +222,8 @@
           }
         ]
       },
+      "min_price": 123,
+      "max_price": null,      
       "programs": null,
       "topics": [
         {

--- a/test_json/mitxonline_programs.json
+++ b/test_json/mitxonline_programs.json
@@ -88,6 +88,8 @@
         "effort": "7 hrs/wk",
         "price": "$175"
       },
+      "min_price": 1230,
+      "max_price": 4560,      
       "program_type": "Series",
       "certificate_type": "Certificate of Completion",
       "departments": [

--- a/test_json/mitxonline_programs.json
+++ b/test_json/mitxonline_programs.json
@@ -89,7 +89,7 @@
         "price": "$175"
       },
       "min_price": 1230,
-      "max_price": 4560,      
+      "max_price": 4560,
       "program_type": "Series",
       "certificate_type": "Certificate of Completion",
       "departments": [


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/8710

### Description (What does it do?)
Assigns prices to MITx Online courses, programs, and runs based on the new `min_price` and `max_price` fields in the API.

### Screenshots (if appropriate):


<img width="1037" height="857" alt="Screenshot 2025-09-30 081500" src="https://github.com/user-attachments/assets/5a1eaa46-69c7-4745-be4e-89307c7c9471" />

<img width="975" height="210" alt="Screenshot 2025-09-30 090438" src="https://github.com/user-attachments/assets/d122738b-fa3a-44d5-aa47-ae293d445c68" />

### How can this be teste

d?
- Set the following in your `backend.local.env` file:
  ```bash
  MITX_ONLINE_BASE_URL=https://mitxonline.mit.edu/
  MITX_ONLINE_COURSES_API_URL=https://mitxonline.mit.edu/api/v2/courses/
  MITX_ONLINE_PROGRAMS_API_URL=https://mitxonline.mit.edu/api/v2/programs/
  ```
- Run the following:
  ```
  python manage.py backpopulate_mitxonline_data
  ```
- Go to the following url: http://open.odl.local:8062/search?q=%22Design+of+Policy%22&platform=mitxonline - the 1st result should show a credentials price range of[ $1250-$5000](https://mitxonline.mit.edu/api/v2/programs/2/) (and also  `Free`  to the right of that).
- Go to http://open.odl.local:8062/search?platform=mitxonline&q=%22Thermodynamics+of+Materials%22 - the 1st result should show a credentials price range of [$38-$150](https://mitxonline.mit.edu/api/v2/courses/67/) (and `Free` to the right of that).

