### PR TITLE
Fix qdrant payload schema type and add mechanism to keep types in sync

### DIFF
--- a/vector_search/constants.py
+++ b/vector_search/constants.py
@@ -46,7 +46,7 @@ QDRANT_RESOURCE_PARAM_MAP = {
 QDRANT_LEARNING_RESOURCE_INDEXES = {
     "readable_id": models.PayloadSchemaType.KEYWORD,
     "resource_type": models.PayloadSchemaType.KEYWORD,
-    "certification": models.PayloadSchemaType.KEYWORD,
+    "certification": models.PayloadSchemaType.BOOL,
     "certification_type.code": models.PayloadSchemaType.KEYWORD,
     "professional": models.PayloadSchemaType.BOOL,
     "published": models.PayloadSchemaType.BOOL,

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -155,24 +155,25 @@ def update_qdrant_indexes():
     Create or update Qdrant indexes based on mapping in constants
     """
     client = qdrant_client()
-    for index_field in QDRANT_LEARNING_RESOURCE_INDEXES:
-        collection_name = RESOURCES_COLLECTION_NAME
-        collection = client.get_collection(collection_name=collection_name)
-        if index_field not in collection.payload_schema:
-            client.create_payload_index(
-                collection_name=collection_name,
-                field_name=index_field,
-                field_schema=QDRANT_LEARNING_RESOURCE_INDEXES[index_field],
-            )
-    for index_field in QDRANT_CONTENT_FILE_INDEXES:
-        collection_name = CONTENT_FILES_COLLECTION_NAME
-        collection = client.get_collection(collection_name=collection_name)
-        if index_field not in collection.payload_schema:
-            client.create_payload_index(
-                collection_name=collection_name,
-                field_name=index_field,
-                field_schema=QDRANT_CONTENT_FILE_INDEXES[index_field],
-            )
+
+    for index in [
+        (QDRANT_LEARNING_RESOURCE_INDEXES, RESOURCES_COLLECTION_NAME),
+        (QDRANT_CONTENT_FILE_INDEXES, CONTENT_FILES_COLLECTION_NAME),
+    ]:
+        indexes = index[0]
+        collection_name = index[1]
+        for index_field in indexes:
+            collection = client.get_collection(collection_name=collection_name)
+            if (
+                index_field not in collection.payload_schema
+                or indexes[index_field]
+                != collection.payload_schema[index_field].dict()["data_type"]
+            ):
+                client.create_payload_index(
+                    collection_name=collection_name,
+                    field_name=index_field,
+                    field_schema=indexes[index_field],
+                )
 
 
 def vector_point_id(readable_id):


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/8567
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR fixes payload index to be the correct type and also includes changes that make sure that types stay in sync with what is defined in vector_search.constants

### How can this be tested?
1. checkout this branch
2. restart celery
3. run `python manage.py generate_embeddings --all`
4. go to your local [qdrant dashboard](http://localhost:6333/dashboard#/collections/resource_embeddings.resources#info) and verify that for the learning resources collection the "certification" is now "boolean" (in the payload indexes section under the info tab)
5. open up vector_search/constants.py and change one of the payload field types for example: `"course_number": models.PayloadSchemaType.INTEGER,` to `"course_number": models.PayloadSchemaType.KEYWORD,`
6. reload celery
7. re-run the generate embeddings command
8. go back to the qdrant dashboard and note that the type associated with the field has changed.

