### PR TITLE
remove old canvas problem fields

### DIFF
--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -1448,10 +1448,6 @@ class CourseRunProblemsViewSet(viewsets.ViewSet):
 
         return Response(
             {
-                # problem_set and solution_set will be removed after i make the
-                # required changes to open_learning_ai_tutor
-                "problem_set": problem_files.first().content,
-                "solution_set": solution_files.first().content,
                 "problem_set_files": [
                     {
                         "file_name": problem_file.file_name,

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -1495,8 +1495,6 @@ def test_course_run_problems_endpoint(client, user_role, django_user_model):
 
     if user_role in ["admin", "group_tutor_problem_viewer"]:
         assert detail_resp.json() == {
-            "problem_set": "Content for Problem Set 1",
-            "solution_set": "Content for Problem Set 1 Solution",
             "problem_set_files": [
                 {"file_name": "problem1.txt", "content": "Content for Problem Set 1"},
                 {


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/8555

### Description (What does it do?)
This pr removes old fields from the canvas problem api response.
https://github.com/mitodl/mit-learn/pull/2512 added new fields to allow for problem sets/solutions to consist of multiple files. I kept the old fields until now so that there isn't a disruption in the tutor while the corresponding learn-ai pr was released.

Now that the learn-ai update is released we can remove the old field.


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
log in as an admin
got to `http://api.open.odl.local:8063/api/v0/tutor/problems/14566-kaleba:20211202+canvas/15C.57%20-%20Homework%205/` or any other tutor problem. You should see `problem_set_files` and `solution_set_files` but not `problem_set` and `solution_set`