### PR TITLE
One-click enrollment via org dashboard card titles

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -169,19 +169,9 @@ const CoursewareButton = styled(
     const userCountry = mitxOnlineUser.data?.legal_address?.country
     const userYearOfBirth = mitxOnlineUser.data?.user_profile?.year_of_birth
     const showJustInTimeDialog = !userCountry || !userYearOfBirth
-    return (hasStarted && href) || !hasEnrolled ? (
-      hasEnrolled && href ? (
-        <ButtonLink
-          size="small"
-          variant="primary"
-          endIcon={<RiArrowRightLine />}
-          href={href}
-          className={className}
-          {...others}
-        >
-          {coursewareText}
-        </ButtonLink>
-      ) : (
+
+    if (!hasEnrolled /* Trigger signup */) {
+      return (
         <Button
           size="small"
           variant="primary"
@@ -216,7 +206,22 @@ const CoursewareButton = styled(
           )}
         </Button>
       )
-    ) : (
+    } else if (hasStarted && href /* Link to course */) {
+      return (
+        <ButtonLink
+          size="small"
+          variant="primary"
+          endIcon={<RiArrowRightLine />}
+          href={href}
+          className={className}
+          {...others}
+        >
+          {coursewareText}
+        </ButtonLink>
+      )
+    }
+    // Disabled
+    return (
       <Button
         size="small"
         variant="primary"

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -32,7 +32,8 @@ import {
 } from "./DashboardDialogs"
 import NiceModal from "@ebay/nice-modal-react"
 import { useCreateEnrollment } from "api/mitxonline-hooks/enrollment"
-import { useMitxOnlineUserMe } from "api/mitxonline-hooks/user"
+import { mitxUserQueries } from "api/mitxonline-hooks/user"
+import { useQuery } from "@tanstack/react-query"
 
 const CardRoot = styled.div<{
   screenSize: "desktop" | "mobile"
@@ -161,7 +162,7 @@ const CoursewareButton = styled(
       courseNoun,
       enrollmentStatus,
     })
-    const mitxOnlineUser = useMitxOnlineUserMe()
+    const mitxOnlineUser = useQuery(mitxUserQueries.me())
     const hasStarted = startDate && isInPast(startDate)
     const hasEnrolled =
       enrollmentStatus && enrollmentStatus !== EnrollmentStatus.NotEnrolled

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -120,6 +120,7 @@ const useOneClickEnroll = () => {
   const userCountry = mitxOnlineUser.data?.legal_address?.country
   const userYearOfBirth = mitxOnlineUser.data?.user_profile?.year_of_birth
   const showJustInTimeDialog = !userCountry || !userYearOfBirth
+
   const mutate = ({
     href,
     coursewareId,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
@@ -215,7 +215,9 @@ describe("JustInTimeDialog", () => {
   test("Opens just-in-time dialog when enrolling with incomplete mitxonline user data", async () => {
     const { course } = setupJustInTimeTest()
 
-    renderWithProviders(<DashboardCard dashboardResource={course} />)
+    renderWithProviders(
+      <DashboardCard titleAction="marketing" dashboardResource={course} />,
+    )
 
     const enrollButtons = await screen.findAllByTestId("courseware-button")
     await user.click(enrollButtons[0]) // Use the first (desktop) button
@@ -250,7 +252,9 @@ describe("JustInTimeDialog", () => {
     "Dialog pre-populates with user data if available",
     async ({ userOverrides, expectCountry, expectYob }) => {
       const { course } = setupJustInTimeTest({ userOverrides })
-      renderWithProviders(<DashboardCard dashboardResource={course} />)
+      renderWithProviders(
+        <DashboardCard titleAction="marketing" dashboardResource={course} />,
+      )
       const enrollButtons = await screen.findAllByTestId("courseware-button")
       await user.click(enrollButtons[0]) // Use the first (desktop) button
       const dialog = await screen.findByRole("dialog", {
@@ -265,7 +269,9 @@ describe("JustInTimeDialog", () => {
   test("Validates required fields in just-in-time dialog", async () => {
     const { course } = setupJustInTimeTest()
 
-    renderWithProviders(<DashboardCard dashboardResource={course} />)
+    renderWithProviders(
+      <DashboardCard titleAction="marketing" dashboardResource={course} />,
+    )
 
     const enrollButtons = await screen.findAllByTestId("courseware-button")
     await user.click(enrollButtons[0]) // Use the first (desktop) button
@@ -296,7 +302,9 @@ describe("JustInTimeDialog", () => {
   test("Generates correct year of birth options (minimum age 13)", async () => {
     const { course } = setupJustInTimeTest()
 
-    renderWithProviders(<DashboardCard dashboardResource={course} />)
+    renderWithProviders(
+      <DashboardCard titleAction="marketing" dashboardResource={course} />,
+    )
 
     const enrollButtons = await screen.findAllByTestId("courseware-button")
     await user.click(enrollButtons[0]) // Use the first (desktop) button
@@ -321,7 +329,9 @@ describe("JustInTimeDialog", () => {
   test("Shows expected countries in country dropdown", async () => {
     const { course, countries } = setupJustInTimeTest()
 
-    renderWithProviders(<DashboardCard dashboardResource={course} />)
+    renderWithProviders(
+      <DashboardCard titleAction="marketing" dashboardResource={course} />,
+    )
 
     const enrollButtons = await screen.findAllByTestId("courseware-button")
     await user.click(enrollButtons[0]) // Use the first (desktop) button
@@ -344,7 +354,9 @@ describe("JustInTimeDialog", () => {
   test("Cancels just-in-time dialog without making API calls", async () => {
     const { course } = setupJustInTimeTest()
 
-    renderWithProviders(<DashboardCard dashboardResource={course} />)
+    renderWithProviders(
+      <DashboardCard titleAction="marketing" dashboardResource={course} />,
+    )
 
     const enrollButtons = await screen.findAllByTestId("courseware-button")
     await user.click(enrollButtons[0]) // Use the first (desktop) button
@@ -372,7 +384,9 @@ describe("JustInTimeDialog", () => {
       userOverrides: { user_profile: { year_of_birth: 1988 } },
     })
 
-    renderWithProviders(<DashboardCard dashboardResource={course} />)
+    renderWithProviders(
+      <DashboardCard titleAction="marketing" dashboardResource={course} />,
+    )
     const enrollButtons = await screen.findAllByTestId("courseware-button")
     await user.click(enrollButtons[0]) // Use the first (desktop) button
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
@@ -30,10 +30,6 @@ const BoldText = styled.span(({ theme }) => ({
   ...theme.typography.subtitle1,
 }))
 
-const SpinnerContainer = styled.div({
-  marginLeft: "8px",
-})
-
 const SelectPlaceholder = styled("span")(({ theme }) => ({
   color: theme.custom.colors.silverGrayDark,
 }))
@@ -88,17 +84,13 @@ const EmailSettingsDialogInner: React.FC<DashboardDialogProps> = ({
             variant="primary"
             type="submit"
             disabled={!formik.dirty || updateEnrollment.isPending}
+            endIcon={
+              updateEnrollment.isPending ? (
+                <LoadingSpinner color="inherit" loading={true} size={16} />
+              ) : undefined
+            }
           >
             Save Settings
-            {updateEnrollment.isPending && (
-              <SpinnerContainer>
-                <LoadingSpinner
-                  color="inherit"
-                  loading={updateEnrollment.isPending}
-                  size={16}
-                />
-              </SpinnerContainer>
-            )}
           </Button>
         </DialogActions>
       }
@@ -169,17 +161,13 @@ const UnenrollDialogInner: React.FC<DashboardDialogProps> = ({
             variant="primary"
             type="submit"
             disabled={destroyEnrollment.isPending}
+            endIcon={
+              destroyEnrollment.isPending ? (
+                <LoadingSpinner color="inherit" loading={true} size={16} />
+              ) : undefined
+            }
           >
             Unenroll
-            {destroyEnrollment.isPending && (
-              <SpinnerContainer>
-                <LoadingSpinner
-                  loading={destroyEnrollment.isPending}
-                  color="inherit"
-                  size={16}
-                />
-              </SpinnerContainer>
-            )}
           </Button>
         </DialogActions>
       }
@@ -275,13 +263,13 @@ const JustInTimeDialogInner: React.FC<{ href: string; readableId: string }> = ({
             variant="primary"
             type="submit"
             disabled={formik.isSubmitting}
+            endIcon={
+              formik.isSubmitting ? (
+                <LoadingSpinner color="inherit" loading={true} size={16} />
+              ) : undefined
+            }
           >
             Submit
-            {formik.isSubmitting && (
-              <SpinnerContainer>
-                <LoadingSpinner color="inherit" loading={true} size={16} />
-              </SpinnerContainer>
-            )}
           </Button>
         </DialogActions>
       }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -139,6 +139,7 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
       <EnrollmentsList itemSpacing={"16px"}>
         {shownEnrollments.map((course) => (
           <DashboardCardStyled
+            titleAction="marketing"
             key={course.key}
             Component="li"
             dashboardResource={course}
@@ -153,6 +154,7 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
             <HiddenEnrollmentsList itemSpacing={"16px"}>
               {hiddenEnrollments.map((course) => (
                 <DashboardCardStyled
+                  titleAction="marketing"
                   key={course.key}
                   Component="li"
                   dashboardResource={course}

--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
@@ -245,7 +245,7 @@ const OrgProgramCollectionDisplay: React.FC<{
             dashboardResource={course}
             courseNoun="Module"
             offerUpgrade={false}
-            titleHref={course.run?.coursewareUrl}
+            titleAction="courseware"
             buttonHref={course.run?.coursewareUrl}
           />
         ))}
@@ -326,7 +326,7 @@ const OrgProgramDisplay: React.FC<{
             dashboardResource={course}
             courseNoun="Module"
             offerUpgrade={false}
-            titleHref={course.run?.coursewareUrl}
+            titleAction="courseware"
             buttonHref={course.run?.coursewareUrl}
           />
         ))}

--- a/frontends/ol-test-utilities/src/cartesianProduct.ts
+++ b/frontends/ol-test-utilities/src/cartesianProduct.ts
@@ -1,0 +1,56 @@
+// Provide several overloads for better type inference with up to 5 arrays.
+function cartesianProduct<A, B>(a: A[], b: B[]): (A & B)[]
+function cartesianProduct<A, B, C>(a: A[], b: B[], c: C[]): (A & B & C)[]
+function cartesianProduct<A, B, C, D>(
+  a: A[],
+  b: B[],
+  c: C[],
+  d: D[],
+): (A & B & C & D)[]
+function cartesianProduct<A, B, C, D, E>(
+  a: A[],
+  b: B[],
+  c: C[],
+  d: D[],
+  e: E[],
+): (A & B & C & D & E)[]
+function cartesianProduct<T>(...arrays: T[][]): T[]
+
+/**
+ * Generates the cartesian product of multiple arrays of objects, merging the
+ * objects. This can be used with jest.each for an effect similar to multiple
+ * pytest.mark.parametrize calls.
+ *
+ * For example:
+ * ```ts
+ * cartesianProduct(
+ *   [{ x: 1 }, { x: 2 }],
+ *   [{ y: 'a' }, { y: 'b' }],
+ *   [{ z: 3 }, { z: 4 }]
+ * )
+ * ```
+ *
+ * would yield:
+ * ```
+ * [
+ *   { x: 1, y: 'a', z: 3 },
+ *   { x: 1, y: 'a', z: 4 },
+ *   { x: 1, y: 'b', z: 3 },
+ *   { x: 1, y: 'b', z: 4 },
+ *   { x: 2, y: 'a', z: 3 },
+ *   { x: 2, y: 'a', z: 4 },
+ *   { x: 2, y: 'b', z: 3 },
+ *   { x: 2, y: 'b', z: 4 }
+ * ]
+ * ```
+ */
+function cartesianProduct<T extends object>(...arrays: T[][]): T[] {
+  return arrays.reduce<T[]>(
+    (acc, curr) => {
+      return acc.flatMap((a) => curr.map((b) => ({ ...a, ...b })))
+    },
+    [{}] as T[],
+  )
+}
+
+export default cartesianProduct

--- a/frontends/ol-test-utilities/src/cartestianProduct.test.ts
+++ b/frontends/ol-test-utilities/src/cartestianProduct.test.ts
@@ -1,0 +1,38 @@
+import cartesianProduct from "./cartesianProduct"
+
+describe("cartesianProduct", () => {
+  it("should return an empty array when given empty arrays", () => {
+    const result = cartesianProduct([], [])
+    expect(result).toEqual([])
+  })
+
+  it("should handle single array", () => {
+    const result = cartesianProduct([{ a: 1 }, { a: 2 }])
+    expect(result).toEqual([{ a: 1 }, { a: 2 }])
+  })
+
+  it("should generate cartesian product of two arrays", () => {
+    const result = cartesianProduct(
+      [
+        { a: 0, x: 10 },
+        { a: 1, x: 20 },
+      ],
+      [{ y: "a" }, { y: "b" }, { y: "c" }],
+      [{ z: true }, { z: false }],
+    )
+    expect(result).toEqual([
+      { a: 0, x: 10, y: "a", z: true },
+      { a: 0, x: 10, y: "a", z: false },
+      { a: 0, x: 10, y: "b", z: true },
+      { a: 0, x: 10, y: "b", z: false },
+      { a: 0, x: 10, y: "c", z: true },
+      { a: 0, x: 10, y: "c", z: false },
+      { a: 1, x: 20, y: "a", z: true },
+      { a: 1, x: 20, y: "a", z: false },
+      { a: 1, x: 20, y: "b", z: true },
+      { a: 1, x: 20, y: "b", z: false },
+      { a: 1, x: 20, y: "c", z: true },
+      { a: 1, x: 20, y: "c", z: false },
+    ])
+  })
+})

--- a/frontends/ol-test-utilities/src/index.ts
+++ b/frontends/ol-test-utilities/src/index.ts
@@ -6,6 +6,7 @@ export * from "./assertions"
 export * from "./domQueries/byImageSrc"
 export * from "./domQueries/byTerm"
 export * from "./domQueries/forms"
+export { default as cartesianProduct } from "./cartesianProduct"
 
 /**
  * This is moment-timezone.


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/8803

### Description (What does it do?)
In the org dashboard, clicking on the card title and "Start Module" buttons now behaves the same—"one-click" enrollment with "Just-in-time"d dialog if profile info missing..

### How can this be tested?

**Assuming you have MITxOnline <> Learn integrated locally AND a b2b org set up, with at least one user in it:** If not, see "Detailed Instructions" below.
1. Using an admin account on your local MITxOnline, find your Org user on the page http://mitxonline.odl.local:8013/admin/users/user/ and ensure it has no birth year or country set.
    - country is in an expandable section labeled "Legal address"
    - birth year is in an expandable section labeled "user profile"
2. Using your Org User, view your org dashboard, and try enrolling in a course. You should get the "JIT Dialog" where you can enter country/birth year.
3. After submitting the form, you should (1) be enrolled in the course, and (2) redirected to the course. _Redirect won't work if you don't have openedx set up;. that's ok._
4. Unenroll in the course and try again. This time you should not get the "just in time" dialog.


<details>
<summary> <strong>Detailed Setup Instructions</strong></summary>

In order to test this, you need a basic installation of `mitxonline` up and running with example data in it. You may be able to skip one or more steps if you have already done them:
- Ensure you have local `hosts` redirects for the following domains, replacing the example IP with your __local__ IP address (Google how to get this if unsure, mine is 192.168.1.50)
`
192.168.1.50 open.odl.local
192.168.1.50 api.open.odl.local
192.168.1.50 kc.ol.local
192.168.1.50 mitxonline.odl.local
```
- Clone `mitxonline`: https://github.com/mitodl/mitxonline
- Create a `.env` file with the following values:
```
CELERY_TASK_ALWAYS_EAGER=True
DJANGO_LOG_LEVEL=INFO
LOG_LEVEL=INFO
SENTRY_LOG_LEVEL=ERROR
MAILGUN_KEY=fake
MAILGUN_URL=
MAILGUN_RECIPIENT_OVERRIDE=
MAILGUN_SENDER_DOMAIN=.odl.local
SECRET_KEY=
STATUS_TOKEN=
UWSGI_THREADS=5
SENTRY_DSN=
MITX_ONLINE_BASE_URL=http://open.odl.local:8065/mitxonline
MITX_ONLINE_ADMIN_CLIENT_ID=refine-local-client-id
MITX_ONLINE_ADMIN_BASE_URL=http://mitxonline.odl.local:8016
POSTHOG_PROJECT_API_KEY=
POSTHOG_API_HOST=https://app.posthog.com/
HUBSPOT_HOME_PAGE_FORM_GUID=
HUBSPOT_PORTAL_ID=
APISIX_PORT=9080

# APISIX/Keycloak settings
APISIX_LOGOUT_URL=http://api.open.odl.local:8065/logout/
APISIX_SESSION_SECRET_KEY=supertopsecret1234
KC_SPI_THEME_WELCOME_THEME=scim
KC_SPI_REALM_RESTAPI_EXTENSION_SCIM_LICENSE_KEY=
KEYCLOAK_BASE_URL=http://kc.ol.local:8066
KEYCLOAK_CLIENT_ID=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
KEYCLOAK_CLIENT_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
KEYCLOAK_DISCOVERY_URL=http://kc.ol.local:8066/realms/ol-local/.well-known/openid-configuration
KEYCLOAK_REALM_NAME=ol-local
KEYCLOAK_SCOPES="openid profile ol-profile"
KEYCLOAK_SVC_KEYSTORE_PASSWORD=supertopsecret1234
KEYCLOAK_SVC_HOSTNAME=kc.ol.local
KEYCLOAK_SVC_ADMIN=admin
KEYCLOAK_SVC_ADMIN_PASSWORD=admin
AUTHORIZATION_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/auth
ACCESS_TOKEN_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/token
OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_KEY=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
SOCIAL_AUTH_OL_OIDC_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
USERINFO_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/userinfo
MITOL_APIGATEWAY_DISABLE_MIDDLEWARE=False

FEATURE_IGNORE_EDX_FAILURES=True
OPENEDX_API_CLIENT_ID=fake
OPENEDX_API_CLIENT_SECRET=fake
OPENEDX_SERVICE_WORKER_API_TOKEN=fake

CSRF_COOKIE_DOMAIN=.odl.local
CORS_ALLOWED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
CSRF_TRUSTED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
```
- Spin up `mitxonline` with `docker compose up --build -d`
- Promote the admin user with `docker compose exec web ./manage.py promote_user promote --superuser --email admin@odl.local`
- Populate test course data with `docker compose exec web ./manage.py populate_course_data`
- Generate docs with `pants docs ::`
- In `dist/sphinx/index.html`, read the section on generating a B2B organization / contract and create one, adding some of the test courses to it
- In Django admin, create a `Program` and add the courses to the program that are included in your B2B org, making sure to mark the program as "live"
- Make sure your user is associated with the B2B org you created
- Make sure you have a personal Posthog project configured and have the API key at the ready
- Before we spin up `mit-learn`, we need to set some env variables:
```
.env
...
MITX_ONLINE_UPSTREAM=mitxonline.odl.local:8013
MITX_ONLINE_DOMAIN=mitxonline.odl.local
MITX_ONLINE_BASE_URL=http://mitxonline.odl.local:8065
POSTHOG_ENABLED=True
CSRF_COOKIE_DOMAIN=.odl.local

shared.local.env
POSTHOG_PROJECT_API_KEY=YOUR_API_KEY_HERE
POSTHOG_PROJECT_ID=YOUR_PROJECT_ID_HERE
POSTHOG_TIMEOUT_MS=1500
```
- In your Posthog project, enable the `enrollment-dashboard` and `mitlearn-organization-dashboard` feature flags for all users
- Spin up `MIT Learn`
- Open an Incognito tab
- Browse to the site and click Log In
- Instead of logging in, create an account (this can be done by using a gmail address and then adding a `+` sign after your username, then adding any string)
- In Django admin in your normal browser window, logged in as an admin, set your test user you just created to be part of your B2B org
- Refresh the dashboard in the Incognito window and click on the org tab
- Click Start Module on any course
- You should be prompted with the just in time dialog
- Fill out a country and year of birth and submit it
- Verify that you are redirected to the courseware URL (this will not actually load if you have not properly configured the OpenEdx <-> MITx Online connection
- Browse back to the dashboard and attempt to click Start Module on any of the other courses
- Instead of showing the popup, you should be redirected to the courseware because this information is now set


</details>
