### PR TITLE
truncate csv files in tutor problems api

### DIFF
--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -1471,18 +1471,29 @@ class CourseRunProblemsViewSet(viewsets.ViewSet):
         return Response(
             {
                 "problem_set_files": [
-                    {
-                        "file_name": problem_file.file_name,
-                        "content": problem_file.content,
-                    }
+                    problem_set_file_output(problem_file)
                     for problem_file in problem_files
                 ],
                 "solution_set_files": [
-                    {
-                        "file_name": solution_file.file_name,
-                        "content": solution_file.content,
-                    }
+                    problem_set_file_output(solution_file)
                     for solution_file in solution_files
                 ],
             }
         )
+
+
+def problem_set_file_output(problem_set_file):
+    if problem_set_file.file_extension == ".csv":
+        csv_lines = problem_set_file.content.splitlines()
+        return {
+            "file_name": problem_set_file.file_name,
+            "file_extension": ".csv",
+            "truncated_content": "\n".join(csv_lines[0:5]),
+            "number_of_records": len(csv_lines) - 1,
+            "note": "The content of the data file has been truncated to the column headers and first 4 rows.",  # noqa: E501
+        }
+    return {
+        "file_name": problem_set_file.file_name,
+        "content": problem_set_file.content,
+        "file_extension": problem_set_file.file_extension,
+    }

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -1456,14 +1456,16 @@ def test_course_run_problems_endpoint(client, user_role, django_user_model):
         type="problem",
         content="Content for Problem Set 1",
         file_name="problem1.txt",
+        file_extension=".txt",
     )
 
     TutorProblemFileFactory.create(
         run=course_run,
         problem_title="Problem Set 1",
         type="problem",
-        content="Content for Problem Set 1 Part 2",
-        file_name="problem1-b.txt",
+        content="a,b\n1,1\n2,2\n3,3\n4,4\n5,5\n6,6",
+        file_name="problem1-data.csv",
+        file_extension=".csv",
     )
 
     TutorProblemFileFactory.create(
@@ -1472,6 +1474,7 @@ def test_course_run_problems_endpoint(client, user_role, django_user_model):
         type="solution",
         content="Content for Problem Set 1 Solution",
         file_name="solution1.txt",
+        file_extension=".txt",
     )
     TutorProblemFileFactory.create(
         run=course_run, problem_title="Problem Set 2", type="problem"
@@ -1496,16 +1499,24 @@ def test_course_run_problems_endpoint(client, user_role, django_user_model):
     if user_role in ["admin", "group_tutor_problem_viewer"]:
         assert detail_resp.json() == {
             "problem_set_files": [
-                {"file_name": "problem1.txt", "content": "Content for Problem Set 1"},
                 {
-                    "file_name": "problem1-b.txt",
-                    "content": "Content for Problem Set 1 Part 2",
+                    "file_name": "problem1.txt",
+                    "content": "Content for Problem Set 1",
+                    "file_extension": ".txt",
+                },
+                {
+                    "file_name": "problem1-data.csv",
+                    "truncated_content": "a,b\n1,1\n2,2\n3,3\n4,4",
+                    "file_extension": ".csv",
+                    "note": "The content of the data file has been truncated to the column headers and first 4 rows.",
+                    "number_of_records": 6,
                 },
             ],
             "solution_set_files": [
                 {
                     "file_name": "solution1.txt",
                     "content": "Content for Problem Set 1 Solution",
+                    "file_extension": ".txt",
                 },
             ],
         }


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/8770

### Description (What does it do?)
https://github.com/mitodl/mit-learn/pull/2560 imports csv files as problem set parts . Unfortunately, even with two 1000 line files, I hit the llm token limit while testing the tutor with a problem set that involves csv files. This truncates the output to only show the first few rows of the csv and the column names. Combined with the solution, this seems to be enough for the tutor to be able to answer questions about problems that require data files

### How can this be tested?
run docker compose exec web ./manage.py backpopulate_canvas_courses --canvas-ids 34716 (if you don't have it imported already)
Go to http://api.open.odl.local:8065/api/v0/tutor/problems/34716-15.C57_FA25+canvas/Assignment%202/
instead of `content` the csv files should have `truncated_content` and `number_of_records`


The same problem set is  also in the test course (14566-kaleba:20211202+canvas) as  "15.C57 FA25 - Assignment 2" 

